### PR TITLE
Add text insertion commands

### DIFF
--- a/autoload/SpaceVim/api/data/list.vim
+++ b/autoload/SpaceVim/api/data/list.vim
@@ -8,13 +8,41 @@ function! SpaceVim#api#data#list#get() abort
                 \ 'char_range' : '',
                 \ 'has' : '',
                 \ 'has_index' : '',
+                \ 'listpart' : '',
                 \ },
                 \ "function('s:' . v:key)"
                 \ )
 endfunction
 
+""
+" @section data#list, api-data-list
+" @parentsection api
+" pop({list})
+"
+" Removes the last element from {list} and returns the element,
+" as if the {list} is a stack.
+"
+" push({list})
+"
+" Appends {val} to the end of {list} and returns the list itself,
+" as if the {list} is a stack.
+"
+" listpart({list}, {start}[, {len}])
+" 
+" The result is a List, which is part of {list}, starting from
+" index {start}, with the length {len}
+
 function! s:pop(list) abort
     return remove(a:list, -1)
+endfunction
+
+function! s:listpart(list, start, ...)
+  let idx = range(a:start, a:start + get(a:000, 0, 0))
+  let rst = []
+  for i in idx
+    call add(rst, get(a:list, i))
+  endfor
+  return rst
 endfunction
 
 function! s:push(list, val) abort

--- a/autoload/SpaceVim/api/data/string.vim
+++ b/autoload/SpaceVim/api/data/string.vim
@@ -63,6 +63,15 @@ endfunction
 
 let s:file['trim_end'] = function('s:trim_end')
 
+function! s:string2chars(str) abort
+  let chars = []
+  for i in range(len(a:str))
+    call add(chars, a:str[i:i])
+  endfor
+  return chars
+endfunction
+let s:file['string2chars'] = function('s:string2chars')
+
 function! SpaceVim#api#data#string#get() abort
   return deepcopy(s:file)
 endfunction

--- a/autoload/SpaceVim/api/data/string.vim
+++ b/autoload/SpaceVim/api/data/string.vim
@@ -66,7 +66,7 @@ let s:file['trim_end'] = function('s:trim_end')
 function! s:string2chars(str) abort
   let chars = []
   for i in range(len(a:str))
-    call add(chars, a:str[i:i])
+    call add(chars, a:str[i : i])
   endfor
   return chars
 endfunction

--- a/autoload/SpaceVim/api/password.vim
+++ b/autoload/SpaceVim/api/password.vim
@@ -7,9 +7,11 @@ function! s:self.generate_simple(len) abort
     let temp = s:STRING.string2chars('abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ')
     let ps = []
     " random(0,len_temp)
-    for i in range(str2nr(a:len))
+    let i = 0
+    while i < str2nr(a:len)
         call add(ps, temp[s:NUMBER.random(0, len(temp))])
-    endfor
+        let i += 1
+    endwhile
     return join(ps, '')
 endfunction
 
@@ -17,9 +19,11 @@ function! s:self.generate_strong(len) abort
     let temp = s:STRING.string2chars('abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ_@!.^%,&-')
     let ps = []
     " random(0,len_temp)
-    for i in range(str2nr(a:len))
+    let i = 0
+    while i < str2nr(a:len)
         call add(ps, temp[s:NUMBER.random(0, len(temp))])
-    endfor
+        let i += 1
+    endwhile
     return join(ps, '')
 endfunction
 
@@ -27,9 +31,11 @@ function! s:self.generate_paranoid(len) abort
     let temp = s:STRING.string2chars('abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()_-+=/?,.><[]{}~')
     let ps = []
     " random(0,len_temp)
-    for i in range(str2nr(a:len))
+    let i = 0
+    while i < str2nr(a:len)
         call add(ps, temp[s:NUMBER.random(0, len(temp))])
-    endfor
+        let i += 1
+    endwhile
     return join(ps, '')
 endfunction
 
@@ -37,9 +43,11 @@ function! s:self.generate_numeric(len) abort
     let temp = s:STRING.string2chars('0123456789')
     let ps = []
     " random(0,len_temp)
-    for i in range(str2nr(a:len))
+    let i = 0
+    while i < str2nr(a:len)
         call add(ps, temp[s:NUMBER.random(0, len(temp))])
-    endfor
+        let i += 1
+    endwhile
     return join(ps, '')
 endfunction
 
@@ -51,7 +59,8 @@ function! s:self.generate_phonetic(len) abort
 
     let ps = []
     " random(0,len_temp)
-    for i in range(str2nr(a:len))
+    let i = 0
+    while i < str2nr(a:len)
         if type == 1
             call add(ps, temp_A[s:NUMBER.random(0, len(temp_A))])
             let type = 2
@@ -62,7 +71,8 @@ function! s:self.generate_phonetic(len) abort
             call add(ps, temp_N[s:NUMBER.random(0, len(temp_N))])
             let type = 1
         endif
-    endfor
+        let i += 1
+    endwhile
     return join(ps, '')
 endfunction
 

--- a/autoload/SpaceVim/api/password.vim
+++ b/autoload/SpaceVim/api/password.vim
@@ -1,0 +1,71 @@
+let s:self = {}
+
+let s:NUMBER = SpaceVim#api#import('data#number')
+let s:STRING = SpaceVim#api#import('data#string')
+
+function! s:self.generate_simple(len) abort
+    let temp = s:STRING.string2chars('abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ')
+    let ps = []
+    " random(0,len_temp)
+    for i in range(str2nr(a:len))
+        call add(ps, temp[s:NUMBER.random(0, len(temp))])
+    endfor
+    return join(ps, '')
+endfunction
+
+function! s:self.generate_strong(len) abort
+    let temp = s:STRING.string2chars('abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ_@!.^%,&-')
+    let ps = []
+    " random(0,len_temp)
+    for i in range(str2nr(a:len))
+        call add(ps, temp[s:NUMBER.random(0, len(temp))])
+    endfor
+    return join(ps, '')
+endfunction
+
+function! s:self.generate_paranoid(len) abort
+    let temp = s:STRING.string2chars('abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()_-+=/?,.><[]{}~')
+    let ps = []
+    " random(0,len_temp)
+    for i in range(str2nr(a:len))
+        call add(ps, temp[s:NUMBER.random(0, len(temp))])
+    endfor
+    return join(ps, '')
+endfunction
+
+function! s:self.generate_numeric(len) abort
+    let temp = s:STRING.string2chars('0123456789')
+    let ps = []
+    " random(0,len_temp)
+    for i in range(str2nr(a:len))
+        call add(ps, temp[s:NUMBER.random(0, len(temp))])
+    endfor
+    return join(ps, '')
+endfunction
+
+function! s:self.generate_phonetic(len) abort
+    let temp_A = s:STRING.string2chars('eyuioa')
+    let temp_B = s:STRING.string2chars('wrtpsdfghjkzxcvbnm')
+    let temp_N = s:STRING.string2chars('123456789')
+    let type = 1
+
+    let ps = []
+    " random(0,len_temp)
+    for i in range(str2nr(a:len))
+        if type == 1
+            call add(ps, temp_A[s:NUMBER.random(0, len(temp_A))])
+            let type = 2
+        elseif type == 2
+            call add(ps, temp_B[s:NUMBER.random(0, len(temp_B))])
+            let type = 3
+        elseif type == 3
+            call add(ps, temp_N[s:NUMBER.random(0, len(temp_N))])
+            let type = 1
+        endif
+    endfor
+    return join(ps, '')
+endfunction
+
+function! SpaceVim#api#password#get() abort
+    return deepcopy(s:self)
+endfunction

--- a/autoload/SpaceVim/layers/edit.vim
+++ b/autoload/SpaceVim/layers/edit.vim
@@ -41,5 +41,66 @@ function! SpaceVim#layers#edit#config() abort
     let g:_spacevim_mappings_space.i = {'name' : '+Insertion'}
     let g:_spacevim_mappings_space.i.l = {'name' : '+Lorem-ipsum'}
     let g:_spacevim_mappings_space.i.p = {'name' : '+Passwords'}
-    call SpaceVim#mapping#space#def('nnoremap', ['i', 'p', 1], '', 'insert simple password', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['i', 'p', 1], 'call call('
+                \ . string(s:_function('s:insert_simple_password')) . ', [])',
+                \ 'insert simple password', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['i', 'p', 2], 'call call('
+                \ . string(s:_function('s:insert_stronger_password')) . ', [])',
+                \ 'insert stronger password', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['i', 'p', 3], 'call call('
+                \ . string(s:_function('s:insert_paranoid_password')) . ', [])',
+                \ 'insert password for paranoids', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['i', 'p', 'p'], 'call call('
+                \ . string(s:_function('s:insert_phonetically_password')) . ', [])',
+                \ 'insert a phonetically easy password', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['i', 'p', 'n'], 'call call('
+                \ . string(s:_function('s:insert_numerical_password')) . ', [])',
+                \ 'insert a numerical password', 1)
 endfunction
+
+let s:PASSWORD = SpaceVim#api#import('password')
+function! s:insert_simple_password() abort
+    let save_register = @k
+    let @k = s:PASSWORD.generate_simple(8)
+    normal! "kPl
+    let @k = save_register
+endfunction
+function! s:insert_stronger_password() abort
+    let save_register = @k
+    let @k = s:PASSWORD.generate_strong(12)
+    normal! "kPl
+    let @k = save_register
+endfunction
+function! s:insert_paranoid_password() abort
+    let save_register = @k
+    let @k = s:PASSWORD.generate_paranoid(20)
+    normal! "kPl
+    let @k = save_register
+endfunction
+function! s:insert_numerical_password() abort
+    let save_register = @k
+    let @k = s:PASSWORD.generate_numeric(4)
+    normal! "kPl
+    let @k = save_register
+endfunction
+function! s:insert_phonetically_password() abort
+    let save_register = @k
+    let @k = s:PASSWORD.generate_phonetic(8)
+    normal! "kPl
+    let @k = save_register
+endfunction
+
+" function() wrapper
+if v:version > 703 || v:version == 703 && has('patch1170')
+    function! s:_function(fstr) abort
+        return function(a:fstr)
+    endfunction
+else
+    function! s:_SID() abort
+        return matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze__SID$')
+    endfunction
+    let s:_s = '<SNR>' . s:_SID() . '_'
+    function! s:_function(fstr) abort
+        return function(substitute(a:fstr, 's:', s:_s, 'g'))
+    endfunction
+endif

--- a/autoload/SpaceVim/layers/edit.vim
+++ b/autoload/SpaceVim/layers/edit.vim
@@ -41,6 +41,7 @@ function! SpaceVim#layers#edit#config() abort
     let g:_spacevim_mappings_space.i = {'name' : '+Insertion'}
     let g:_spacevim_mappings_space.i.l = {'name' : '+Lorem-ipsum'}
     let g:_spacevim_mappings_space.i.p = {'name' : '+Passwords'}
+    let g:_spacevim_mappings_space.i.U = {'name' : '+UUID'}
     call SpaceVim#mapping#space#def('nnoremap', ['i', 'p', 1], 'call call('
                 \ . string(s:_function('s:insert_simple_password')) . ', [])',
                 \ 'insert simple password', 1)
@@ -56,6 +57,10 @@ function! SpaceVim#layers#edit#config() abort
     call SpaceVim#mapping#space#def('nnoremap', ['i', 'p', 'n'], 'call call('
                 \ . string(s:_function('s:insert_numerical_password')) . ', [])',
                 \ 'insert a numerical password', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['i', 'u'], 'Unite unicode', 'search and insert unicode', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['i', 'U', 'U'], 'call call('
+                \ . string(s:_function('s:uuidgen_U')) . ', [])',
+                \ 'uuidgen-4', 1)
 endfunction
 
 let s:PASSWORD = SpaceVim#api#import('password')
@@ -86,6 +91,14 @@ endfunction
 function! s:insert_phonetically_password() abort
     let save_register = @k
     let @k = s:PASSWORD.generate_phonetic(8)
+    normal! "kPl
+    let @k = save_register
+endfunction
+
+function! s:uuidgen_U() abort
+    let uuid = system('uuidgen')
+    let save_register = @k
+    let @k = uuid
     normal! "kPl
     let @k = save_register
 endfunction

--- a/autoload/SpaceVim/layers/edit.vim
+++ b/autoload/SpaceVim/layers/edit.vim
@@ -72,6 +72,9 @@ function! SpaceVim#layers#edit#config() abort
     call SpaceVim#mapping#space#def('nnoremap', ['i', 'l', 'p'], 'call call('
                 \ . string(s:_function('s:insert_lorem_ipsum_paragraph')) . ', [])',
                 \ 'insert lorem-ipsum paragraph', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['i', 'l', 's'], 'call call('
+                \ . string(s:_function('s:insert_lorem_ipsum_sentence')) . ', [])',
+                \ 'insert lorem-ipsum sentence', 1)
 endfunction
 let s:local_lorem_ipsum = [
             \ 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit.',
@@ -154,8 +157,14 @@ function! s:insert_lorem_ipsum_paragraph() abort
     normal! "kgP
     let @k = save_register
 endfunction
-"
-"
+
+function! s:insert_lorem_ipsum_sentence() abort
+    let save_register = @k
+    let @k =  s:local_lorem_ipsum[s:NUMBER.random(0, len(s:local_lorem_ipsum))] . s:lorem_ipsum_sentence_separator
+    normal! "kgP
+    let @k = save_register
+endfunction
+
 function! s:insert_simple_password() abort
     let save_register = @k
     let @k = s:PASSWORD.generate_simple(8)

--- a/autoload/SpaceVim/layers/edit.vim
+++ b/autoload/SpaceVim/layers/edit.vim
@@ -1,5 +1,6 @@
 let s:PASSWORD = SpaceVim#api#import('password')
 let s:NUMBER = SpaceVim#api#import('data#number')
+let s:LIST = SpaceVim#api#import('data#list')
 
 
 function! SpaceVim#layers#edit#plugins() abort
@@ -68,6 +69,9 @@ function! SpaceVim#layers#edit#config() abort
     call SpaceVim#mapping#space#def('nnoremap', ['i', 'l', 'l'], 'call call('
                 \ . string(s:_function('s:insert_lorem_ipsum_list')) . ', [])',
                 \ 'insert lorem-ipsum list', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['i', 'l', 'p'], 'call call('
+                \ . string(s:_function('s:insert_lorem_ipsum_paragraph')) . ', [])',
+                \ 'insert lorem-ipsum paragraph', 1)
 endfunction
 let s:local_lorem_ipsum = [
             \ 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit.',
@@ -81,68 +85,77 @@ let s:local_lorem_ipsum = [
             \ 'Cras placerat accumsan nulla.',
             \ 'Nullam rutrum.',
             \ 'Nam vestibulum accumsan nisl.',
+            \ 'Pellentesque dapibus suscipit ligula.',
+            \ 'Donec posuere augue in quam.',
+            \ 'Etiam vel tortor sodales tellus ultricies commodo.',
+            \ 'Suspendisse potenti.',
+            \ 'Aenean in sem ac leo mollis blandit.',
+            \ 'Donec neque quam, dignissim in, mollis nec, sagittis eu, wisi.',
+            \ 'Phasellus lacus.',
+            \ 'Etiam laoreet quam sed arcu.',
+            \ 'Phasellus at dui in ligula mollis ultricies.',
+            \ 'Integer placerat tristique nisl.',
+            \ 'Praesent augue.',
+            \ 'Fusce commodo.',
+            \ 'Vestibulum convallis, lorem a tempus semper, dui dui euismod elit, vitae placerat urna tortor vitae lacus.',
+            \ 'Nullam libero mauris, consequat quis, varius et, dictum id, arcu.',
+            \ 'Mauris mollis tincidunt felis.',
+            \ 'Aliquam feugiat tellus ut neque.',
+            \ 'Nulla facilisis, risus a rhoncus fermentum, tellus tellus lacinia purus, et dictum nunc justo sit amet elit.',
+            \ 'Aliquam erat volutpat.',
+            \ 'Nunc eleifend leo vitae magna.',
+            \ 'In id erat non orci commodo lobortis.',
+            \ 'Proin neque massa, cursus ut, gravida ut, lobortis eget, lacus.',
+            \ 'Sed diam.',
+            \ 'Praesent fermentum tempor tellus.',
+            \ 'Nullam tempus.',
+            \ 'Mauris ac felis vel velit tristique imperdiet.',
+            \ 'Donec at pede.',
+            \ 'Etiam vel neque nec dui dignissim bibendum.',
+            \ 'Vivamus id enim.',
+            \ 'Phasellus neque orci, porta a, aliquet quis, semper a, massa.',
+            \ 'Phasellus purus.',
+            \ 'Pellentesque tristique imperdiet tortor.',
+            \ 'Nam euismod tellus id erat.',
+            \ 'Nullam eu ante vel est convallis dignissim.',
+            \ 'Fusce suscipit, wisi nec facilisis facilisis, est dui fermentum leo, quis tempor ligula erat quis odio.',
+            \ 'Nunc porta vulputate tellus.',
+            \ 'Nunc rutrum turpis sed pede.',
+            \ 'Sed bibendum.',
+            \ 'Aliquam posuere.',
+            \ 'Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis varius mi purus non odio.',
+            \ 'Pellentesque condimentum, magna ut suscipit hendrerit, ipsum augue ornare nulla, non luctus diam neque sit amet urna.',
+            \ 'Curabitur vulputate vestibulum lorem.',
+            \ 'Fusce sagittis, libero non molestie mollis, magna orci ultrices dolor, at vulputate neque nulla lacinia eros.',
+            \ 'Sed id ligula quis est convallis tempor.',
+            \ 'Curabitur lacinia pulvinar nibh.',
+            \ 'Nam a sapien.',
             \ ]
+
+let s:lorem_ipsum_paragraph_separator = "\n\n"
+let s:lorem_ipsum_sentence_separator = '  '
+let s:lorem_ipsum_list_beginning = ''
+let s:lorem_ipsum_list_bullet = '* '
+let s:lorem_ipsum_list_item_end = "\n"
+let s:lorem_ipsum_list_end = ''
+
 function! s:insert_lorem_ipsum_list() abort
     let save_register = @k
     let @k =  '* ' . s:local_lorem_ipsum[s:NUMBER.random(0, len(s:local_lorem_ipsum))] . "\n"
     normal! "kgP
     let @k = save_register
 endfunction
+
+function! s:insert_lorem_ipsum_paragraph() abort
+    let save_register = @k
+    let pids = len(s:local_lorem_ipsum) / 11
+    let pid = s:NUMBER.random(0, pids) * 11
+    let @k = join(s:LIST.listpart(s:local_lorem_ipsum, pid, 11), s:lorem_ipsum_sentence_separator) . s:lorem_ipsum_paragraph_separator
+    normal! "kgP
+    let @k = save_register
+endfunction
 "
-"     ("Pellentesque dapibus suscipit ligula."
-"      "Donec posuere augue in quam."
-"      "Etiam vel tortor sodales tellus ultricies commodo."
-"      "Suspendisse potenti."
-"      "Aenean in sem ac leo mollis blandit."
-"      "Donec neque quam, dignissim in, mollis nec, sagittis eu, wisi."
-"      "Phasellus lacus."
-"      "Etiam laoreet quam sed arcu."
-"      "Phasellus at dui in ligula mollis ultricies."
-"      "Integer placerat tristique nisl."
-"      "Praesent augue."
-"      "Fusce commodo."
-"      "Vestibulum convallis, lorem a tempus semper, dui dui euismod elit, vitae placerat urna tortor vitae lacus."
-"      "Nullam libero mauris, consequat quis, varius et, dictum id, arcu."
-"      "Mauris mollis tincidunt felis."
-"      "Aliquam feugiat tellus ut neque."
-"      "Nulla facilisis, risus a rhoncus fermentum, tellus tellus lacinia purus, et dictum nunc justo sit amet elit.")
 "
-"     ("Aliquam erat volutpat."
-"      "Nunc eleifend leo vitae magna."
-"      "In id erat non orci commodo lobortis."
-"      "Proin neque massa, cursus ut, gravida ut, lobortis eget, lacus."
-"      "Sed diam."
-"      "Praesent fermentum tempor tellus."
-"      "Nullam tempus."
-"      "Mauris ac felis vel velit tristique imperdiet."
-"      "Donec at pede."
-"      "Etiam vel neque nec dui dignissim bibendum."
-"      "Vivamus id enim."
-"      "Phasellus neque orci, porta a, aliquet quis, semper a, massa."
-"      "Phasellus purus."
-"      "Pellentesque tristique imperdiet tortor."
-"      "Nam euismod tellus id erat.")
-"
-"     ("Nullam eu ante vel est convallis dignissim."
-"      "Fusce suscipit, wisi nec facilisis facilisis, est dui fermentum leo, quis tempor ligula erat quis odio."
-"      "Nunc porta vulputate tellus."
-"      "Nunc rutrum turpis sed pede."
-"      "Sed bibendum."
-"      "Aliquam posuere."
-"      "Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis varius mi purus non odio."
-"      "Pellentesque condimentum, magna ut suscipit hendrerit, ipsum augue ornare nulla, non luctus diam neque sit amet urna."
-"      "Curabitur vulputate vestibulum lorem."
-"      "Fusce sagittis, libero non molestie mollis, magna orci ultrices dolor, at vulputate neque nulla lacinia eros."
-"      "Sed id ligula quis est convallis tempor."
-"      "Curabitur lacinia pulvinar nibh."
-"      "Nam a sapien.")))
-"
-" (defvar lorem-ipsum-paragraph-separator "\n\n")
-" (defvar lorem-ipsum-sentence-separator "  ")
-" (defvar lorem-ipsum-list-beginning "")
-" (defvar lorem-ipsum-list-bullet "* ")
-" (defvar lorem-ipsum-list-item-end "\n")
-" (defvar lorem-ipsum-list-end "")
 function! s:insert_simple_password() abort
     let save_register = @k
     let @k = s:PASSWORD.generate_simple(8)

--- a/autoload/SpaceVim/layers/edit.vim
+++ b/autoload/SpaceVim/layers/edit.vim
@@ -1,3 +1,7 @@
+let s:PASSWORD = SpaceVim#api#import('password')
+let s:NUMBER = SpaceVim#api#import('data#number')
+
+
 function! SpaceVim#layers#edit#plugins() abort
     let plugins = [
                 \ ['tpope/vim-surround'],
@@ -61,9 +65,84 @@ function! SpaceVim#layers#edit#config() abort
     call SpaceVim#mapping#space#def('nnoremap', ['i', 'U', 'U'], 'call call('
                 \ . string(s:_function('s:uuidgen_U')) . ', [])',
                 \ 'uuidgen-4', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['i', 'l', 'l'], 'call call('
+                \ . string(s:_function('s:insert_lorem_ipsum_list')) . ', [])',
+                \ 'insert lorem-ipsum list', 1)
 endfunction
-
-let s:PASSWORD = SpaceVim#api#import('password')
+let s:local_lorem_ipsum = [
+            \ 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit.',
+            \ 'Donec hendrerit tempor tellus.',
+            \ 'Donec pretium posuere tellus.',
+            \ 'Proin quam nisl, tincidunt et, mattis eget, convallis nec, purus.',
+            \ 'Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.',
+            \ 'Nulla posuere.',
+            \ 'Donec vitae dolor.',
+            \ 'Nullam tristique diam non turpis.',
+            \ 'Cras placerat accumsan nulla.',
+            \ 'Nullam rutrum.',
+            \ 'Nam vestibulum accumsan nisl.',
+            \ ]
+function! s:insert_lorem_ipsum_list() abort
+    let save_register = @k
+    let @k =  '* ' . s:local_lorem_ipsum[s:NUMBER.random(0, len(s:local_lorem_ipsum))] . "\n"
+    normal! "kgP
+    let @k = save_register
+endfunction
+"
+"     ("Pellentesque dapibus suscipit ligula."
+"      "Donec posuere augue in quam."
+"      "Etiam vel tortor sodales tellus ultricies commodo."
+"      "Suspendisse potenti."
+"      "Aenean in sem ac leo mollis blandit."
+"      "Donec neque quam, dignissim in, mollis nec, sagittis eu, wisi."
+"      "Phasellus lacus."
+"      "Etiam laoreet quam sed arcu."
+"      "Phasellus at dui in ligula mollis ultricies."
+"      "Integer placerat tristique nisl."
+"      "Praesent augue."
+"      "Fusce commodo."
+"      "Vestibulum convallis, lorem a tempus semper, dui dui euismod elit, vitae placerat urna tortor vitae lacus."
+"      "Nullam libero mauris, consequat quis, varius et, dictum id, arcu."
+"      "Mauris mollis tincidunt felis."
+"      "Aliquam feugiat tellus ut neque."
+"      "Nulla facilisis, risus a rhoncus fermentum, tellus tellus lacinia purus, et dictum nunc justo sit amet elit.")
+"
+"     ("Aliquam erat volutpat."
+"      "Nunc eleifend leo vitae magna."
+"      "In id erat non orci commodo lobortis."
+"      "Proin neque massa, cursus ut, gravida ut, lobortis eget, lacus."
+"      "Sed diam."
+"      "Praesent fermentum tempor tellus."
+"      "Nullam tempus."
+"      "Mauris ac felis vel velit tristique imperdiet."
+"      "Donec at pede."
+"      "Etiam vel neque nec dui dignissim bibendum."
+"      "Vivamus id enim."
+"      "Phasellus neque orci, porta a, aliquet quis, semper a, massa."
+"      "Phasellus purus."
+"      "Pellentesque tristique imperdiet tortor."
+"      "Nam euismod tellus id erat.")
+"
+"     ("Nullam eu ante vel est convallis dignissim."
+"      "Fusce suscipit, wisi nec facilisis facilisis, est dui fermentum leo, quis tempor ligula erat quis odio."
+"      "Nunc porta vulputate tellus."
+"      "Nunc rutrum turpis sed pede."
+"      "Sed bibendum."
+"      "Aliquam posuere."
+"      "Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis varius mi purus non odio."
+"      "Pellentesque condimentum, magna ut suscipit hendrerit, ipsum augue ornare nulla, non luctus diam neque sit amet urna."
+"      "Curabitur vulputate vestibulum lorem."
+"      "Fusce sagittis, libero non molestie mollis, magna orci ultrices dolor, at vulputate neque nulla lacinia eros."
+"      "Sed id ligula quis est convallis tempor."
+"      "Curabitur lacinia pulvinar nibh."
+"      "Nam a sapien.")))
+"
+" (defvar lorem-ipsum-paragraph-separator "\n\n")
+" (defvar lorem-ipsum-sentence-separator "  ")
+" (defvar lorem-ipsum-list-beginning "")
+" (defvar lorem-ipsum-list-bullet "* ")
+" (defvar lorem-ipsum-list-item-end "\n")
+" (defvar lorem-ipsum-list-end "")
 function! s:insert_simple_password() abort
     let save_register = @k
     let @k = s:PASSWORD.generate_simple(8)

--- a/autoload/SpaceVim/layers/edit.vim
+++ b/autoload/SpaceVim/layers/edit.vim
@@ -38,4 +38,8 @@ function! SpaceVim#layers#edit#config() abort
     "noremap <SPACE> <Plug>(wildfire-fuel)
     vnoremap <C-SPACE> <Plug>(wildfire-water)
     let g:wildfire_objects = ["i'", 'i"', 'i)', 'i]', 'i}', 'ip', 'it']
+    let g:_spacevim_mappings_space.i = {'name' : '+Insertion'}
+    let g:_spacevim_mappings_space.i.l = {'name' : '+Lorem-ipsum'}
+    let g:_spacevim_mappings_space.i.p = {'name' : '+Passwords'}
+    call SpaceVim#mapping#space#def('nnoremap', ['i', 'p', 1], '', 'insert simple password', 1)
 endfunction

--- a/autoload/SpaceVim/layers/unite.vim
+++ b/autoload/SpaceVim/layers/unite.vim
@@ -3,6 +3,7 @@ function! SpaceVim#layers#unite#plugins() abort
                 \ ['Shougo/unite.vim',{ 'merged' : 0 , 'loadconf' : 1}],
                 \ ['Shougo/neoyank.vim'],
                 \ ['soh335/unite-qflist'],
+                \ ['SpaceVim/unite-unicode'],
                 \ ['ujihisa/unite-equery'],
                 \ ['m2mdas/unite-file-vcs'],
                 \ ['Shougo/neomru.vim'],

--- a/doc/SpaceVim.txt
+++ b/doc/SpaceVim.txt
@@ -49,8 +49,9 @@ CONTENTS                                                   *SpaceVim-contents*
       26. tmux...........................................|SpaceVim-layer-tmux|
   6. API........................................................|SpaceVim-api|
       1. cmdlinemenu................................|SpaceVim-api-cmdlinemenu|
-      2. sid............................................|SpaceVim-api-vim-sid|
-      3. vim#message................................|SpaceVim-api-vim-message|
+      2. data#list....................................|SpaceVim-api-data-list|
+      3. sid............................................|SpaceVim-api-vim-sid|
+      4. vim#message................................|SpaceVim-api-vim-message|
   7. FAQ........................................................|SpaceVim-faq|
 
 ==============================================================================
@@ -962,6 +963,24 @@ menu({items})
 Create a cmdline selection menu from a list of {items}, each item should be a
 list of two value in it, first one is the description, and the next one should
 be a funcrc.
+
+==============================================================================
+DATA#LIST                                             *SpaceVim-api-data-list*
+
+pop({list})
+
+Removes the last element from {list} and returns the element, as if the {list}
+is a stack.
+
+push({list})
+
+Appends {val} to the end of {list} and returns the list itself, as if the
+{list} is a stack.
+
+listpart({list}, {start}[, {len}])
+
+The result is a List, which is part of {list}, starting from index {start},
+with the length {len}
 
 ==============================================================================
 SID                                                     *SpaceVim-api-vim-sid*

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -77,6 +77,7 @@ title:  "Documentation"
             * [Searching the web](#searching-the-web)
         * [Persistent highlighting](#persistent-highlighting)
     * [Editing](#editing)
+        * [Text insertion commands](#text-insertion-commands)
         * [Multi-Encodings](#multi-encodings)
     * [Errors handling](#errors-handling)
 * [Achievements](#achievements)
@@ -1106,6 +1107,24 @@ Key Binding	Description
 SpaceVim uses `g:spacevim_search_highlight_persist` to keep the searched expression highlighted until the next search. It is also possible to clear the highlighting by pressing `SPC s c` or executing the ex command `:noh`.
 
 ### Editing
+
+#### Text insertion commands
+
+Text insertion commands (start with `i`):
+
+Key binding | Description
+`SPC i l l` | insert lorem-ipsum list
+`SPC i l p` | insert lorem-ipsum paragraph
+`SPC i l s` | insert lorem-ipsum sentence
+`SPC i p 1` | insert simple password
+`SPC i p 2` | insert stronger password
+`SPC i p 3` | insert password for paranoids
+`SPC i p p` | insert a phonetically easy password
+`SPC i p n` | insert a numerical password
+`SPC i u` | Search for Unicode characters and insert them into the active buffer.
+`SPC i U 1` | insert UUIDv1 (use universal argument to insert with CID format)
+`SPC i U 4` | insert UUIDv4 (use universal argument to insert with CID format)
+`SPC i U U` | insert UUIDv4 (use universal argument to insert with CID format)
 
 #### Multi-Encodings
 


### PR DESCRIPTION
#### Text insertion commands

Text insertion commands (start with `i`):

Key binding | Description
----- | ----
`SPC i l l` | insert lorem-ipsum list
`SPC i l p` | insert lorem-ipsum paragraph
`SPC i l s` | insert lorem-ipsum sentence
`SPC i p 1` | insert simple password
`SPC i p 2` | insert stronger password
`SPC i p 3` | insert password for paranoids
`SPC i p p` | insert a phonetically easy password
`SPC i p n` | insert a numerical password
`SPC i u` | Search for Unicode characters and insert them into the active buffer.
`SPC i U 1` | insert UUIDv1 (use universal argument to insert with CID format)
`SPC i U 4` | insert UUIDv4 (use universal argument to insert with CID format)
`SPC i U U` | insert UUIDv4 (use universal argument to insert with CID format)
