### PR TITLE
Add more common ctrlp_custom_ignore

### DIFF
--- a/config/plugins/ctrlp.vim
+++ b/config/plugins/ctrlp.vim
@@ -12,8 +12,8 @@ let g:ctrlp_cache_dir = $HOME.'/.cache/ctrlp'
 "let g:ctrlp_open_multiple_files = 'v'
 "if you have install ag, the g:ctrlp_custom_ignore will not work
 let g:ctrlp_custom_ignore = {
-      \ 'dir':  '\v[\/]\.(git|hg|svn)$|target',
-      \ 'file': '\v\.(exe|so|dll|ttf|png)$|\-rplugin\~',
+      \ 'dir':  '\v[\/]\.(git|hg|svn)$|target|node_modules|te?mp$|logs?$|public$|dist$',
+      \ 'file': '\v\.(exe|so|dll|ttf|png|gif|jpe?g|bpm)$|\-rplugin\~',
       \ 'link': 'some_bad_symbolic_links',
       \ }
 if executable('rg')


### PR DESCRIPTION
I may have added too much, and would be willing to reduce and update the PR, but including `node_modules` and `tmp` at least should be done