### PR TITLE
Use on_event, instead of deprecated on_i

### DIFF
--- a/autoload/SpaceVim/layers/autocomplete.vim
+++ b/autoload/SpaceVim/layers/autocomplete.vim
@@ -22,18 +22,18 @@
 
 function! SpaceVim#layers#autocomplete#plugins() abort
   let plugins = [
-        \ ['honza/vim-snippets',          { 'on_i' : 1, 'loadconf_before' : 1}],
-        \ ['Shougo/neco-syntax',          { 'on_i' : 1}],
-        \ ['ujihisa/neco-look',           { 'on_i' : 1}],
-        \ ['Shougo/context_filetype.vim', { 'on_i' : 1}],
-        \ ['Shougo/neoinclude.vim',       { 'on_i' : 1}],
+        \ ['honza/vim-snippets',          { 'on_event' : 'InsertEnter', 'loadconf_before' : 1}],
+        \ ['Shougo/neco-syntax',          { 'on_event' : 'InsertEnter'}],
+        \ ['ujihisa/neco-look',           { 'on_event' : 'InsertEnter'}],
+        \ ['Shougo/context_filetype.vim', { 'on_event' : 'InsertEnter'}],
+        \ ['Shougo/neoinclude.vim',       { 'on_event' : 'InsertEnter'}],
         \ ['Shougo/neosnippet-snippets',  { 'merged' : 0}],
-        \ ['Shougo/neopairs.vim',         { 'on_i' : 1}],
+        \ ['Shougo/neopairs.vim',         { 'on_event' : 'InsertEnter'}],
         \ ['Raimondi/delimitMate',        { 'merged' : 0}],
         \ ]
   " snippet
   if g:spacevim_snippet_engine ==# 'neosnippet'
-    call add(plugins,  ['Shougo/neosnippet.vim', { 'on_i'  : 1 ,
+    call add(plugins,  ['Shougo/neosnippet.vim', { 'on_event' : 'InsertEnter',
           \ 'on_ft' : 'neosnippet',
           \ 'loadconf' : 1,
           \ 'on_cmd' : 'NeoSnippetEdit'}])
@@ -46,17 +46,17 @@ function! SpaceVim#layers#autocomplete#plugins() abort
     call add(plugins, ['Valloric/YouCompleteMe',            { 'loadconf_before' : 1, 'merged' : 0}])
   elseif g:spacevim_autocomplete_method ==# 'neocomplete'
     call add(plugins, ['Shougo/neocomplete', {
-          \ 'on_i' : 1,
+          \ 'on_event' : 'InsertEnter',
           \ 'loadconf' : 1,
           \ }])
   elseif g:spacevim_autocomplete_method ==# 'neocomplcache' "{{{
     call add(plugins, ['Shougo/neocomplcache.vim', {
-          \ 'on_i' : 1,
+          \ 'on_event' : 'InsertEnter',
           \ 'loadconf' : 1,
           \ }])
   elseif g:spacevim_autocomplete_method ==# 'deoplete'
     call add(plugins, ['Shougo/deoplete.nvim', {
-          \ 'on_i' : 1,
+          \ 'on_event' : 'InsertEnter',
           \ 'loadconf' : 1,
           \ }])
   endif

--- a/autoload/SpaceVim/layers/edit.vim
+++ b/autoload/SpaceVim/layers/edit.vim
@@ -16,7 +16,7 @@ function! SpaceVim#layers#edit#plugins() abort
                 \ ['floobits/floobits-neovim',      { 'on_cmd' : ['FlooJoinWorkspace','FlooShareDirPublic','FlooShareDirPrivate']}],
                 \ ]
     if executable('fcitx')
-        call add(plugins,['lilydjwg/fcitx.vim',        { 'on_i' : 1}])
+        call add(plugins,['lilydjwg/fcitx.vim',        { 'on_event' : 'InsertEnter'}])
     endif
     return plugins
 endfunction

--- a/autoload/SpaceVim/layers/lang/vim.vim
+++ b/autoload/SpaceVim/layers/lang/vim.vim
@@ -6,7 +6,7 @@ function! SpaceVim#layers#lang#vim#plugins() abort
                 \ ]
     call add(plugins,['tweekmonster/exception.vim'])
     call add(plugins,['mhinz/vim-lookup'])
-    call add(plugins,['Shougo/neco-vim',              { 'on_i' : 1, 'loadconf_before' : 1}])
+    call add(plugins,['Shougo/neco-vim',              { 'on_event' : 'InsertEnter', 'loadconf_before' : 1}])
     call add(plugins,['tweekmonster/helpful.vim',      {'on_cmd': 'HelpfulVersion'}])
     return plugins
 endfunction


### PR DESCRIPTION
Based on dein plugin documentation, 'on_i' or 'dein-options-on_i' is deprecated. It should be used 'on_event'.

'on_i' will call dein#source() on InsertEnter autocmd event, and the equivalent for 'on_event' is "'on_event' : 'InsertEnter'".