### PR TITLE
Fix search_index after :noh

### DIFF
--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -78,11 +78,11 @@ endfunction
 function! s:search_status() abort
     let ct = 0
     let tt = 0
-    let ctl = split(s:VIMCOMP.execute('.,$s/' . @/ . '//gn', 'silent!'), "\n")
+    let ctl = split(s:VIMCOMP.execute('keeppatterns .,$s/' . @/ . '//gn', 'silent!'), "\n")
     if !empty(ctl)
         let ct = split(ctl[0])[0]
     endif
-    let ttl = split(s:VIMCOMP.execute('%s/' . @/ . '//gn', 'silent!'), "\n")
+    let ttl = split(s:VIMCOMP.execute('keeppatterns %s/' . @/ . '//gn', 'silent!'), "\n")
     if !empty(ctl)
         let tt = split(ttl[0])[0]
     endif


### PR DESCRIPTION
when use :noh after set hlsearch, if open mapping guide, the partten will be highlight again.

Thanks:
markzen: keeppa %s,pattern,,gn Patch 7.4.083