### PR TITLE
Statusline

### DIFF
--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -131,6 +131,9 @@ let g:spacevim_enable_neocomplcache    = 0
 " <
 let g:spacevim_enable_cursorline       = 1
 ""
+" Set the statusline separators of statusline, default is 'arrow'
+let g:spacevim_statusline_separator = 'arrow'
+""
 " Enable/Disable cursorcolumn. Default is 0, cursorcolumn will be
 " highlighted in normal mode. To enable this feature:
 " >

--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -479,6 +479,10 @@ function! SpaceVim#end() abort
     silent exec 'lan ' . g:spacevim_language
   endif
 
+  if index(g:spacevim_plugin_groups, 'core#statusline') != -1
+    call SpaceVim#layers#core#statusline#init()
+  endif
+
   if g:spacevim_realtime_leader_guide
     nnoremap <silent><nowait> <leader> :<c-u>LeaderGuide get(g:, 'mapleader', '\')<CR>
     vnoremap <silent> <leader> :<c-u>LeaderGuideVisual get(g:, 'mapleader', '\')<CR>

--- a/autoload/SpaceVim/api/time.vim
+++ b/autoload/SpaceVim/api/time.vim
@@ -1,0 +1,11 @@
+let s:self = {}
+
+" see: man 3 strftime
+function! s:self.current_time() abort
+  return strftime('%I:%M %p')   
+endfunction
+
+
+function! SpaceVim#api#time#get() abort
+    return deepcopy(s:self)
+endfunction

--- a/autoload/SpaceVim/api/vim/buffer.vim
+++ b/autoload/SpaceVim/api/vim/buffer.vim
@@ -36,6 +36,10 @@ func! s:self.resize(size, ...) abort
 	exe cmd 'resize' a:size
 endf
 
+function! s:self.listed_buffers() abort
+    return filter(range(1, bufnr('$')), 'buflisted(v:val)')
+endfunction
+
 fu! SpaceVim#api#vim#buffer#get() abort
    return deepcopy(s:self)
 endf

--- a/autoload/SpaceVim/api/vim/highlight.vim
+++ b/autoload/SpaceVim/api/vim/highlight.vim
@@ -7,8 +7,8 @@ function! s:self.group2dict(name) abort
     endif
     let rst = {
                 \ 'name' : synIDattr(id, 'name'),
-                \ 'ctermbg' : synIDattr(id, 'bg'),
-                \ 'ctermfg' : synIDattr(id, 'fg'),
+                \ 'ctermbg' : synIDattr(id, 'bg', 'cterm'),
+                \ 'ctermfg' : synIDattr(id, 'fg', 'cterm'),
                 \ 'bold' : synIDattr(id, 'bold'),
                 \ 'italic' : synIDattr(id, 'italic'),
                 \ 'underline' : synIDattr(id, 'underline'),

--- a/autoload/SpaceVim/api/vim/highlight.vim
+++ b/autoload/SpaceVim/api/vim/highlight.vim
@@ -69,7 +69,6 @@ function! s:self.hide_in_normal(name) abort
         return
     endif
     if &termguicolors || has('gui_running')
-        let g:wsd = self.group2dict('Normal')
         let bg = self.group2dict('Normal').guibg
         let group.guifg = bg
         let group.guibg = bg

--- a/autoload/SpaceVim/api/vim/highlight.vim
+++ b/autoload/SpaceVim/api/vim/highlight.vim
@@ -1,7 +1,7 @@
 let s:self = {}
 
 function! s:self.group2dict(name) abort
-    let id = index(map(range(999), 'synIDattr(v:val, "name")'), a:name)
+    let id = index(map(range(999), "synIDattr(v:val, 'name')"), a:name)
     if id == -1
         return {}
     endif
@@ -78,6 +78,28 @@ function! s:self.hide_in_normal(name) abort
         let group.ctermbg = bg
     endif
     call self.hi(group)
+endfunction
+
+
+function! s:self.hi_separator(a, b) abort
+    let hi_a = self.group2dict(a:a)
+    let hi_b = self.group2dict(a:b)
+    let hi_a_b = {
+                \ 'name' : a:a . '_' . a:b,
+                \ 'guibg' : hi_b.guibg,
+                \ 'guifg' : hi_a.guibg,
+                \ 'ctermbg' : hi_b.ctermbg,
+                \ 'ctermfg' : hi_a.ctermbg,
+                \ }
+    let hi_b_a = {
+                \ 'name' : a:b . '_' . a:a,
+                \ 'guibg' : hi_a.guibg,
+                \ 'guifg' : hi_b.guibg,
+                \ 'ctermbg' : hi_a.ctermbg,
+                \ 'ctermfg' : hi_b.ctermbg,
+                \ }
+    call self.hi(hi_a_b)
+    call self.hi(hi_b_a)
 endfunction
 
 function! SpaceVim#api#vim#highlight#get() abort

--- a/autoload/SpaceVim/api/vim/statusline.vim
+++ b/autoload/SpaceVim/api/vim/statusline.vim
@@ -16,7 +16,7 @@ function! s:self.build(left_sections, right_sections, lsep, rsep, hi_a, hi_b, hi
         let flag = flag * -1
     endfor
     let l = l[:-4]
-    if flag
+    if flag == 1
         let l .= '%#' . a:hi_c . '_' . a:hi_z . '#' . a:lsep . '%='
     else
         let l .= '%#' . a:hi_b . '_' . a:hi_z . '#' . a:lsep . '%='

--- a/autoload/SpaceVim/api/vim/statusline.vim
+++ b/autoload/SpaceVim/api/vim/statusline.vim
@@ -1,0 +1,41 @@
+let s:self = {}
+
+
+function! s:self.build(left_sections, right_sections, lsep, rsep, hi_a, hi_b, hi_c, hi_z) abort
+    let l = '%#' . a:hi_a . '#' . a:left_sections[0]
+    let l .= '%#' . a:hi_a . '_' . a:hi_b . '#' . a:lsep
+    let flag = 1
+    for sec in a:left_sections[1:]
+        if flag == 1
+            let l .= '%#' . a:hi_b . '#' . sec
+            let l .= '%#' . a:hi_b . '_' . a:hi_c . '#' . a:lsep
+        else
+            let l .= '%#' . a:hi_c . '#' . sec
+            let l .= '%#' . a:hi_c . '_' . a:hi_b . '#' . a:lsep
+        endif
+        let flag = flag * -1
+    endfor
+    let l = l[:-4]
+    if flag
+        let l .= '%#' . a:hi_c . '_' . a:hi_z . '#' . a:lsep . '%='
+    else
+        let l .= '%#' . a:hi_b . '_' . a:hi_z . '#' . a:lsep . '%='
+    endif
+    let l .= '%#' . a:hi_b . '_' . a:hi_z . '#' . a:rsep
+    let flag = 1
+    for sec in a:right_sections
+        if flag == 1
+            let l .= '%#' . a:hi_b . '#' . sec
+            let l .= '%#' . a:hi_c . '_' . a:hi_b . '#' . a:rsep
+        else
+            let l .= '%#' . a:hi_c . '#' . sec
+            let l .= '%#' . a:hi_b . '_' . a:hi_c . '#' . a:rsep
+        endif
+        let flag = flag * -1
+    endfor
+    return l[:-4]
+endfunction
+
+function! SpaceVim#api#vim#statusline#get() abort
+    return deepcopy(s:self)
+endfunction

--- a/autoload/SpaceVim/autocmds.vim
+++ b/autoload/SpaceVim/autocmds.vim
@@ -123,6 +123,14 @@ function! SpaceVim#autocmds#VimEnter() abort
   for argv in g:_spacevim_mappings_space_custom
     call call('SpaceVim#mapping#space#def', argv)
   endfor
+  if get(g:, '_spacevim_statusline_loaded', 0) == 1
+    set laststatus=2
+    set statusline=%!ActiveStatus()
+    hi User1 guibg=#afd700 guifg=#005f00
+    hi User2 guibg=#005f00 guifg=#afd700
+    hi User3 guibg=#222222 guifg=#005f00
+    hi User4 guibg=#222222 guifg=#d0d0d0
+  endif
 endfunction
 
 

--- a/autoload/SpaceVim/autocmds.vim
+++ b/autoload/SpaceVim/autocmds.vim
@@ -126,7 +126,7 @@ function! SpaceVim#autocmds#VimEnter() abort
   if get(g:, '_spacevim_statusline_loaded', 0) == 1
     set laststatus=2
     call SpaceVim#layers#core#statusline#def_colors()
-    set statusline=%!SpaceVim#layers#core#statusline#get(1)
+    setlocal statusline=%!SpaceVim#layers#core#statusline#get(1)
   endif
   if get(g:, '_spacevim_tabline_loaded', 0) == 1
     call SpaceVim#layers#core#tabline#def_colors()

--- a/autoload/SpaceVim/autocmds.vim
+++ b/autoload/SpaceVim/autocmds.vim
@@ -128,6 +128,10 @@ function! SpaceVim#autocmds#VimEnter() abort
     call SpaceVim#layers#core#statusline#def_colors()
     set statusline=%!SpaceVim#layers#core#statusline#get(1)
   endif
+  if get(g:, '_spacevim_tabline_loaded', 0) == 1
+    call SpaceVim#layers#core#tabline#def_colors()
+    set showtabline=2
+  endif
 endfunction
 
 

--- a/autoload/SpaceVim/autocmds.vim
+++ b/autoload/SpaceVim/autocmds.vim
@@ -125,11 +125,8 @@ function! SpaceVim#autocmds#VimEnter() abort
   endfor
   if get(g:, '_spacevim_statusline_loaded', 0) == 1
     set laststatus=2
-    set statusline=%!ActiveStatus()
-    hi User1 guibg=#afd700 guifg=#005f00
-    hi User2 guibg=#005f00 guifg=#afd700
-    hi User3 guibg=#222222 guifg=#005f00
-    hi User4 guibg=#222222 guifg=#d0d0d0
+    call SpaceVim#layers#core#statusline#def_colors()
+    set statusline=%!SpaceVim#layers#core#statusline#get(1)
   endif
 endfunction
 

--- a/autoload/SpaceVim/layers/core.vim
+++ b/autoload/SpaceVim/layers/core.vim
@@ -9,6 +9,8 @@ endfunction
 function! SpaceVim#layers#core#config() abort
     let g:rooter_silent_chdir = 1
     call SpaceVim#layers#load('core#banner')
+    call SpaceVim#layers#load('core#statusline')
+    call SpaceVim#layers#load('core#tabline')
     call SpaceVim#mapping#space#def('nnoremap', ['p', 't'], 'Rooter', 'find-project-root', 1)
     call SpaceVim#mapping#space#def('nnoremap', ['p', 'f'], 'CtrlP', 'find files in current project', 1)
     call SpaceVim#mapping#space#def('nnoremap', ['p', '/'], 'Grepper', 'fuzzy search for text in current project', 1)

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -21,7 +21,7 @@ let s:separators = {
             \ 'brace' : ["\ue0d2", "\ue0d4"],
             \ 'nil' : ['', ''],
             \ }
-let s:loaded_modes = ['center-cursor']
+let s:loaded_modes = ['syntax-checking']
 let s:modes = {
             \ 'center-cursor': {
             \ 'icon' : '⊝',
@@ -45,7 +45,7 @@ let s:modes = {
             \ },
             \ }
 
-let s:loaded_sections = []
+let s:loaded_sections = ['syntax checking']
 
 function! s:battery_status() abort
     if executable('acpi')
@@ -61,22 +61,17 @@ function! s:time() abort
 endfunction
 
 if g:spacevim_enable_neomake
-    function! s:syntax_checking_warn() abort
+    function! s:syntax_checking()
         let counts = neomake#statusline#LoclistCounts()
         let warnings = get(counts, 'W', 0)
-        return warnings ?  '●' . warnings : ''
-    endfunction
-    function! s:syntax_checking_error() abort
+        let l =  warnings ?  '%#SpaceVim_statusline_warn#●' . warnings : ''
         let counts = neomake#statusline#LoclistCounts()
         let errors = get(counts, 'E', 0)
-        return errors ?  '●' . errors : ''
+        let l .=  errors ?  ' %#SpaceVim_statusline_error#●' . errors : ''
+        return l
     endfunction
 else
 endif
-
-let s:sections = {
-            \ 'battery status' : function('s:battery_status'),
-            \ }
 
 function! s:winnr() abort
     return s:MESSLETTERS.circled_num(winnr(), g:spacevim_buffer_index_type)
@@ -138,12 +133,18 @@ function! s:active() abort
     let l = '%#SpaceVim_statusline_a# ' . s:winnr() . ' %#SpaceVim_statusline_a_b#' . s:lsep
                 \ . '%#SpaceVim_statusline_b# ' . s:filename() . ' %#SpaceVim_statusline_b_c#' . s:lsep
                 \ . '%#SpaceVim_statusline_c# ' . &filetype . ' %#SpaceVim_statusline_c_b#' . s:lsep 
-    if index(s:loaded_sections, 'syntax checking')
-        " TODO : add syntax_checking_warn and syntax_checking_error
+    if index(s:loaded_sections, 'syntax checking') != -1 && s:syntax_checking() != ''
+        let l .= '%#SpaceVim_statusline_b# '
+                    \ . s:syntax_checking()
+                    \ . ' %#SpaceVim_statusline_b_c#' . s:lsep
+        let l .= '%#SpaceVim_statusline_c# ' . s:modes() . ' %#SpaceVim_statusline_c_b#' . s:lsep
+                    \ . '%#SpaceVim_statusline_b# ' . s:git_branch() . ' %#SpaceVim_statusline_z_b#' . s:lsep
+                    \ . '%#SpaceVim_statusline_z#%='
+    else
+        let l .= '%#SpaceVim_statusline_b# ' . s:modes() . ' %#SpaceVim_statusline_b_c#' . s:lsep
+                    \ . '%#SpaceVim_statusline_c# ' . s:git_branch() . ' %#SpaceVim_statusline_c_z#' . s:lsep
+                    \ . '%#SpaceVim_statusline_z#%='
     endif
-    let l .= '%#SpaceVim_statusline_b# ' . s:modes() . ' %#SpaceVim_statusline_b_c#' . s:lsep
-                \ . '%#SpaceVim_statusline_c# ' . s:git_branch() . ' %#SpaceVim_statusline_c_z#' . s:lsep
-                \ . '%#SpaceVim_statusline_z#%='
     if index(s:loaded_sections, 'battery status') != -1
         let l .= '%#SpaceVim_statusline_z_b#' . s:rsep . '%#SpaceVim_statusline_b# ' . s:battery_status() . ' %#SpaceVim_statusline_c_b#'
     else
@@ -195,8 +196,10 @@ function! SpaceVim#layers#core#statusline#def_colors() abort
     hi! SpaceVim_statusline_c_z ctermbg=003 ctermfg=Black guibg=#665c54 guifg=#3c3836
     hi! SpaceVim_statusline_z_c ctermbg=003 ctermfg=Black guibg=#3c3836 guifg=#665c54
     hi! SpaceVim_statusline_z_b ctermbg=003 ctermfg=Black guibg=#665c54 guifg=#504945
+    hi! SpaceVim_statusline_b_z ctermbg=003 ctermfg=Black guibg=#504945 guifg=#665c54
     hi! SpaceVim_statusline_z ctermbg=003 ctermfg=Black guibg=#665c54 guifg=#665c54
-
+    hi! SpaceVim_statusline_error ctermbg=003 ctermfg=Black guibg=#504945 guifg=#fb4934 gui=bold
+    hi! SpaceVim_statusline_warn ctermbg=003 ctermfg=Black guibg=#504945 guifg=#fabd2f gui=bold
 endfunction
 
 function! SpaceVim#layers#core#statusline#toggle_mode(name) abort

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -111,8 +111,8 @@ endfunction
 function! SpaceVim#layers#core#statusline#init() abort
     augroup status
         autocmd!
-        autocmd BufWinEnter,WinEnter * setlocal statusline=%!SpaceVim#layers#core#statusline#get(1)
-        autocmd BufWinLeave,WinLeave * setlocal statusline=%!SpaceVim#layers#core#statusline#get()
+        autocmd BufWinEnter,WinEnter * let &l:statusline = SpaceVim#layers#core#statusline#get(1)
+        autocmd BufWinLeave,WinLeave * let &l:statusline = SpaceVim#layers#core#statusline#get()
     augroup END
 endfunction
 
@@ -131,7 +131,7 @@ function! SpaceVim#layers#core#statusline#toggle_mode(name) abort
     else
         call add(s:loaded_modes, a:name)
     endif
-    setlocal statusline=%!SpaceVim#layers#core#statusline#get(1)
+    let &l:statusline = SpaceVim#layers#core#statusline#get(1)
 endfunction
 
 function! Test() abort

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -49,7 +49,7 @@ let s:loaded_sections = ['syntax checking']
 
 function! s:battery_status() abort
     if executable('acpi')
-        return '⚡ ' . substitute(split(system('acpi'))[-1], '%', '%%', 'g')
+        return '⚡' . substitute(split(system('acpi'))[-1], '%', '%%', 'g')
     else
         return ''
     endif
@@ -84,7 +84,7 @@ endfunction
 function! s:git_branch() abort
     if exists('g:loaded_fugitive')
         let l:head = fugitive#head()
-        return empty(l:head) ? '' : ''.l:head . ' '
+        return empty(l:head) ? '' : ' '.l:head . ' '
     endif
     return ''
 endfunction

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -1,3 +1,11 @@
+" ============================================================================
+" File:        statusline.vim
+" Description: SpaceVim core#statusline layer
+" Author:      Shidong Wang <wsdjeg@outlook.com>
+" Website:     https://spacevim.org
+" License:     MIT
+" ============================================================================
+
 " statusline
 scriptencoding utf-8
 let g:_spacevim_statusline_loaded = 1

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -14,6 +14,10 @@ let s:MESSLETTERS = SpaceVim#api#import('messletters')
 let s:TIME = SpaceVim#api#import('time')
 
 " init
+let s:separators = {
+            \ 'arrow' : ["\ue0b0", "\ue0b2"],
+            \ 'curve' : ["\ue0b4", "\ue0b6"],
+            \ }
 let s:loaded_modes = ['center-cursor']
 let s:modes = {
             \ 'center-cursor': {
@@ -105,21 +109,21 @@ function! SpaceVim#layers#core#statusline#get(...) abort
 endfunction
 
 function! s:active() abort
-    let l = '%#SpaceVim_statusline_a# ' . s:winnr() . ' %#SpaceVim_statusline_a_b#'
-                \ . '%#SpaceVim_statusline_b# ' . s:filename() . ' %#SpaceVim_statusline_b_c#'
-                \ . '%#SpaceVim_statusline_c# ' . &filetype . ' %#SpaceVim_statusline_c_b#' 
-                \ . '%#SpaceVim_statusline_b# ' . s:modes() . ' %#SpaceVim_statusline_b_c#'
-                \ . '%#SpaceVim_statusline_c# ' . s:git_branch() . ' %#SpaceVim_statusline_c_z#'
+    let l = '%#SpaceVim_statusline_a# ' . s:winnr() . ' %#SpaceVim_statusline_a_b#' . s:lsep
+                \ . '%#SpaceVim_statusline_b# ' . s:filename() . ' %#SpaceVim_statusline_b_c#' . s:lsep
+                \ . '%#SpaceVim_statusline_c# ' . &filetype . ' %#SpaceVim_statusline_c_b#' . s:lsep 
+                \ . '%#SpaceVim_statusline_b# ' . s:modes() . ' %#SpaceVim_statusline_b_c#' . s:lsep
+                \ . '%#SpaceVim_statusline_c# ' . s:git_branch() . ' %#SpaceVim_statusline_c_z#' . s:lsep
                 \ . '%#SpaceVim_statusline_z#%='
     if index(s:loaded_sections, 'battery status') != -1
-        let l .= '%#SpaceVim_statusline_z_b#%#SpaceVim_statusline_b# ' . s:battery_status() . ' %#SpaceVim_statusline_c_b#'
+        let l .= '%#SpaceVim_statusline_z_b#' . s:rsep . '%#SpaceVim_statusline_b# ' . s:battery_status() . ' %#SpaceVim_statusline_c_b#'
     else
         let l .= '%#SpaceVim_statusline_c_z#'
     endif
-    let l .= '%#SpaceVim_statusline_c#%{" " . &ff . "|" . (&fenc!=""?&fenc:&enc) . " "}'
-                \ . '%#SpaceVim_statusline_b_c#%#SpaceVim_statusline_b# %P '
+    let l .= s:rsep . '%#SpaceVim_statusline_c#%{" " . &ff . "|" . (&fenc!=""?&fenc:&enc) . " "}'
+                \ . '%#SpaceVim_statusline_b_c#' . s:rsep . '%#SpaceVim_statusline_b# %P '
     if index(s:loaded_sections, 'time') != -1
-        let l .= '%#SpaceVim_statusline_c_b#%#SpaceVim_statusline_c# ' . s:time() . ' '
+        let l .= '%#SpaceVim_statusline_c_b#' . s:rsep . '%#SpaceVim_statusline_c# ' . s:time() . ' '
     endif
     return l
 endfunction
@@ -189,6 +193,7 @@ function! Test() abort
 endfunction
 
 function! SpaceVim#layers#core#statusline#config() abort
+    let [s:lsep , s:rsep] = get(s:separators, g:spacevim_statusline_separator, s:separators['arrow'])
     call SpaceVim#mapping#space#def('nnoremap', ['t', 'm', 'b'], 'call SpaceVim#layers#core#statusline#toggle_section("battery status")',
                 \ 'toggle the battery status', 1)
     call SpaceVim#mapping#space#def('nnoremap', ['t', 'm', 't'], 'call SpaceVim#layers#core#statusline#toggle_section("time")',

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -185,4 +185,6 @@ function! SpaceVim#layers#core#statusline#config() abort
                 \ 'toggle the battery status', 1)
     call SpaceVim#mapping#space#def('nnoremap', ['t', 'm', 't'], 'call SpaceVim#layers#core#statusline#toggle_section("time")',
                 \ 'toggle the time', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['t', 'm', 'T'], 'if &laststatus == 2 | let &laststatus = 0 | else | let &laststatus = 2 | endif',
+                \ 'toggle the statuline itself', 1)
 endfunction

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -48,7 +48,7 @@ let s:modes = {
             \ },
             \ }
 
-let s:loaded_sections = ['syntax checking']
+let s:loaded_sections = ['syntax checking', 'major mode', 'minor mode lighters']
 
 function! s:battery_status() abort
     if executable('acpi')
@@ -133,13 +133,19 @@ function! SpaceVim#layers#core#statusline#get(...) abort
 endfunction
 
 function! s:active() abort
-    let lsec = [s:winnr(), s:filename(), ' ' . &filetype . ' ']
+    let lsec = [s:winnr(), s:filename()]
+
+    if index(s:loaded_sections, 'major mode') != -1
+        call add(lsec, ' ' . &filetype . ' ')
+    endif
     let rsec = []
     if index(s:loaded_sections, 'syntax checking') != -1 && s:syntax_checking() != ''
         call add(lsec, s:syntax_checking())
     endif
 
-    call add(lsec, s:modes())
+    if index(s:loaded_sections, 'minor mode lighters') != -1
+        call add(lsec, s:modes())
+    endif
     call add(lsec, s:git_branch())
     if index(s:loaded_sections, 'battery status') != -1
         call add(rsec, s:battery_status())

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -1,40 +1,65 @@
-let g:spacevim_statusline_mode_format = {
-            \ 'n' : 'NORMAL',
-            \ 'i' : 'INSERT',
-            \ 'v' : 'VISUAL', 
-            \ }
+" statusline
+let g:_spacevim_statusline_loaded = 1
 
-"""""""""""""""""""""""""""""""""
-
-function! s:mode() abort
-    let mt = g:spacevim_statusline_mode_format
-    let m = mode()
-    return mt[m]
+function! ActiveStatus()
+    let statusline=""
+    let statusline.="%1*"
+    let statusline.="%(%{'help'!=&filetype?'\ \ '.bufnr('%'):''}\ %)"
+    let statusline.="%2*"
+    let statusline.=""
+    let statusline.="%{fugitive#head()!=''?'\ \ '.fugitive#head().'\ ':''}"
+    let statusline.="%3*"
+    let statusline.=""
+    let statusline.="%4*"
+    let statusline.="\ %<"
+    let statusline.="%f"
+    let statusline.="%{&modified?'\ \ +':''}"
+    let statusline.="%{&readonly?'\ \ ':''}"
+    let statusline.="%="
+    let statusline.="\ %{''!=#&filetype?&filetype:'none'}"
+    let statusline.="%(\ %{(&bomb\|\|'^$\|utf-8'!~#&fileencoding?'\ '.&fileencoding.(&bomb?'-bom':''):'').('unix'!=#&fileformat?'\ '.&fileformat:'')}%)"
+    let statusline.="%(\ \ %{&modifiable?(&expandtab?'et\ ':'noet\ ').&shiftwidth:''}%)"
+    let statusline.="%3*"
+    let statusline.="\ "
+    let statusline.="%2*"
+    let statusline.=""
+    let statusline.="%1*"
+    let statusline.="\ %2v"
+    let statusline.="\ %3p%%\ "
+    return statusline
 endfunction
 
-function! s:filetype() abort
-    return &filetype
+function! InactiveStatus()
+    let statusline=""
+    let statusline.="%(%{'help'!=&filetype?'\ \ '.bufnr('%').'\ \ ':'\ '}%)"
+    let statusline.="%{fugitive#head()!=''?'\ \ '.fugitive#head().'\ ':'\ '}"
+    let statusline.="\ %<"
+    let statusline.="%f"
+    let statusline.="%{&modified?'\ \ +':''}"
+    let statusline.="%{&readonly?'\ \ ':''}"
+    let statusline.="%="
+    let statusline.="\ %{''!=#&filetype?&filetype:'none'}"
+    let statusline.="%(\ %{(&bomb\|\|'^$\|utf-8'!~#&fileencoding?'\ '.&fileencoding.(&bomb?'-bom':''):'').('unix'!=#&fileformat?'\ '.&fileformat:'')}%)"
+    let statusline.="%(\ \ %{&modifiable?(&expandtab?'et\ ':'noet\ ').&shiftwidth:''}%)"
+    let statusline.="\ \ "
+    let statusline.="\ %2v"
+    let statusline.="\ %3p%%\ "
+    return statusline
 endfunction
 
-function! s:encoding() abort
-    return &encoding
+
+function! SpaceVim#layers#core#statusline#init() abort
+    augroup status
+        autocmd!
+        autocmd WinEnter * setlocal statusline=%!ActiveStatus()
+        autocmd WinLeave * setlocal statusline=%!InactiveStatus()
+        autocmd ColorScheme kalisi if(&background=="dark") | hi User1 guibg=#afd700 guifg=#005f00 | endif
+        autocmd ColorScheme kalisi if(&background=="dark") | hi User2 guibg=#005f00 guifg=#afd700 | endif
+        autocmd ColorScheme kalisi if(&background=="dark") | hi User3 guibg=#222222 guifg=#005f00 | endif
+        autocmd ColorScheme kalisi if(&background=="dark") | hi User4 guibg=#222222 guifg=#d0d0d0 | endif
+        autocmd ColorScheme kalisi if(&background=="light") | hi User1 guibg=#afd700 guifg=#005f00 | endif
+        autocmd ColorScheme kalisi if(&background=="light") | hi User2 guibg=#005f00 guifg=#afd700 | endif
+        autocmd ColorScheme kalisi if(&background=="light") | hi User3 guibg=#707070 guifg=#005f00 | endif
+        autocmd ColorScheme kalisi if(&background=="light") | hi User4 guibg=#707070 guifg=#d0d0d0 | endif
+    augroup END
 endfunction
-
-
-function! s:tabname() abort
-    return '1'
-endfunction
-
-function! SpaceVim#layers#core#statusline#get() abort
-    return join([
-                \ s:mode(),
-                \ s:tabname(),
-                \ s:encoding(),
-                \ s:filetype()
-                \ ], ' ')
-endfunction
-
-function! s:refresh() abort
-endfunction
-set statusline=%!SpaceVim#layers#core#statusline#get()
-

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -62,6 +62,13 @@ function! s:filesize() abort
 endfunction
 
 function! SpaceVim#layers#core#statusline#get(...) abort
+    if &filetype ==# 'vimfiler'
+        return '%#SpaceVim_statusline_a# ' . s:winnr() . ' %#SpaceVim_statusline_a_b#'
+                \ . '%#SpaceVim_statusline_b# vimfiler %#SpaceVim_statusline_b_c#'
+    elseif &filetype ==# 'tagbar'
+        return '%#SpaceVim_statusline_a# ' . s:winnr() . ' %#SpaceVim_statusline_a_b#'
+                \ . '%#SpaceVim_statusline_b# tagbar %#SpaceVim_statusline_b_c#'
+    endif
     if a:0 > 0
         return s:active()
     else
@@ -104,8 +111,8 @@ endfunction
 function! SpaceVim#layers#core#statusline#init() abort
     augroup status
         autocmd!
-        autocmd WinEnter * setlocal statusline=%!SpaceVim#layers#core#statusline#get(1)
-        autocmd WinLeave * setlocal statusline=%!SpaceVim#layers#core#statusline#get()
+        autocmd BufWinEnter,WinEnter * setlocal statusline=%!SpaceVim#layers#core#statusline#get(1)
+        autocmd BufWinLeave,WinLeave * setlocal statusline=%!SpaceVim#layers#core#statusline#get()
     augroup END
 endfunction
 

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -5,13 +5,21 @@ let g:_spacevim_statusline_loaded = 1
 let s:MESSLETTERS = SpaceVim#api#import('messletters')
 
 " init
-let s:loaded_modes = ['⊝']
-let s:modes = [
-            \ {
-            \ 'name' : '⊝',
+let s:loaded_modes = ['center-cursor']
+let s:modes = {
+            \ 'center-cursor': {
+            \ 'icon' : '⊝',
             \ 'desc' : 'centered-cursor mode',
+            \ },
+            \ 'hi-characters-for-long-lines' :{
+            \ 'icon' : '⑧',
+            \ 'desc' : 'toggle highlight of characters for long lines',
+            \ },
+            \ 'fill-column-indicator' :{
+            \ 'icon' : s:MESSLETTERS.circled_letter('f'),
+            \ 'desc' : 'fill-column-indicator mode',
+            \ },
             \ }
-            \ ]
 
 function! s:winnr() abort
     return s:MESSLETTERS.circled_num(winnr(), g:spacevim_buffer_index_type)
@@ -32,7 +40,7 @@ endfunction
 function! s:modes() abort
     let m = '❖ '
     for mode in s:loaded_modes
-        let m .= mode . ' '
+        let m .= s:modes[mode].icon . ' '
     endfor
     return m
 endfunction
@@ -62,11 +70,6 @@ function! SpaceVim#layers#core#statusline#get(...) abort
 endfunction
 
 function! s:active() abort
-    let l:m_r_f = '%7* %m%r%y %*'
-    let l:ff = '%8* %{&ff} |'
-    let l:enc = " %{''.(&fenc!=''?&fenc:&enc).''} | %{(&bomb?\",BOM\":\"\")}"
-    let l:pos = '%l:%c%V %*'
-    let l:pct = '%9* %P %*'
     return '%#SpaceVim_statusline_a# ' . s:winnr() . ' %#SpaceVim_statusline_a_b#'
                 \ . '%#SpaceVim_statusline_b# ' . s:filename() . ' %#SpaceVim_statusline_b_c#'
                 \ . '%#SpaceVim_statusline_c# ' . &filetype . ' %#SpaceVim_statusline_c_b#' 
@@ -79,9 +82,16 @@ function! s:active() abort
 endfunction
 
 function! s:inactive() abort
-
+    return '%#SpaceVim_statusline_a# ' . s:winnr() . ' %#SpaceVim_statusline_a_b#'
+                \ . '%#SpaceVim_statusline_b# ' . s:filename() . ' '
+                \ . ' ' . &filetype . ' ' 
+                \ . ' ' . s:modes() . ' '
+                \ . ' ' . s:git_branch() . ' '
+                \ . ' %='
+                \ . '%{" " . &ff . "|" . (&fenc!=""?&fenc:&enc) . " "}'
+                \ . ' %P '
 endfunction
-function! s:gitgutter()
+function! s:gitgutter() abort
     if exists('b:gitgutter_summary')
         let l:summary = get(b:, 'gitgutter_summary')
         if l:summary[0] != 0 || l:summary[1] != 0 || l:summary[2] != 0
@@ -106,4 +116,17 @@ function! SpaceVim#layers#core#statusline#def_colors() abort
     hi! SpaceVim_statusline_b_c ctermbg=003 ctermfg=Black guibg=#3c3836 guifg=#504945
     hi! SpaceVim_statusline_c ctermbg=003 ctermfg=Black guibg=#3c3836 guifg=#a89984
     hi! SpaceVim_statusline_c_b ctermbg=003 ctermfg=Black guibg=#504945 guifg=#3c3836
+endfunction
+
+function! SpaceVim#layers#core#statusline#toggle_mode(name) abort
+    if index(s:loaded_modes, a:name) != -1
+        call remove(s:loaded_modes, index(s:loaded_modes, a:name))
+    else
+        call add(s:loaded_modes, a:name)
+    endif
+    setlocal statusline=%!SpaceVim#layers#core#statusline#get(1)
+endfunction
+
+function! Test() abort
+    echo s:loaded_modes
 endfunction

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -18,7 +18,8 @@ let s:separators = {
             \ 'arrow' : ["\ue0b0", "\ue0b2"],
             \ 'curve' : ["\ue0b4", "\ue0b6"],
             \ 'slant' : ["\ue0b8", "\ue0ba"],
-            \ 'nil' : ['', '']
+            \ 'brace' : ["\ue0d2", "\ue0d4"],
+            \ 'nil' : ['', ''],
             \ }
 let s:loaded_modes = ['center-cursor']
 let s:modes = {
@@ -34,6 +35,14 @@ let s:modes = {
             \ 'icon' : s:MESSLETTERS.circled_letter('f'),
             \ 'desc' : 'fill-column-indicator mode',
             \ },
+            \ 'syntax-checking' :{
+            \ 'icon' : s:MESSLETTERS.circled_letter('s'),
+            \ 'desc' : 'syntax-checking mode',
+            \ },
+            \ 'spell-checking' :{
+            \ 'icon' : s:MESSLETTERS.circled_letter('S'),
+            \ 'desc' : 'spell-checking mode',
+            \ },
             \ }
 
 let s:loaded_sections = []
@@ -46,9 +55,24 @@ function! s:battery_status() abort
     endif
 endfunction
 
+
 function! s:time() abort
     return s:TIME.current_time()
 endfunction
+
+if g:spacevim_enable_neomake
+    function! s:syntax_checking_warn() abort
+        let counts = neomake#statusline#LoclistCounts()
+        let warnings = get(counts, 'W', 0)
+        return warnings ?  '●' . warnings : ''
+    endfunction
+    function! s:syntax_checking_error() abort
+        let counts = neomake#statusline#LoclistCounts()
+        let errors = get(counts, 'E', 0)
+        return errors ?  '●' . errors : ''
+    endfunction
+else
+endif
 
 let s:sections = {
             \ 'battery status' : function('s:battery_status'),
@@ -98,10 +122,10 @@ endfunction
 function! SpaceVim#layers#core#statusline#get(...) abort
     if &filetype ==# 'vimfiler'
         return '%#SpaceVim_statusline_a# ' . s:winnr() . ' %#SpaceVim_statusline_a_b#'
-                \ . '%#SpaceVim_statusline_b# vimfiler %#SpaceVim_statusline_b_c#'
+                    \ . '%#SpaceVim_statusline_b# vimfiler %#SpaceVim_statusline_b_c#'
     elseif &filetype ==# 'tagbar'
         return '%#SpaceVim_statusline_a# ' . s:winnr() . ' %#SpaceVim_statusline_a_b#'
-                \ . '%#SpaceVim_statusline_b# tagbar %#SpaceVim_statusline_b_c#'
+                    \ . '%#SpaceVim_statusline_b# tagbar %#SpaceVim_statusline_b_c#'
     endif
     if a:0 > 0
         return s:active()
@@ -114,7 +138,10 @@ function! s:active() abort
     let l = '%#SpaceVim_statusline_a# ' . s:winnr() . ' %#SpaceVim_statusline_a_b#' . s:lsep
                 \ . '%#SpaceVim_statusline_b# ' . s:filename() . ' %#SpaceVim_statusline_b_c#' . s:lsep
                 \ . '%#SpaceVim_statusline_c# ' . &filetype . ' %#SpaceVim_statusline_c_b#' . s:lsep 
-                \ . '%#SpaceVim_statusline_b# ' . s:modes() . ' %#SpaceVim_statusline_b_c#' . s:lsep
+    if index(s:loaded_sections, 'syntax checking')
+        " TODO : add syntax_checking_warn and syntax_checking_error
+    endif
+    let l .= '%#SpaceVim_statusline_b# ' . s:modes() . ' %#SpaceVim_statusline_b_c#' . s:lsep
                 \ . '%#SpaceVim_statusline_c# ' . s:git_branch() . ' %#SpaceVim_statusline_c_z#' . s:lsep
                 \ . '%#SpaceVim_statusline_z#%='
     if index(s:loaded_sections, 'battery status') != -1

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -18,6 +18,7 @@ let s:separators = {
             \ 'arrow' : ["\ue0b0", "\ue0b2"],
             \ 'curve' : ["\ue0b4", "\ue0b6"],
             \ 'slant' : ["\ue0b8", "\ue0ba"],
+            \ 'nil' : ['', '']
             \ }
 let s:loaded_modes = ['center-cursor']
 let s:modes = {

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -17,6 +17,7 @@ let s:TIME = SpaceVim#api#import('time')
 let s:separators = {
             \ 'arrow' : ["\ue0b0", "\ue0b2"],
             \ 'curve' : ["\ue0b4", "\ue0b6"],
+            \ 'slant' : ["\ue0b8", "\ue0ba"],
             \ }
 let s:loaded_modes = ['center-cursor']
 let s:modes = {

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -26,7 +26,7 @@ let s:loaded_sections = []
 
 function! s:battery_status() abort
     if executable('acpi')
-        return substitute(split(system('acpi'))[-1], '%', '%%', 'g')
+        return '⚡ ' . substitute(split(system('acpi'))[-1], '%', '%%', 'g')
     else
         return ''
     endif

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -1,65 +1,109 @@
 " statusline
+scriptencoding utf-8
 let g:_spacevim_statusline_loaded = 1
+" APIs
+let s:MESSLETTERS = SpaceVim#api#import('messletters')
 
-function! ActiveStatus()
-    let statusline=""
-    let statusline.="%1*"
-    let statusline.="%(%{'help'!=&filetype?'\ \ '.bufnr('%'):''}\ %)"
-    let statusline.="%2*"
-    let statusline.=""
-    let statusline.="%{fugitive#head()!=''?'\ \ '.fugitive#head().'\ ':''}"
-    let statusline.="%3*"
-    let statusline.=""
-    let statusline.="%4*"
-    let statusline.="\ %<"
-    let statusline.="%f"
-    let statusline.="%{&modified?'\ \ +':''}"
-    let statusline.="%{&readonly?'\ \ ':''}"
-    let statusline.="%="
-    let statusline.="\ %{''!=#&filetype?&filetype:'none'}"
-    let statusline.="%(\ %{(&bomb\|\|'^$\|utf-8'!~#&fileencoding?'\ '.&fileencoding.(&bomb?'-bom':''):'').('unix'!=#&fileformat?'\ '.&fileformat:'')}%)"
-    let statusline.="%(\ \ %{&modifiable?(&expandtab?'et\ ':'noet\ ').&shiftwidth:''}%)"
-    let statusline.="%3*"
-    let statusline.="\ "
-    let statusline.="%2*"
-    let statusline.=""
-    let statusline.="%1*"
-    let statusline.="\ %2v"
-    let statusline.="\ %3p%%\ "
-    return statusline
+" init
+let s:loaded_modes = ['⊝']
+let s:modes = [
+            \ {
+            \ 'name' : '⊝',
+            \ 'desc' : 'centered-cursor mode',
+            \ }
+            \ ]
+
+function! s:winnr() abort
+    return s:MESSLETTERS.circled_num(winnr(), g:spacevim_buffer_index_type)
 endfunction
 
-function! InactiveStatus()
-    let statusline=""
-    let statusline.="%(%{'help'!=&filetype?'\ \ '.bufnr('%').'\ \ ':'\ '}%)"
-    let statusline.="%{fugitive#head()!=''?'\ \ '.fugitive#head().'\ ':'\ '}"
-    let statusline.="\ %<"
-    let statusline.="%f"
-    let statusline.="%{&modified?'\ \ +':''}"
-    let statusline.="%{&readonly?'\ \ ':''}"
-    let statusline.="%="
-    let statusline.="\ %{''!=#&filetype?&filetype:'none'}"
-    let statusline.="%(\ %{(&bomb\|\|'^$\|utf-8'!~#&fileencoding?'\ '.&fileencoding.(&bomb?'-bom':''):'').('unix'!=#&fileformat?'\ '.&fileformat:'')}%)"
-    let statusline.="%(\ \ %{&modifiable?(&expandtab?'et\ ':'noet\ ').&shiftwidth:''}%)"
-    let statusline.="\ \ "
-    let statusline.="\ %2v"
-    let statusline.="\ %3p%%\ "
-    return statusline
+function! s:filename() abort
+    return (&modified ? ' * ' : ' - ') . s:filesize() . fnamemodify(bufname('%'), ':t')
 endfunction
 
+function! s:git_branch() abort
+    if exists('g:loaded_fugitive')
+        let l:head = fugitive#head()
+        return empty(l:head) ? '' : ''.l:head . ' '
+    endif
+    return ''
+endfunction
+
+function! s:modes() abort
+    let m = '❖ '
+    for mode in s:loaded_modes
+        let m .= mode . ' '
+    endfor
+    return m
+endfunction
+
+function! s:filesize() abort
+    let l:size = getfsize(bufname('%'))
+    if l:size == 0 || l:size == -1 || l:size == -2
+        return ''
+    endif
+    if l:size < 1024
+        return l:size.' bytes '
+    elseif l:size < 1024*1024
+        return printf('%.1f', l:size/1024.0).'k '
+    elseif l:size < 1024*1024*1024
+        return printf('%.1f', l:size/1024.0/1024.0) . 'm '
+    else
+        return printf('%.1f', l:size/1024.0/1024.0/1024.0) . 'g '
+    endif
+endfunction
+
+function! SpaceVim#layers#core#statusline#get(...) abort
+    if a:0 > 0
+        return s:active()
+    else
+        return s:inactive()
+    endif
+endfunction
+
+function! s:active() abort
+    let l:m_r_f = '%7* %m%r%y %*'
+    let l:ff = '%8* %{&ff} |'
+    let l:enc = " %{''.(&fenc!=''?&fenc:&enc).''} | %{(&bomb?\",BOM\":\"\")}"
+    let l:pos = '%l:%c%V %*'
+    let l:pct = '%9* %P %*'
+    return '%#SpaceVim_statusline_a# ' . s:winnr() . ' %#SpaceVim_statusline_a_b#'
+                \ . '%#SpaceVim_statusline_b# ' . s:filename() . ' %#SpaceVim_statusline_b_c#'
+                \ . '%#SpaceVim_statusline_c# ' . &filetype . ' %#SpaceVim_statusline_c_b#' 
+                \ . '%#SpaceVim_statusline_b# ' . s:modes() . ' %#SpaceVim_statusline_b_c#'
+                \ . '%#SpaceVim_statusline_c# ' . s:git_branch() . ' %#SpaceVim_statusline_c_b#'
+                \ . '%#SpaceVim_statusline_b# %='
+                \ . '%#SpaceVim_statusline_c_b#%#SpaceVim_statusline_c#%{" " . &ff . "|" . (&fenc!=""?&fenc:&enc) . " "}'
+                \ . '%#SpaceVim_statusline_b_c#%#SpaceVim_statusline_b# %P '
+
+endfunction
+
+function! s:inactive() abort
+
+endfunction
+function! s:gitgutter()
+    if exists('b:gitgutter_summary')
+        let l:summary = get(b:, 'gitgutter_summary')
+        if l:summary[0] != 0 || l:summary[1] != 0 || l:summary[2] != 0
+            return ' +'.l:summary[0].' ~'.l:summary[1].' -'.l:summary[2].' '
+        endif
+    endif
+    return ''
+endfunction
 
 function! SpaceVim#layers#core#statusline#init() abort
     augroup status
         autocmd!
-        autocmd WinEnter * setlocal statusline=%!ActiveStatus()
-        autocmd WinLeave * setlocal statusline=%!InactiveStatus()
-        autocmd ColorScheme kalisi if(&background=="dark") | hi User1 guibg=#afd700 guifg=#005f00 | endif
-        autocmd ColorScheme kalisi if(&background=="dark") | hi User2 guibg=#005f00 guifg=#afd700 | endif
-        autocmd ColorScheme kalisi if(&background=="dark") | hi User3 guibg=#222222 guifg=#005f00 | endif
-        autocmd ColorScheme kalisi if(&background=="dark") | hi User4 guibg=#222222 guifg=#d0d0d0 | endif
-        autocmd ColorScheme kalisi if(&background=="light") | hi User1 guibg=#afd700 guifg=#005f00 | endif
-        autocmd ColorScheme kalisi if(&background=="light") | hi User2 guibg=#005f00 guifg=#afd700 | endif
-        autocmd ColorScheme kalisi if(&background=="light") | hi User3 guibg=#707070 guifg=#005f00 | endif
-        autocmd ColorScheme kalisi if(&background=="light") | hi User4 guibg=#707070 guifg=#d0d0d0 | endif
+        autocmd WinEnter * setlocal statusline=%!SpaceVim#layers#core#statusline#get(1)
+        autocmd WinLeave * setlocal statusline=%!SpaceVim#layers#core#statusline#get()
     augroup END
+endfunction
+
+function! SpaceVim#layers#core#statusline#def_colors() abort
+    hi! SpaceVim_statusline_a ctermbg=003 ctermfg=Black guibg=#a89984 guifg=#282828
+    hi! SpaceVim_statusline_a_b ctermbg=003 ctermfg=Black guibg=#504945 guifg=#a89984
+    hi! SpaceVim_statusline_b ctermbg=003 ctermfg=Black guibg=#504945 guifg=#a89984
+    hi! SpaceVim_statusline_b_c ctermbg=003 ctermfg=Black guibg=#3c3836 guifg=#504945
+    hi! SpaceVim_statusline_c ctermbg=003 ctermfg=Black guibg=#3c3836 guifg=#a89984
+    hi! SpaceVim_statusline_c_b ctermbg=003 ctermfg=Black guibg=#504945 guifg=#3c3836
 endfunction

--- a/autoload/SpaceVim/layers/core/tabline.vim
+++ b/autoload/SpaceVim/layers/core/tabline.vim
@@ -69,9 +69,12 @@ function! SpaceVim#layers#core#tabline#get() abort
         let t .= '%#SpaceVim_tabline_a# Tabs'
     else
         let buffers = s:BUFFER.listed_buffers()
+        if len(buffers) == 0
+            return ''
+        endif
         let ct = bufnr('%')
         let pt = index(buffers, ct) > 0 ? buffers[index(buffers, ct) - 1] : -1
-        if ct == buffers[0]
+        if ct == get(buffers, 0, -1)
             let t = '%#SpaceVim_tabline_a#  '
         else
             let t = '%#SpaceVim_tabline_b#  '

--- a/autoload/SpaceVim/layers/core/tabline.vim
+++ b/autoload/SpaceVim/layers/core/tabline.vim
@@ -11,9 +11,12 @@
 " @parentsection layers
 " This layer provides default tabline for SpaceVim
 
+scriptencoding utf-8
 let s:messletters = SpaceVim#api#import('messletters')
 let s:file = SpaceVim#api#import('file')
+let s:BUFFER = SpaceVim#api#import('vim#buffer')
 
+let g:_spacevim_tabline_loaded = 1
 
 function! s:tabname(id) abort
     let id = s:messletters.bubble_num(a:id, g:spacevim_buffer_index_type) . ' '
@@ -32,28 +35,78 @@ function! s:tabname(id) abort
 endfunction
 
 function! SpaceVim#layers#core#tabline#get() abort
-    let t = '  '
-    let nr = tabpagenr()
-    " if nr > 1
-    for i in range(1, nr)
-        let buflist = tabpagebuflist(i)
-        let winnr = tabpagewinnr(i)
-        let name = fnamemodify(bufname(buflist[winnr - 1]), ':t')
-        let id = s:messletters.bubble_num(i, g:spacevim_buffer_index_type)
-        let icon = s:file.fticon(name)
-        if !empty(icon)
-            let name = icon . ' ' . name
-        endif
-        let t .= id . ' ' . name
-        if i == nr
-            let t .= '%#TabLineSel#'
+    let nr = tabpagenr('$')
+    let t = ''
+    if nr > 1
+        let ct = tabpagenr()
+        if ct == 1
+            let t = '%#SpaceVim_tabline_a#  '
         else
-            let t .= '%#TabLine# | '
+            let t = '%#SpaceVim_tabline_b#  '
         endif
-    endfor
-    let t .= '%#TabLineFill#%T'
+        for i in range(1, nr)
+            if i == ct
+                let t .= '%#SpaceVim_tabline_a#'
+            endif
+            let buflist = tabpagebuflist(i)
+            let winnr = tabpagewinnr(i)
+            let name = fnamemodify(bufname(buflist[winnr - 1]), ':t')
+            let id = s:messletters.bubble_num(i, g:spacevim_buffer_index_type)
+            let icon = s:file.fticon(name)
+            if !empty(icon)
+                let name = icon . ' ' . name
+            endif
+            let t .= id . ' ' . name
+            if i == ct - 1
+                let t .= ' %#SpaceVim_tabline_b_a# '
+            elseif i == ct
+                let t .= ' %#SpaceVim_tabline_a_b# '
+            else
+                let t .= '  '
+            endif
+        endfor
+        let t .= '%=%#SpaceVim_tabline_a_b#'
+        let t .= '%#SpaceVim_tabline_a# Tabs'
+    else
+        let buffers = s:BUFFER.listed_buffers()
+        let ct = bufnr('%')
+        let pt = index(buffers, ct) > 0 ? buffers[index(buffers, ct) - 1] : -1
+        if ct == buffers[0]
+            let t = '%#SpaceVim_tabline_a#  '
+        else
+            let t = '%#SpaceVim_tabline_b#  '
+        endif
+        for i in buffers
+            if i == ct
+                let t .= '%#SpaceVim_tabline_a#'
+            endif
+            let name = fnamemodify(bufname(i), ':t')
+            let id = s:messletters.bubble_num(index(buffers, i) + 1, g:spacevim_buffer_index_type)
+            let icon = s:file.fticon(name)
+            if !empty(icon)
+                let name = icon . ' ' . name
+            endif
+            let t .= id . ' ' . name
+            if i == ct
+                let t .= ' %#SpaceVim_tabline_a_b# '
+            elseif i == pt
+                let t .= ' %#SpaceVim_tabline_b_a# '
+            else
+                let t .= '  '
+            endif
+        endfor
+        let t .= '%=%#SpaceVim_tabline_a_b#'
+        let t .= '%#SpaceVim_tabline_a# Buffers'
+    endif
     return t
 endfunction
 function! SpaceVim#layers#core#tabline#config() abort
     set tabline=%!SpaceVim#layers#core#tabline#get()
+endfunction
+
+function! SpaceVim#layers#core#tabline#def_colors() abort
+    hi! SpaceVim_tabline_a ctermbg=003 ctermfg=Black guibg=#a89984 guifg=#282828
+    hi! SpaceVim_tabline_b ctermbg=003 ctermfg=Black guibg=#504945 guifg=#a89984
+    hi! SpaceVim_tabline_a_b ctermbg=003 ctermfg=Black guibg=#504945 guifg=#a89984
+    hi! SpaceVim_tabline_b_a ctermbg=003 ctermfg=Black guibg=#a89984 guifg=#504945
 endfunction

--- a/autoload/SpaceVim/layers/core/tabline.vim
+++ b/autoload/SpaceVim/layers/core/tabline.vim
@@ -107,14 +107,14 @@ endfunction
 function! SpaceVim#layers#core#tabline#config() abort
     set tabline=%!SpaceVim#layers#core#tabline#get()
     for i in range(1, 9)
-        exe "call SpaceVim#mapping#space#def('nmap', [" . i . "], 'b" . i . "', 'window " . i . "', 1)"
+        exe "call SpaceVim#mapping#space#def('nnoremap', [" . i . "], 'call SpaceVim#layers#core#tabline#jump(" . i . ")', 'window " . i . "', 1)"
     endfor
     call SpaceVim#mapping#space#def('nmap', ['-'], 'bprevious', 'window previous', 1)
     call SpaceVim#mapping#space#def('nmap', ['+'], 'bnext', 'window next', 1)
 endfunction
 
 function! SpaceVim#layers#core#tabline#jump(id) abort
-    if len(s:buffers) > a:id + 1
+    if len(s:buffers) >= a:id
         let bid = s:buffers[a:id - 1]
         exe 'b' . bid
     endif

--- a/autoload/SpaceVim/layers/core/tabline.vim
+++ b/autoload/SpaceVim/layers/core/tabline.vim
@@ -17,6 +17,7 @@ let s:file = SpaceVim#api#import('file')
 let s:BUFFER = SpaceVim#api#import('vim#buffer')
 
 let g:_spacevim_tabline_loaded = 1
+let s:buffers = s:BUFFER.listed_buffers()
 
 function! s:tabname(id) abort
     let id = s:messletters.bubble_num(a:id, g:spacevim_buffer_index_type) . ' '
@@ -68,23 +69,23 @@ function! SpaceVim#layers#core#tabline#get() abort
         let t .= '%=%#SpaceVim_tabline_a_b#'
         let t .= '%#SpaceVim_tabline_a# Tabs'
     else
-        let buffers = s:BUFFER.listed_buffers()
-        if len(buffers) == 0
+        let s:buffers = s:BUFFER.listed_buffers()
+        if len(s:buffers) == 0
             return ''
         endif
         let ct = bufnr('%')
-        let pt = index(buffers, ct) > 0 ? buffers[index(buffers, ct) - 1] : -1
-        if ct == get(buffers, 0, -1)
+        let pt = index(s:buffers, ct) > 0 ? s:buffers[index(s:buffers, ct) - 1] : -1
+        if ct == get(s:buffers, 0, -1)
             let t = '%#SpaceVim_tabline_a#  '
         else
             let t = '%#SpaceVim_tabline_b#  '
         endif
-        for i in buffers
+        for i in s:buffers
             if i == ct
                 let t .= '%#SpaceVim_tabline_a#'
             endif
             let name = fnamemodify(bufname(i), ':t')
-            let id = s:messletters.bubble_num(index(buffers, i) + 1, g:spacevim_buffer_index_type)
+            let id = s:messletters.bubble_num(index(s:buffers, i) + 1, g:spacevim_buffer_index_type)
             let icon = s:file.fticon(name)
             if !empty(icon)
                 let name = icon . ' ' . name
@@ -105,6 +106,18 @@ function! SpaceVim#layers#core#tabline#get() abort
 endfunction
 function! SpaceVim#layers#core#tabline#config() abort
     set tabline=%!SpaceVim#layers#core#tabline#get()
+    for i in range(1, 9)
+        exe "call SpaceVim#mapping#space#def('nmap', [" . i . "], 'b" . i . "', 'window " . i . "', 1)"
+    endfor
+    call SpaceVim#mapping#space#def('nmap', ['-'], 'bprevious', 'window previous', 1)
+    call SpaceVim#mapping#space#def('nmap', ['+'], 'bnext', 'window next', 1)
+endfunction
+
+function! SpaceVim#layers#core#tabline#jump(id) abort
+    if len(s:buffers) > a:id + 1
+        let bid = s:buffers[a:id - 1]
+        exe 'b' . bid
+    endif
 endfunction
 
 function! SpaceVim#layers#core#tabline#def_colors() abort

--- a/autoload/SpaceVim/layers/lang/markdown.vim
+++ b/autoload/SpaceVim/layers/lang/markdown.vim
@@ -10,6 +10,7 @@ endfunction
 
 function! SpaceVim#layers#lang#markdown#config() abort
     let g:markdown_minlines = 100
+    let g:markdown_syntax_conceal = 0
     let g:markdown_enable_mappings = 0
     let g:markdown_enable_insert_mode_leader_mappings = 0
     let g:markdown_enable_spell_checking = 0

--- a/autoload/SpaceVim/layers/ui.vim
+++ b/autoload/SpaceVim/layers/ui.vim
@@ -1,16 +1,21 @@
 scriptencoding utf-8
 function! SpaceVim#layers#ui#plugins() abort
-    return [
+    let plugins = [
                 \ ['Yggdroot/indentLine'],
                 \ ['mhinz/vim-signify'],
                 \ ['majutsushi/tagbar', {'loadconf' : 1}],
                 \ ['lvht/tagbar-markdown',{'merged' : 0}],
                 \ ['t9md/vim-choosewin', {'merged' : 0}],
-                \ ['vim-airline/vim-airline',                { 'merged' : 0, 
-                \ 'loadconf' : 1}],
-                \ ['vim-airline/vim-airline-themes',         { 'merged' : 0}],
                 \ ['mhinz/vim-startify', {'loadconf' : 1}],
                 \ ]
+    if get(g:, '_spacevim_statusline_loaded', 0) == 0
+        call add(plugins, ['vim-airline/vim-airline',                { 'merged' : 0, 
+                \ 'loadconf' : 1}])
+        call add(plugins, ['vim-airline/vim-airline-themes',         { 'merged' : 0}])
+    endif
+
+    return plugins
+
 endfunction
 
 function! SpaceVim#layers#ui#config() abort

--- a/autoload/SpaceVim/layers/ui.vim
+++ b/autoload/SpaceVim/layers/ui.vim
@@ -113,6 +113,7 @@ function! s:toggle_colorcolumn() abort
         set cc=
         let s:ccflag = 0
     endif
+    call SpaceVim#layers#core#statusline#toggle_mode('fill-column-indicator')
 endfunction
 
 let s:fcflag = 0
@@ -124,6 +125,7 @@ function! s:toggle_fill_column() abort
         set cc=
         let s:fcflag = 0
     endif
+    call SpaceVim#layers#core#statusline#toggle_mode('hi-characters-for-long-lines')
 endfunction
 
 let s:idflag = 0

--- a/autoload/SpaceVim/layers/ui.vim
+++ b/autoload/SpaceVim/layers/ui.vim
@@ -10,7 +10,7 @@ function! SpaceVim#layers#ui#plugins() abort
                 \ ]
     if get(g:, '_spacevim_statusline_loaded', 0) == 0
         call add(plugins, ['vim-airline/vim-airline',                { 'merged' : 0, 
-                \ 'loadconf' : 1}])
+                    \ 'loadconf' : 1}])
         call add(plugins, ['vim-airline/vim-airline-themes',         { 'merged' : 0}])
     endif
 
@@ -66,6 +66,9 @@ function! SpaceVim#layers#ui#config() abort
                 \ 'display ~ in the fringe on empty lines', 1)
     call SpaceVim#mapping#space#def('nnoremap', ['t', 's'], 'call call('
                 \ . string(s:_function('s:toggle_syntax_checker')) . ', [])',
+                \ 'toggle syntax checker', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['t', 'S'], 'call call('
+                \ . string(s:_function('s:toggle_spell_check')) . ', [])',
                 \ 'toggle syntax checker', 1)
 endfunction
 " function() wrapper
@@ -185,5 +188,16 @@ function! s:toggle_win_fringe() abort
 endfunction
 
 function! s:toggle_syntax_checker() abort
+    call SpaceVim#layers#core#statusline#toggle_section('syntax checking')
+    call SpaceVim#layers#core#statusline#toggle_mode('syntax-checking')
     let g:_spacevim_toggle_syntax_flag = g:_spacevim_toggle_syntax_flag * -1
+endfunction
+
+function! s:toggle_spell_check() abort
+    if &l:spell
+        let &l:spell = 0
+    else
+        let &l:spell = 1
+    endif
+    call SpaceVim#layers#core#statusline#toggle_mode('spell-checking')
 endfunction

--- a/autoload/SpaceVim/mapping/guide.vim
+++ b/autoload/SpaceVim/mapping/guide.vim
@@ -337,6 +337,7 @@ function! s:handle_input(input) " {{{
     call s:start_buffer()
   else
     let s:prefix_key_inp = ''
+    doautocmd WinEnter
     call feedkeys(s:vis.s:reg.s:count, 'ti')
     redraw!
     try
@@ -352,6 +353,7 @@ function! s:wait_for_input() " {{{
   if inp ==? ''
     let s:prefix_key_inp = ''
     call s:winclose()
+    doautocmd WinEnter
   elseif match(inp, "^<LGCMD>paging_help") == 0
     let s:guide_help_mode = 1
     call s:updateStatusline()

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -9,6 +9,7 @@ function! SpaceVim#mapping#space#init() abort
     let g:_spacevim_mappings_space['?'] = ['Unite menu:CustomKeyMaps -input=[SPC]', 'show mappings']
     let g:_spacevim_mappings_space.t = {'name' : '+Toggles'}
     let g:_spacevim_mappings_space.t.h = {'name' : '+Toggles highlight'}
+    let g:_spacevim_mappings_space.t.m = {'name' : '+modeline'}
     let g:_spacevim_mappings_space.T = {'name' : '+UI toggles/themes'}
     let g:_spacevim_mappings_space.a = {'name' : '+Applications'}
     let g:_spacevim_mappings_space.b = {'name' : '+Buffers'}
@@ -86,7 +87,7 @@ function! SpaceVim#mapping#space#def(m, keys, cmd, desc, is_cmd) abort
 endfunction
 
 function! s:has_map_to_spc() abort
-    return get(g:, 'mapleader', '\') == ' '
+    return get(g:, 'mapleader', '\') ==# ' '
 endfunction
 
 function! s:windows_layout_toggle() abort

--- a/autoload/zvim/util.vim
+++ b/autoload/zvim/util.vim
@@ -188,7 +188,9 @@ endfunction
 function! zvim#util#OpenVimfiler() abort
     if bufnr('vimfiler') == -1
         VimFiler
-        AirlineRefresh
+        if exists(':AirlineRefresh')
+            AirlineRefresh
+        endif
         wincmd p
         if &filetype !=# 'startify'
             IndentLinesToggle
@@ -197,7 +199,9 @@ function! zvim#util#OpenVimfiler() abort
         wincmd p
     else
         VimFiler
-        AirlineRefresh
+        if exists(':AirlineRefresh')
+            AirlineRefresh
+        endif
     endif
 endfunction
 

--- a/autoload/zvim/util.vim
+++ b/autoload/zvim/util.vim
@@ -199,6 +199,7 @@ function! zvim#util#OpenVimfiler() abort
         wincmd p
     else
         VimFiler
+        doautocmd WinEnter
         if exists(':AirlineRefresh')
             AirlineRefresh
         endif

--- a/doc/SpaceVim.txt
+++ b/doc/SpaceVim.txt
@@ -162,6 +162,9 @@ normal mode.To disable this feature:
   let g:spacevim_enable_cursorline = 0
 <
 
+                                             *g:spacevim_statusline_separator*
+Set the statusline separators of statusline, default is 'arrow'
+
                                               *g:spacevim_enable_cursorcolumn*
 Enable/Disable cursorcolumn. Default is 0, cursorcolumn will be highlighted in
 normal mode. To enable this feature:

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -412,6 +412,7 @@ Separator | Screenshot
 `arrow` | ![separator-arrow](https://cloud.githubusercontent.com/assets/13142418/26234639/b28bdc04-3c98-11e7-937e-641c9d85c493.png)
 `curve` | ![separator-curve](https://cloud.githubusercontent.com/assets/13142418/26248272/42bbf6e8-3cd4-11e7-8792-665447040f49.png)
 `slant` | ![separator-slant](https://cloud.githubusercontent.com/assets/13142418/26248515/53a65ea2-3cd5-11e7-8758-d079c5a9c2d6.png)
+`nil` | ![separator-nil](https://cloud.githubusercontent.com/assets/13142418/26249776/645a5a96-3cda-11e7-9655-0aa1f76714f4.png)
 `alternate` | 
 arrow-fade |
 bar |
@@ -424,7 +425,6 @@ rounded |
 roundstub |
 wave |
 zigzag |
-nil |
 
 
 ## Manual

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -367,9 +367,25 @@ Key Binding	| Description
 `SPC t m T` | toggle the mode line itself
 `SPC t m v` | toggle the version control info
 
+**Powerline font installation:**
+
+By defalut SpaceVim use  [DejaVu Sans Mono for Powerline](https://github.com/powerline/fonts/tree/master/DejaVuSansMono), to make statusline render correctly, you need to install the font.
+
+**syntax checking integration:**
+
+When syntax checking minor mode is enabled, a new element appears showing the number of errors, warnings.
+
+syntax checking integration in statusline.
+
+**Search status integration:**
+
+Search status shows the number of occurrence when performing a search via `/`. SpaceVim integrates nicely the search status by displaying it temporarily when n or N are being pressed. See the 5/6 segment on the screenshot below.
+
+_Anzu integration in mode-line_
+
 **Battery status integration:**
 
-__acpi__ displays the percentage of total charge of the battery as well as the time remaining to charge or discharge completely the battery.
+_acpi_ displays the percentage of total charge of the battery as well as the time remaining to charge or discharge completely the battery.
 
 A color code is used for the battery status:
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -413,6 +413,7 @@ Separator | Screenshot
 `curve` | ![separator-curve](https://cloud.githubusercontent.com/assets/13142418/26248272/42bbf6e8-3cd4-11e7-8792-665447040f49.png)
 `slant` | ![separator-slant](https://cloud.githubusercontent.com/assets/13142418/26248515/53a65ea2-3cd5-11e7-8758-d079c5a9c2d6.png)
 `nil` | ![separator-nil](https://cloud.githubusercontent.com/assets/13142418/26249776/645a5a96-3cda-11e7-9655-0aa1f76714f4.png)
+`fire` | ![separator-fire](https://cloud.githubusercontent.com/assets/13142418/26274142/434cdd10-3d75-11e7-811b-e44cebfdca58.png)
 `alternate` | 
 arrow-fade |
 bar |

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -411,6 +411,7 @@ Separator | Screenshot
 --------- | ----------
 `arrow` | ![separator-arrow](https://cloud.githubusercontent.com/assets/13142418/26234639/b28bdc04-3c98-11e7-937e-641c9d85c493.png)
 `curve` | ![separator-curve](https://cloud.githubusercontent.com/assets/13142418/26248272/42bbf6e8-3cd4-11e7-8792-665447040f49.png)
+`slant` | ![separator-slant](https://cloud.githubusercontent.com/assets/13142418/26248515/53a65ea2-3cd5-11e7-8758-d079c5a9c2d6.png)
 `alternate` | 
 arrow-fade |
 bar |
@@ -421,7 +422,6 @@ chamfer |
 contour |
 rounded |
 roundstub |
-slant |
 wave |
 zigzag |
 nil |

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -30,6 +30,7 @@ title:  "Documentation"
     * [Font](#font)
     * [UI Toggles](#ui-toggles)
     * [Statusline && tabline](#statusline--tabline)
+        * [statusline](#statusline)
 * [Manual](#manual)
     * [Completion](#completion)
         * [Unite/Denite](#unitedenite)
@@ -326,9 +327,23 @@ The statusline and tabline is a heavily customized [airline](https://github.com/
 - checker info: numbers of errors and warnings.
 - trailing line number.
 
-    Key Binding | Description
-    ----------- | -----------
-    `SPC [1-9]` | jump to the index of tabline.
+Key Binding | Description
+----------- | -----------
+`SPC [1-9]` | jump to the index of tabline.
+
+#### statusline
+
+The `core#statusline` layer provide a heavily customized powerline with the following capabilities:, It is inspired by spacemacs's mode-line.
+
+
+- show the window number
+- color code for current state
+- show the number of search occurrences via anzu
+- toggle flycheck info
+- toggle battery info
+- toggle minor mode lighters
+
+Reminder of the color codes for the states:
 
 
 ## Manual

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -410,8 +410,8 @@ here is an exhaustive set of screenshots for all the available separator:
 Separator | Screenshot
 --------- | ----------
 `arrow` | ![separator-arrow](https://cloud.githubusercontent.com/assets/13142418/26234639/b28bdc04-3c98-11e7-937e-641c9d85c493.png)
+`curve` | ![separator-curve](https://cloud.githubusercontent.com/assets/13142418/26248272/42bbf6e8-3cd4-11e7-8792-665447040f49.png)
 `alternate` | 
-arrow |
 arrow-fade |
 bar |
 box |
@@ -419,7 +419,6 @@ brace |
 butt |
 chamfer |
 contour |
-curve |
 rounded |
 roundstub |
 slant |

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -369,7 +369,7 @@ Key Binding	| Description
 
 **Powerline font installation:**
 
-By defalut SpaceVim use  [DejaVu Sans Mono for Powerline](https://github.com/powerline/fonts/tree/master/DejaVuSansMono), to make statusline render correctly, you need to install the font.
+By defalut SpaceVim use  [DejaVu Sans Mono for Powerline](https://github.com/powerline/fonts/tree/master/DejaVuSansMono), to make statusline render correctly, you need to install the font. [powerline extra symbols](https://github.com/ryanoasis/powerline-extra-symbols) also should be installed.
 
 **syntax checking integration:**
 
@@ -409,7 +409,23 @@ here is an exhaustive set of screenshots for all the available separator:
 
 Separator | Screenshot
 --------- | ----------
-`arrow` (default) | ![separator-arrow](https://cloud.githubusercontent.com/assets/13142418/26234639/b28bdc04-3c98-11e7-937e-641c9d85c493.png)
+`arrow` | ![separator-arrow](https://cloud.githubusercontent.com/assets/13142418/26234639/b28bdc04-3c98-11e7-937e-641c9d85c493.png)
+`alternate` | 
+arrow |
+arrow-fade |
+bar |
+box |
+brace |
+butt |
+chamfer |
+contour |
+curve |
+rounded |
+roundstub |
+slant |
+wave |
+zigzag |
+nil |
 
 
 ## Manual

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -338,13 +338,46 @@ The `core#statusline` layer provide a heavily customized powerline with the foll
 
 - show the window number
 - color code for current state
-- show the number of search occurrences via anzu
-- toggle flycheck info
+- show the number of search results
+- toggle syntax checking info
 - toggle battery info
 - toggle minor mode lighters
 
 Reminder of the color codes for the states:
 
+Mode | Color
+--- |  ---
+Normal | Orange
+Insert | Green
+Visual | Grey
+
+all the colors based on the current colorscheme
+
+Some elements can be dynamically toggled:
+
+Key Binding	| Description
+----------- | -----------
+`SPC t m b` | toggle the battery status (need to install acpi)
+`SPC t m c` | toggle the org task clock (available in org layer)
+`SPC t m m` | toggle the minor mode lighters
+`SPC t m M` | toggle the major mode
+`SPC t m n` | toggle the cat! (if colors layer is declared in your dotfile)
+`SPC t m p` | toggle the point character position
+`SPC t m t` | toggle the time
+`SPC t m T` | toggle the mode line itself
+`SPC t m v` | toggle the version control info
+
+**Battery status integration:**
+
+__acpi__ displays the percentage of total charge of the battery as well as the time remaining to charge or discharge completely the battery.
+
+A color code is used for the battery status:
+
+Battery State | Color
+------------ | ----
+Charging | Green
+Discharging | Orange
+Critical | Red
 
 ## Manual
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -395,6 +395,23 @@ Charging | Green
 Discharging | Orange
 Critical | Red
 
+all the colors based on the current colorscheme
+
+**Statusline separators:**
+
+It is possible to easily customize the statusline separator by setting the `g:spacevim_statusline_separator` variable in your custon configration file and then redraw the statusline. For instance if you want to set back the separator to the well-known arrow separator add the following snippet to your configuration file:
+
+```vim
+let g:spacevim_statusline_separator = 'arrow'
+```
+
+here is an exhaustive set of screenshots for all the available separator:
+
+Separator | Screenshot
+--------- | ----------
+`arrow` (default) | ![separator-arrow](https://cloud.githubusercontent.com/assets/13142418/26234639/b28bdc04-3c98-11e7-937e-641c9d85c493.png)
+
+
 ## Manual
 
 ### Completion


### PR DESCRIPTION
#### statusline

The `core#statusline` layer provide a heavily customized powerline with the following capabilities:, It is inspired by spacemacs's mode-line.

![2017-05-20_1365x59](https://cloud.githubusercontent.com/assets/13142418/26275180/872c3e78-3d8d-11e7-88ad-702ba4e41f80.png)

- show the window number
- color code for current state
- show the number of search results
- toggle syntax checking info
- toggle battery info
- toggle minor mode lighters

Reminder of the color codes for the states:

Mode | Color
--- |  ---
Normal | Orange
Insert | Green
Visual | Grey

all the colors based on the current colorscheme

Some elements can be dynamically toggled:

Key Binding	| Description
----------- | -----------
`SPC t m b` | toggle the battery status (need to install acpi)
`SPC t m c` | toggle the org task clock (available in org layer)
`SPC t m m` | toggle the minor mode lighters
`SPC t m M` | toggle the major mode
`SPC t m n` | toggle the cat! (if colors layer is declared in your dotfile)
`SPC t m p` | toggle the point character position
`SPC t m t` | toggle the time
`SPC t m T` | toggle the mode line itself
`SPC t m v` | toggle the version control info

**Powerline font installation:**

By defalut SpaceVim use  [DejaVu Sans Mono for Powerline](https://github.com/powerline/fonts/tree/master/DejaVuSansMono), to make statusline render correctly, you need to install the font. [powerline extra symbols](https://github.com/ryanoasis/powerline-extra-symbols) also should be installed.

**syntax checking integration:**

When syntax checking minor mode is enabled, a new element appears showing the number of errors, warnings.

syntax checking integration in statusline.

**Search status integration:**

Search status shows the number of occurrence when performing a search via `/`. SpaceVim integrates nicely the search status by displaying it temporarily when n or N are being pressed. See the 5/6 segment on the screenshot below.

_Anzu integration in mode-line_

**Battery status integration:**

_acpi_ displays the percentage of total charge of the battery as well as the time remaining to charge or discharge completely the battery.

A color code is used for the battery status:

Battery State | Color
------------ | ----
Charging | Green
Discharging | Orange
Critical | Red

all the colors based on the current colorscheme

**Statusline separators:**

It is possible to easily customize the statusline separator by setting the `g:spacevim_statusline_separator` variable in your custon configration file and then redraw the statusline. For instance if you want to set back the separator to the well-known arrow separator add the following snippet to your configuration file:

```vim
let g:spacevim_statusline_separator = 'arrow'
```

here is an exhaustive set of screenshots for all the available separator:

Separator | Screenshot
--------- | ----------
`arrow` | ![separator-arrow](https://cloud.githubusercontent.com/assets/13142418/26234639/b28bdc04-3c98-11e7-937e-641c9d85c493.png)
`curve` | ![separator-curve](https://cloud.githubusercontent.com/assets/13142418/26248272/42bbf6e8-3cd4-11e7-8792-665447040f49.png)
`slant` | ![separator-slant](https://cloud.githubusercontent.com/assets/13142418/26248515/53a65ea2-3cd5-11e7-8758-d079c5a9c2d6.png)
`nil` | ![separator-nil](https://cloud.githubusercontent.com/assets/13142418/26249776/645a5a96-3cda-11e7-9655-0aa1f76714f4.png)
`fire` | ![separator-fire](https://cloud.githubusercontent.com/assets/13142418/26274142/434cdd10-3d75-11e7-811b-e44cebfdca58.png)

