### PR TITLE
Add missing BAR between 'blogs' and 'sponsors'

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -95,7 +95,7 @@
                         <b><a href="https://spacevim.org/development">Development</a></b> |
                         <b><a href="https://spacevim.org/community">Community</a></b> |
                         <b><a href="https://spacevim.org/documentation">Documentation</a></b> |
-                        <b><a href="https://spacevim.org/blog">Blog</a></b>
+                        <b><a href="https://spacevim.org/blog">Blog</a></b> |
                         <b><a href="https://spacevim.org/sponsors">Sponsors</a></b>
                     </p>
                     <hr>


### PR DESCRIPTION
Sorry, my bad, the BAR was missing. (: