### PR TITLE
Setting blog up

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
+gem 'jekyll-redirect-from', group: :jekyll_plugins

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,3 +4,5 @@ description: A community-driven Vim distribution
 show_downloads: false
 google_analytics: UA-89745542-1
 project_repo_url: https://github.com/SpaceVim/SpaceVim
+
+permalink: /:title/

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -95,6 +95,7 @@
                         <b><a href="https://spacevim.org/development">Development</a></b> |
                         <b><a href="https://spacevim.org/community">Community</a></b> |
                         <b><a href="https://spacevim.org/documentation">Documentation</a></b> |
+                        <b><a href="https://spacevim.org/blog">Blog</a></b>
                         <b><a href="https://spacevim.org/sponsors">Sponsors</a></b>
                     </p>
                     <hr>

--- a/docs/_posts/2017-01-26-SpaceVim-release-v0.1.0.md
+++ b/docs/_posts/2017-01-26-SpaceVim-release-v0.1.0.md
@@ -1,5 +1,7 @@
 ---
+title: SpaceVim release v0.1.0
 categories: changelog
+excerpt: "Here you can check what has been done so far."
 ---
 
 # [Changelogs](https://spacevim.org/development#changelog) > SpaceVim release v0.1.0

--- a/docs/_posts/2017-02-11-use-vim-as-a-java-ide.md
+++ b/docs/_posts/2017-02-11-use-vim-as-a-java-ide.md
@@ -1,3 +1,9 @@
+---
+title: "Use Vim as a Java IDE"
+categories: tutorials
+excerpt: "I am a vimmer and a java developer. Here are some useful plugins for developing java in vim/neovim."
+---
+
 # [Blogs](https://spacevim.org/community#blogs) > Use Vim as a Java IDE
 
 I am a vimmer and a java developer. Here are some useful plugins for developing java in vim/neovim.

--- a/docs/_posts/2017-02-11-use-vim-as-a-java-ide.md
+++ b/docs/_posts/2017-02-11-use-vim-as-a-java-ide.md
@@ -2,6 +2,7 @@
 title: "Use Vim as a Java IDE"
 categories: tutorials
 excerpt: "I am a vimmer and a java developer. Here are some useful plugins for developing java in vim/neovim."
+redirect_from: "/2017/02/11/use-vim-as-a-java-ide.html"
 ---
 
 # [Blogs](https://spacevim.org/community#blogs) > Use Vim as a Java IDE

--- a/docs/blog.md
+++ b/docs/blog.md
@@ -1,0 +1,18 @@
+---
+title: "Blog"
+---
+
+# Blog
+
+Here you can learn more about SpaceVim with our tutorials and find out what's
+going on. 
+
+<ul>
+    {% for post in site.posts %}
+            <li>
+               <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+               <span class="post-date">{{ post.date | date_to_string }}</span>
+               <h4>{{ post.excerpt | truncatewords: 100 }}</h4>
+            </li>
+    {% endfor %}
+</ul>


### PR DESCRIPTION
This PR:

### Adds a basic Gemfile

If you have jekyll installed locally, now you should be able to preview the webpage (locally)by running:

```
$ bundle exec jekyll server
```
### Adds 'Blog' to the menu
So users hopefully can reach all posts in an easier way.
I renamed `blogs.md` to `blog.md`... as the website has one blog with multiple posts. Hope that makes sense. (:

### Adds some fields to the front matter
the blog was originally created by the automatic page generator... right? On the long run, having these fields should allow some better control (in case the blog gets bigger):

- `title:` -> allows to have a custom title, not necessarily restricted to the DATA-FILENAME.md, it also separates the title to its link.
- `categories` -> maybe on the future users want to take a look only on the "changelogs", "news" or "tutorials" categories.

It is also possible to add the `permalink: ` field. It would allow to have a blog called "Use Vim as a Java IDE" and its permalink could be only `/vim-java-ide`, giving clean links.

### Install the plugin Redirect_from


The plugin was added to the Gemfile. Then I needed to run `bundle install`. Then added the field `redirect_from:` to the post 'Use vim as a java ide'.
It worked perfectly, without any problems locally. Hopefully, there won't be any issue when Github builds it.

---------

The posts' titles should probably be handled in another way. They do not exist only in a repository, but they are handled by Jekyll in a bunch of ways: to create headers, posts lists etc, and it would be easier to change the title's CSS. In instead of manually adding a hash (#) and markdown the title manually, it would be better to use the `title:` field and just write the article (without a markdown h1 title) after the front matter.

Let me know if something else should be (re)done.
In case it works, it would be a good idea to test the redirect thing with other pages.
