### PR TITLE
[RFC] Clean up install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For learning about Vim in general, read
 ## Install
 
 ```sh
-curl spacevim.org/install.sh -sSf | sh
+curl spacevim.org/install.sh -sSf | bash
 ```
 before use SpaceVim, you should install the plugin by `call dein#install()`
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For learning about Vim in general, read
 ## Install
 
 ```sh
-curl spacevim.org/install.sh -sSf | bash
+curl -sLf https://raw.githubusercontent.com/SpaceVim/SpaceVim/dev/install.sh | bash
 ```
 before use SpaceVim, you should install the plugin by `call dein#install()`
 

--- a/install.sh
+++ b/install.sh
@@ -9,62 +9,61 @@ Red='\033[0;31m'          # Red
 Blue='\033[0;34m'         # Blue
 
 need_cmd () {
-    if ! command -v "$1" > /dev/null 2>&1;then
-        printf "${Red}need '$1' (command not found)${Color_off}\n"
-        exit 0
+    if ! hash "$1" &>/dev/null; then
+        echo -e "${Red}need '$1' (command not found)${Color_off}"
+        exit 1
     fi
 }
 
 fetch_repo () {
-    if [ -d "${HOME}/.SpaceVim" ];then
-        cd ${HOME}/.SpaceVim
-        git pull
-        ret="$?"
-        printf "${Blue}Successfully update SpaceVim${Color_off}\n"
+    if [[ -d "$HOME/.SpaceVim" ]]; then
+        git -C "$HOME/.SpaceVim" pull
+        ret=$?
+        echo -e "${Blue}Successfully update SpaceVim${Color_off}"
     else
-        git clone https://github.com/SpaceVim/SpaceVim.git ${HOME}/.SpaceVim
-        ret="$?"
-        printf "${Blue}Successfully clone SpaceVim${Color_off}\n"
+        git clone https://github.com/SpaceVim/SpaceVim.git "$HOME/.SpaceVim"
+        ret=$?
+        echo -e "${Blue}Successfully clone SpaceVim${Color_off}"
     fi
 }
 
 install_vim () {
-    if [ -f "${HOME}/.vimrc" ];then
-        mv ${HOME}/.vimrc ${HOME}/.vimrc_back
-        ret="$?"
-        printf "${Blue}BackUp ${HOME}/.vimrc${Color_off}\n"
+    if [[ -f "$HOME/.vimrc" ]]; then
+        mv "$HOME/.vimrc" "$HOME/.vimrc_back"
+        ret=$?
+        echo -e "${Blue}BackUp $HOME/.vimrc${Color_off}"
     fi
 
-    if [ -d "${HOME}/.vim" ];then
-        if file ${HOME}/.vim | grep ${HOME}/.SpaceVim &> /dev/null;then
-            printf "${Blue}Installed SpaceVim for vim${Color_off}\n"
+    if [[ -d "$HOME/.vim" ]]; then
+        if file "$HOME/.vim" | grep "$HOME/.SpaceVim" &>/dev/null; then
+            echo -e "${Blue}Installed SpaceVim for vim${Color_off}"
         else
-            mv ${HOME}/.vim ${HOME}/.vim_back
-            ret="$?"
-            printf "${Blue}BackUp ${HOME}/.vim${Color_off}\n"
-            ln -s ${HOME}/.SpaceVim ${HOME}/.vim
-            printf "${Blue}Installed SpaceVim for vim${Color_off}\n"
+            mv "$HOME/.vim" "$HOME/.vim_back"
+            ret=$?
+            echo -e "${Blue}BackUp $HOME/.vim${Color_off}"
+            ln -s "$HOME/.SpaceVim" "$HOME/.vim"
+            echo -e "${Blue}Installed SpaceVim for vim${Color_off}"
         fi
     else
-        ln -s ${HOME}/.SpaceVim ${HOME}/.vim
-        printf "${Blue}Installed SpaceVim for vim${Color_off}\n"
+        ln -s "$HOME/.SpaceVim" "$HOME/.vim"
+        echo -e "${Blue}Installed SpaceVim for vim${Color_off}"
     fi
 }
 
 install_neovim () {
-    if [ -d "${HOME}/.config/nvim" ];then
-        if file ${HOME}/.config/nvim | grep ${HOME}/.SpaceVim &> /dev/null;then
-            printf "${Blue}Installed SpaceVim for neovim${Color_off}\n"
+    if [[ -d "$HOME/.config/nvim" ]]; then
+        if file "$HOME/.config/nvim" | grep "$HOME/.SpaceVim" &>/dev/null; then
+            echo -e "${Blue}Installed SpaceVim for neovim${Color_off}"
         else
-            mv ${HOME}/.config/nvim ${HOME}/.config/nvim_back
-            ret="$?"
-            printf "${Blue}BackUp ${HOME}/.config/nvim${Color_off}\n"
-            ln -s ${HOME}/.SpaceVim ${HOME}/.config/nvim
-            printf "${Blue}Installed SpaceVim for neovim${Color_off}\n"
+            mv "$HOME/.config/nvim" "$HOME/.config/nvim_back"
+            ret=$?
+            echo -e "${Blue}BackUp $HOME/.config/nvim${Color_off}"
+            ln -s "$HOME/.SpaceVim" "$HOME/.config/nvim"
+            echo -e "${Blue}Installed SpaceVim for neovim${Color_off}"
         fi
     else
-        ln -s ${HOME}/.SpaceVim ${HOME}/.config/nvim
-        printf "${Blue}Installed SpaceVim for neovim${Color_off}\n"
+        ln -s "$HOME/.SpaceVim" "$HOME/.config/nvim"
+        echo -e "${Blue}Installed SpaceVim for neovim${Color_off}"
     fi
 }
 


### PR DESCRIPTION
I used shellcheck on it and fixed all immediate issues.

Two questions:

1. You often saved `$?` in `ret`, but didn't use `ret` anywhere yet. I guess it's just not implemented yet?
2. In two places you do `file "$HOME/.vim" | grep "$HOME/.SpaceVim"`. What is that supposed to do? I can't see how the `$HOME/.SpaceVim` should ever be contained in the output of `$HOME/.vim`. Maybe I'm missing something here.