### PR TITLE
Add the separator option of statusline in doc

### DIFF
--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -135,6 +135,17 @@ let g:spacevim_enable_neocomplcache    = 0
 let g:spacevim_enable_cursorline       = 1
 ""
 " Set the statusline separators of statusline, default is 'arrow'
+" >
+"   Separatos options:
+"     1. arrow
+"     2. curve
+"     3. slant
+"     4. nil
+"     5. fire
+" <
+"
+" See more details in: http://spacevim.org/documentation/#statusline
+"
 let g:spacevim_statusline_separator = 'arrow'
 ""
 " Enable/Disable cursorcolumn. Default is 0, cursorcolumn will be

--- a/doc/SpaceVim.txt
+++ b/doc/SpaceVim.txt
@@ -167,6 +167,17 @@ normal mode.To disable this feature:
 
                                              *g:spacevim_statusline_separator*
 Set the statusline separators of statusline, default is 'arrow'
+>
+  Separatos options:
+    1. arrow
+    2. curve
+    3. slant
+    4. nil
+    5. fire
+<
+
+See more details in: http://spacevim.org/documentation/#statusline
+
 
                                               *g:spacevim_enable_cursorcolumn*
 Enable/Disable cursorcolumn. Default is 0, cursorcolumn will be highlighted in


### PR DESCRIPTION
## Status
**Complete**

## Details
Options of separators only exists in docs instead of doc.
So, I added it.