### PR TITLE
Enable z prefix mapping guide

### DIFF
--- a/.SpaceVim.d/autoload/SpaceVim/dev/z.vim
+++ b/.SpaceVim.d/autoload/SpaceVim/dev/z.vim
@@ -1,0 +1,13 @@
+function! SpaceVim#dev#z#updatedoc()
+ let keys = keys(g:_spacevim_mappings_z)
+ let lines = []
+ for key in keys
+     if key == '`'
+         let line = '`` z' . key . ' `` | ' . g:_spacevim_mappings_z[key][1]
+     else
+         let line = '`z' . key . '` | ' . g:_spacevim_mappings_z[key][1]
+     endif
+     call add(lines, line)
+ endfor
+ call append(line('.'), lines)
+endfunction

--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -472,6 +472,7 @@ function! SpaceVim#end() abort
   call SpaceVim#mapping#leader#defindKEYs()
   call SpaceVim#mapping#space#init()
   call SpaceVim#mapping#g#init()
+  call SpaceVim#mapping#z#init()
   if !SpaceVim#mapping#guide#has_configuration()
     let g:leaderGuide_map = {}
     call SpaceVim#mapping#guide#register_prefix_descriptions('', 'g:leaderGuide_map')

--- a/autoload/SpaceVim/layers/incsearch.vim
+++ b/autoload/SpaceVim/layers/incsearch.vim
@@ -52,10 +52,6 @@ function! SpaceVim#layers#incsearch#config() abort
                     \   ],
                     \ }), get(a:, 1, {}))
     endfunction
-
-    noremap <silent><expr> z/ incsearch#go(<SID>config_fuzzyall())
-    noremap <silent><expr> z? incsearch#go(<SID>config_fuzzyall({'command': '?'}))
-    noremap <silent><expr> zg? incsearch#go(<SID>config_fuzzyall({'is_stay': 1}))
     function! s:config_easyfuzzymotion(...) abort
         return extend(copy({
                     \   'converters': [incsearch#config#fuzzy#converter()],
@@ -65,9 +61,6 @@ function! SpaceVim#layers#incsearch#config() abort
                     \   'is_stay': 1
                     \ }), get(a:, 1, {}))
     endfunction
-
-    noremap <silent><expr> <Space>/ incsearch#go(<SID>config_easyfuzzymotion())
-    call SpaceVim#mapping#space#def('nnoremap', ['/',], 'call feedkeys("\<Space>/", "m")', 'incsearch-fuzzy', 1)
 endfunction
 
 

--- a/autoload/SpaceVim/mapping/guide.vim
+++ b/autoload/SpaceVim/mapping/guide.vim
@@ -572,10 +572,12 @@ call SpaceVim#mapping#guide#register_prefix_descriptions(
 call SpaceVim#mapping#guide#register_prefix_descriptions(
       \ '[KEYs]',
       \ 'g:_spacevim_mappings_prefixs')
-
 call SpaceVim#mapping#guide#register_prefix_descriptions(
       \ 'g',
       \ 'g:_spacevim_mappings_g')
+call SpaceVim#mapping#guide#register_prefix_descriptions(
+      \ 'z',
+      \ 'g:_spacevim_mappings_z')
 let &cpo = s:save_cpo
 unlet s:save_cpo
 

--- a/autoload/SpaceVim/mapping/leader.vim
+++ b/autoload/SpaceVim/mapping/leader.vim
@@ -293,6 +293,8 @@ function! SpaceVim#mapping#leader#getName(key) abort
     return '[SPC]'
   elseif a:key == 'g'
     return '[g]'
+  elseif a:key == 'z'
+    return '[z]'
   else
     return '<leader>'
   endif

--- a/autoload/SpaceVim/mapping/z.vim
+++ b/autoload/SpaceVim/mapping/z.vim
@@ -2,4 +2,16 @@ function! SpaceVim#mapping#z#init() abort
     nnoremap <silent><nowait> [z] :<c-u>LeaderGuide "z"<CR>
     nmap z [z]
     let g:_spacevim_mappings_z = {}
+    let g:_spacevim_mappings_z['A'] = ['call feedkeys("zA", "n")', 'toggle folds recursively']
+    nnoremap zA zA
+    let g:_spacevim_mappings_z['C'] = ['call feedkeys("zC", "n")', 'close folds recursively']
+    nnoremap zC zC
+    let g:_spacevim_mappings_z['D'] = ['call feedkeys("zD", "n")', 'delete folds recursively']
+    nnoremap zD zD
+    let g:_spacevim_mappings_z['E'] = ['call feedkeys("zE", "n")', 'eliminate all folds']
+    nnoremap zE zE
+    let g:_spacevim_mappings_z['F'] = ['call feedkeys("zF", "n")', 'create a fold for N lines']
+    nnoremap zF zF
+    let g:_spacevim_mappings_z['G'] = ['call feedkeys("zG", "n")', 'mark good spelled']
+    nnoremap zG zG
 endfunction

--- a/autoload/SpaceVim/mapping/z.vim
+++ b/autoload/SpaceVim/mapping/z.vim
@@ -1,4 +1,4 @@
-function! SpaceVim#mapping#z#init() abort
+function! SpaceVim#mapping#z#init() abort "{{{
     nnoremap <silent><nowait> [z] :<c-u>LeaderGuide "z"<CR>
     nmap z [z]
     let g:_spacevim_mappings_z = {}
@@ -12,7 +12,7 @@ function! SpaceVim#mapping#z#init() abort
     nnoremap zE zE
     let g:_spacevim_mappings_z['F'] = ['call feedkeys("zF", "n")', 'create a fold for N lines']
     nnoremap zF zF
-    let g:_spacevim_mappings_z['G'] = ['call feedkeys("zG", "n")', 'mark good spelled']
+    let g:_spacevim_mappings_z['G'] = ['call feedkeys("zG", "n")', 'mark good spelled(update internal-wordlist)']
     nnoremap zG zG
     let g:_spacevim_mappings_z['M'] = ['call feedkeys("zM", "n")', 'set `foldlevel` to zero']
     nnoremap zM zM
@@ -26,4 +26,32 @@ function! SpaceVim#mapping#z#init() abort
     nnoremap zW zW
     let g:_spacevim_mappings_z['X'] = ['call feedkeys("zX", "n")', 're-apply `foldleve`']
     nnoremap zX zX
-endfunction
+    let g:_spacevim_mappings_z['a'] = ['call feedkeys("za", "n")', 'toggle a fold']
+    nnoremap za za
+    let g:_spacevim_mappings_z['b'] = ['call feedkeys("zb", "n")', 'redraw, cursor line at bottom']
+    nnoremap zb zb
+    let g:_spacevim_mappings_z['c'] = ['call feedkeys("zc", "n")', 'close a fold']
+    nnoremap zc zc
+    let g:_spacevim_mappings_z['d'] = ['call feedkeys("zd", "n")', 'delete a fold']
+    nnoremap zd zd
+    let g:_spacevim_mappings_z['g'] = ['call feedkeys("zg", "n")', 'mark good spelled']
+    nnoremap zg zg
+    let g:_spacevim_mappings_z['i'] = ['call feedkeys("zi", "n")', 'toggle foldenable']
+    nnoremap zi zi
+    let g:_spacevim_mappings_z['j'] = ['call feedkeys("zj", "n")', 'mode to start of next fold']
+    nnoremap zj zj
+    let g:_spacevim_mappings_z['k'] = ['call feedkeys("zk", "n")', 'mode to end of previous fold']
+    nnoremap zk zk
+    let g:_spacevim_mappings_z['m'] = ['call feedkeys("zm", "n")', 'subtract one from `foldlevel`']
+    nnoremap zm zm
+    let g:_spacevim_mappings_z['n'] = ['call feedkeys("zn", "n")', 'reset `foldenable`']
+    nnoremap zn zn
+    let g:_spacevim_mappings_z['o'] = ['call feedkeys("zo", "n")', 'open fold']
+    nnoremap zo zo
+    let g:_spacevim_mappings_z['r'] = ['call feedkeys("zr", "n")', 'add one to `foldlevel`']
+    nnoremap zr zr
+    " smart scroll
+    let g:_spacevim_mappings_z['z'] = ['call feedkeys("zz", "n")', 'smart scroll']
+    nnoremap zz zz
+
+endfunction "}}}

--- a/autoload/SpaceVim/mapping/z.vim
+++ b/autoload/SpaceVim/mapping/z.vim
@@ -14,4 +14,16 @@ function! SpaceVim#mapping#z#init() abort
     nnoremap zF zF
     let g:_spacevim_mappings_z['G'] = ['call feedkeys("zG", "n")', 'mark good spelled']
     nnoremap zG zG
+    let g:_spacevim_mappings_z['M'] = ['call feedkeys("zM", "n")', 'set `foldlevel` to zero']
+    nnoremap zM zM
+    let g:_spacevim_mappings_z['N'] = ['call feedkeys("zN", "n")', 'set `foldenable`']
+    nnoremap zN zN
+    let g:_spacevim_mappings_z['O'] = ['call feedkeys("zO", "n")', 'open folds recursively']
+    nnoremap zO zO
+    let g:_spacevim_mappings_z['R'] = ['call feedkeys("zR", "n")', 'set `foldlevel` to deepest fold']
+    nnoremap zR zR
+    let g:_spacevim_mappings_z['W'] = ['call feedkeys("zW", "n")', 'mark wrong spelled']
+    nnoremap zW zW
+    let g:_spacevim_mappings_z['X'] = ['call feedkeys("zX", "n")', 're-apply `foldleve`']
+    nnoremap zX zX
 endfunction

--- a/autoload/SpaceVim/mapping/z.vim
+++ b/autoload/SpaceVim/mapping/z.vim
@@ -2,6 +2,18 @@ function! SpaceVim#mapping#z#init() abort "{{{
     nnoremap <silent><nowait> [z] :<c-u>LeaderGuide "z"<CR>
     nmap z [z]
     let g:_spacevim_mappings_z = {}
+    let g:_spacevim_mappings_z['<CR>'] = ['call feedkeys("z\<CR>", "n")', 'cursor line to top']
+    nnoremap z<CR> z<CR>
+    let g:_spacevim_mappings_z['+'] = ['call feedkeys("z+", "n")', 'cursor to screen top line N']
+    nnoremap z+ z+
+    let g:_spacevim_mappings_z['-'] = ['call feedkeys("z-", "n")', 'cursor to screen bottom line N']
+    nnoremap z- z-
+    let g:_spacevim_mappings_z['^'] = ['call feedkeys("z^", "n")', 'cursor to screen bottom line N']
+    nnoremap z^ z^
+    let g:_spacevim_mappings_z['.'] = ['call feedkeys("z.", "n")', 'cursor line to center']
+    nnoremap z. z.
+    let g:_spacevim_mappings_z['='] = ['call feedkeys("z=", "n")', 'spelling suggestions']
+    nnoremap z= z=
     let g:_spacevim_mappings_z['A'] = ['call feedkeys("zA", "n")', 'toggle folds recursively']
     nnoremap zA zA
     let g:_spacevim_mappings_z['C'] = ['call feedkeys("zC", "n")', 'close folds recursively']
@@ -14,6 +26,10 @@ function! SpaceVim#mapping#z#init() abort "{{{
     nnoremap zF zF
     let g:_spacevim_mappings_z['G'] = ['call feedkeys("zG", "n")', 'mark good spelled(update internal-wordlist)']
     nnoremap zG zG
+    let g:_spacevim_mappings_z['H'] = ['call feedkeys("zH", "n")', 'scroll half a screenwidth to the right']
+    nnoremap zH zH
+    let g:_spacevim_mappings_z['L'] = ['call feedkeys("zL", "n")', 'scroll half a screenwidth to the left']
+    nnoremap zL zL
     let g:_spacevim_mappings_z['M'] = ['call feedkeys("zM", "n")', 'set `foldlevel` to zero']
     nnoremap zM zM
     let g:_spacevim_mappings_z['N'] = ['call feedkeys("zN", "n")', 'set `foldenable`']
@@ -34,14 +50,26 @@ function! SpaceVim#mapping#z#init() abort "{{{
     nnoremap zc zc
     let g:_spacevim_mappings_z['d'] = ['call feedkeys("zd", "n")', 'delete a fold']
     nnoremap zd zd
+    let g:_spacevim_mappings_z['e'] = ['call feedkeys("ze", "n")', 'right scroll horizontally to cursor position']
+    nnoremap ze ze
+    let g:_spacevim_mappings_z['f'] = ['call feedkeys("zf", "n")', 'create a fold for motion']
+    nnoremap zf zf
     let g:_spacevim_mappings_z['g'] = ['call feedkeys("zg", "n")', 'mark good spelled']
     nnoremap zg zg
+    let g:_spacevim_mappings_z['h'] = ['call feedkeys("zh", "n")', 'scroll screen N characters to right']
+    nnoremap zh zh
+    let g:_spacevim_mappings_z['<Left>'] = ['call feedkeys("zh", "n")', 'scroll screen N characters to right']
+    nnoremap z<Left> zh
     let g:_spacevim_mappings_z['i'] = ['call feedkeys("zi", "n")', 'toggle foldenable']
     nnoremap zi zi
     let g:_spacevim_mappings_z['j'] = ['call feedkeys("zj", "n")', 'mode to start of next fold']
     nnoremap zj zj
     let g:_spacevim_mappings_z['k'] = ['call feedkeys("zk", "n")', 'mode to end of previous fold']
     nnoremap zk zk
+    let g:_spacevim_mappings_z['l'] = ['call feedkeys("zl", "n")', 'scroll screen N characters to left']
+    nnoremap zl zl
+    let g:_spacevim_mappings_z['<Right>'] = ['call feedkeys("zl", "n")', 'scroll screen N characters to left']
+    nnoremap z<Right> zl
     let g:_spacevim_mappings_z['m'] = ['call feedkeys("zm", "n")', 'subtract one from `foldlevel`']
     nnoremap zm zm
     let g:_spacevim_mappings_z['n'] = ['call feedkeys("zn", "n")', 'reset `foldenable`']
@@ -50,6 +78,14 @@ function! SpaceVim#mapping#z#init() abort "{{{
     nnoremap zo zo
     let g:_spacevim_mappings_z['r'] = ['call feedkeys("zr", "n")', 'add one to `foldlevel`']
     nnoremap zr zr
+    let g:_spacevim_mappings_z.s = ['call feedkeys("zs", "n")', 'left scroll horizontally to cursor position']
+    nnoremap zs zs
+    let g:_spacevim_mappings_z['t'] = ['call feedkeys("zt", "n")', 'cursor line at top of window']
+    nnoremap zt zt
+    let g:_spacevim_mappings_z['v'] = ['call feedkeys("zv", "n")', 'open enough folds to view cursor line']
+    nnoremap zv zv
+    let g:_spacevim_mappings_z['x'] = ['call feedkeys("zx", "n")', 're-apply foldlevel and do "zV"']
+    nnoremap zx zx
     " smart scroll
     let g:_spacevim_mappings_z['z'] = ['call feedkeys("zz", "n")', 'smart scroll']
     nnoremap zz zz

--- a/autoload/SpaceVim/mapping/z.vim
+++ b/autoload/SpaceVim/mapping/z.vim
@@ -1,0 +1,5 @@
+function! SpaceVim#mapping#z#init() abort
+    nnoremap <silent><nowait> [z] :<c-u>LeaderGuide "z"<CR>
+    nmap z [z]
+    let g:_spacevim_mappings_z = {}
+endfunction

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -65,6 +65,7 @@ title:  "Documentation"
             * [File tree navigation](#file-tree-navigation)
             * [Open file with file tree.](#open-file-with-file-tree)
     * [Commands starting with `g`](#commands-starting-with-g)
+    * [Commands starting with `z`](#commands-starting-with-z)
     * [Auto-saving](#auto-saving)
     * [Searching](#searching)
         * [With an external tool](#with-an-external-tool)
@@ -917,6 +918,13 @@ Key Binding | Description
 `g<End>` | go to rightmost character
 `g<C-G>` | show cursor info
 
+### Commands starting with `z`
+
+after pressing prefix `z` in normal mode, if you do not remember the mappings, you will see the guide which will tell you the functional of all mappings starting with `z`.
+
+Key Binding | Description
+-----------| -----------
+`z<Cr>` | redraw, cursor line to top
 
 ### Auto-saving
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -924,12 +924,49 @@ after pressing prefix `z` in normal mode, if you do not remember the mappings, y
 
 Key Binding | Description
 -----------| -----------
+`z<Right>` | scroll screen N characters to left
+`z+` | cursor to screen top line N
+`z-` | cursor to screen bottom line N
+`z.` | cursor line to center
+`z<CR>` | cursor line to top
+`z=` | spelling suggestions
 `zA` | toggle folds recursively
 `zC` | close folds recursively
 `zD` | delete folds recursively
 `zE` | eliminate all folds
 `zF` | create a fold for N lines
-`zG` | mark good spelled
+`zG` | mark good spelled(update internal-wordlist)
+`zH` | scroll half a screenwidth to the right
+`zL` | scroll half a screenwidth to the left
+`zM` | set `foldlevel` to zero
+`zN` | set `foldenable`
+`zO` | open folds recursively
+`zR` | set `foldlevel` to deepest fold
+`zW` | mark wrong spelled
+`zX` | re-apply `foldleve`
+`z^` | cursor to screen bottom line N
+`za` | toggle a fold
+`zb` | redraw, cursor line at bottom
+`zc` | close a fold
+`zd` | delete a fold
+`ze` | right scroll horizontally to cursor position
+`zf` | create a fold for motion
+`zg` | mark good spelled
+`zh` | scroll screen N characters to right
+`zi` | toggle foldenable
+`zj` | mode to start of next fold
+`zk` | mode to end of previous fold
+`zl` | scroll screen N characters to left
+`zm` | subtract one from `foldlevel`
+`zn` | reset `foldenable`
+`zo` | open fold
+`zr` | add one to `foldlevel`
+`zs` | left scroll horizontally to cursor position
+`zt` | cursor line at top of window
+`zv` | open enough folds to view cursor line
+`zx` | re-apply foldlevel and do "zV"
+`zz` | smart scroll
+`z<Left>` | scroll screen N characters to right
 
 ### Auto-saving
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -924,7 +924,12 @@ after pressing prefix `z` in normal mode, if you do not remember the mappings, y
 
 Key Binding | Description
 -----------| -----------
-`z<Cr>` | redraw, cursor line to top
+`zA` | toggle folds recursively
+`zC` | close folds recursively
+`zD` | delete folds recursively
+`zE` | eliminate all folds
+`zF` | create a fold for N lines
+`zG` | mark good spelled
 
 ### Auto-saving
 


### PR DESCRIPTION
### Commands starting with `z`

after pressing prefix `z` in normal mode, if you do not remember the mappings, you will see the guide which will tell you the functional of all mappings starting with `z`.

Key Binding | Description
-----------| -----------
`z<Right>` | scroll screen N characters to left
`z+` | cursor to screen top line N
`z-` | cursor to screen bottom line N
`z.` | cursor line to center
`z<CR>` | cursor line to top
`z=` | spelling suggestions
`zA` | toggle folds recursively
`zC` | close folds recursively
`zD` | delete folds recursively
`zE` | eliminate all folds
`zF` | create a fold for N lines
`zG` | mark good spelled(update internal-wordlist)
`zH` | scroll half a screenwidth to the right
`zL` | scroll half a screenwidth to the left
`zM` | set `foldlevel` to zero
`zN` | set `foldenable`
`zO` | open folds recursively
`zR` | set `foldlevel` to deepest fold
`zW` | mark wrong spelled
`zX` | re-apply `foldleve`
`z^` | cursor to screen bottom line N
`za` | toggle a fold
`zb` | redraw, cursor line at bottom
`zc` | close a fold
`zd` | delete a fold
`ze` | right scroll horizontally to cursor position
`zf` | create a fold for motion
`zg` | mark good spelled
`zh` | scroll screen N characters to right
`zi` | toggle foldenable
`zj` | mode to start of next fold
`zk` | mode to end of previous fold
`zl` | scroll screen N characters to left
`zm` | subtract one from `foldlevel`
`zn` | reset `foldenable`
`zo` | open fold
`zr` | add one to `foldlevel`
`zs` | left scroll horizontally to cursor position
`zt` | cursor line at top of window
`zv` | open enough folds to view cursor line
`zx` | re-apply foldlevel and do "zV"
`zz` | smart scroll
`z<Left>` | scroll screen N characters to right
