### PR TITLE
Fix exclude syntax (-g) for rg util

### DIFF
--- a/autoload/zvim/util.vim
+++ b/autoload/zvim/util.vim
@@ -277,7 +277,7 @@ fu! zvim#util#Generate_ignore(ignore,tool) abort
     elseif a:tool ==# 'rg'
         for ig in split(a:ignore,',')
             call add(ignore, '-g')
-            call add(ignore, '!' . ig)
+            call add(ignore, "'!" . ig . "'")
         endfor
     endif
     return ignore


### PR DESCRIPTION
A fix for #516 issue.

In rg values given to -g must be quoted or your shell will expand them
and result in unexpected behavior. For example: rg -g '\<glob\>'.

