### PR TITLE
E197: 不能设定语言为 "en_US.utf8"

### DIFF
--- a/config/init.vim
+++ b/config/init.vim
@@ -26,7 +26,7 @@ else
         silent exec 'language en_US'
     else
         " in linux-terminal
-        silent exec 'language en_US.utf8'
+        silent exec 'lan POSIX'
     endif
 endif
 


### PR DESCRIPTION
E197: 不能设定语言为 "en_US.utf8"