### PR TITLE
add support for puppet

### DIFF
--- a/autoload/SpaceVim/autocmds.vim
+++ b/autoload/SpaceVim/autocmds.vim
@@ -10,6 +10,7 @@ function! SpaceVim#autocmds#init() abort
         autocmd FileType jsp call JspFileTypeInit()
         autocmd FileType html,css,jsp EmmetInstall
         autocmd FileType java call JavaFileTypeInit()
+        autocmd BufRead,BufNewFile *.pp setfiletype puppet
         autocmd BufEnter,WinEnter,InsertLeave * set cursorline
         autocmd BufLeave,WinLeave,InsertEnter * set nocursorline
         autocmd BufReadPost *

--- a/autoload/SpaceVim/layers/lang.vim
+++ b/autoload/SpaceVim/layers/lang.vim
@@ -24,6 +24,7 @@ function! SpaceVim#layers#lang#plugins() abort
                 \ ['isundil/vim-irssi-syntax',               { 'on_ft' : 'irssi'}],
                 \ ['lervag/vimtex',                          { 'on_ft' : 'tex'}],
                 \ ['vimperator/vimperator.vim',              { 'on_ft' : 'vimperator'}],
+                \ ['voxpupuli/vim-puppet',                   {'on_ft' : 'puppet'}],
                 \ ['rust-lang/rust.vim',            {'merged' : 1}],
                 \ ] 
     " python


### PR DESCRIPTION
The "standard" puppet vim plugin has moved to Voxpupuli. This plugin
requires tabular and syntastic, both of which we already provide.