### PR TITLE
update themes palettes to work with statusline modes

### DIFF
--- a/autoload/SpaceVim/mapping/guide/theme/molokai.vim
+++ b/autoload/SpaceVim/mapping/guide/theme/molokai.vim
@@ -4,5 +4,8 @@ function! SpaceVim#mapping#guide#theme#molokai#palette() abort
                 \ ['#f8f8f0', '#232526', 16, 253],
                 \ ['#f8f8f0', '#293739', 236, 253],
                 \ ['#465457', 67],
+                \ ['#282828', '#8787af', 235, 103],
+                \ ['#282828', '#ffd700', 235, 220],
+                \ ['#282828', '#ff5f5f', 235, 203],
                 \ ]
 endfunction

--- a/autoload/SpaceVim/mapping/guide/theme/one.vim
+++ b/autoload/SpaceVim/mapping/guide/theme/one.vim
@@ -3,6 +3,9 @@ function! SpaceVim#mapping#guide#theme#one#palette() abort
                 \ ['#2c323c', '#98c379', 114, 16],
                 \ ['#abb2bf', '#3b4048', 16, 145],
                 \ ['#abb2bf', '#2c323c', 16, 145],
-                \ ['#2c323c', 16]
+                \ ['#2c323c', 16],
+                \ ['#2c323c', '#afd7d7', 114, 152],
+                \ ['#2c323c', '#ff8787', 114, 210],
+                \ ['#2c323c', '#d75f5f', 114, 167],
                 \ ]
 endfunction

--- a/autoload/SpaceVim/mapping/guide/theme/onedark.vim
+++ b/autoload/SpaceVim/mapping/guide/theme/onedark.vim
@@ -5,5 +5,8 @@ function! SpaceVim#mapping#guide#theme#onedark#palette() abort
                 \ ['#ABB2BF', '#3E4452', 236, 144],
                 \ ['#ABB2BF', '#3B4048', 238, 144],
                 \ ['#5C6370', 59],
+                \ ['#282c34', '#00af87', 235, 36],
+                \ ['#282c34', '#ff8700', 235, 208],
+                \ ['#282c34', '#af5f5f', 235, 131],
                 \ ]
 endfunction


### PR DESCRIPTION
@wsdjeg looking at https://github.com/SpaceVim/SpaceVim/blob/07026408b241079e36335af582c21a00cd1955d0/autoload/SpaceVim/layers/core/statusline.vim#L355-L368 and https://github.com/SpaceVim/SpaceVim/blob/07026408b241079e36335af582c21a00cd1955d0/autoload/SpaceVim/layers/core/statusline.vim#L281-L290, spacevim is broken right now.. I see that gruvbox theme was updated to include new implementation but other theme#palette were not. I've updated those as well so that we don't get error because of this.