### PR TITLE
Fix php layer

### DIFF
--- a/autoload/SpaceVim/layers/lang/php.vim
+++ b/autoload/SpaceVim/layers/lang/php.vim
@@ -8,7 +8,8 @@
 " >
 "   PHP 5.3+
 "   PCNTL Extension
-"   Msgpack 0.5.7+(for NeoVim) Extension or JSON(for Vim 7.4+) Extension
+"   Msgpack 0.5.7+(for NeoVim)Extension: https://github.com/msgpack/msgpack-php
+"   JSON(for Vim 7.4+)Extension
 "   Composer Project
 " <
 
@@ -16,10 +17,7 @@
 
 function! SpaceVim#layers#lang#php#plugins() abort
     let plugins = []
-    if has('nvim')
-        call add(plugins, ['padawan-php/deoplete-padawan'])
-    endif
-    call add(plugins, ['php-vim/phpcd.vim'])
+    call add(plugins, ['php-vim/phpcd.vim', { 'on_ft' : 'php'}])
     return plugins
 endfunction
 

--- a/doc/SpaceVim.txt
+++ b/doc/SpaceVim.txt
@@ -522,7 +522,8 @@ requirement:
 >
   PHP 5.3+
   PCNTL Extension
-  Msgpack 0.5.7+(for NeoVim) Extension or JSON(for Vim 7.4+) Extension
+  Msgpack 0.5.7+(for NeoVim)Extension: https://github.com/msgpack/msgpack-php
+  JSON(for Vim 7.4+)Extension
   Composer Project
 <
 


### PR DESCRIPTION
close #213 

@lvht, I just remove padawan-php/deoplete-padawan in php layer, only phpcd.vim in this layer, but I still get errors , I think it is due to the requirement does not be installed successfully.
so, do you have any idea how to check the requirement?