### PR TITLE
Add comment mappings

### DIFF
--- a/autoload/SpaceVim/mapping/g.vim
+++ b/autoload/SpaceVim/mapping/g.vim
@@ -20,6 +20,8 @@ function! SpaceVim#mapping#g#init() abort
     nnoremap g, g,
     let g:_spacevim_mappings_g[';'] = ['call feedkeys("g;", "n")', 'older position in change list']
     nnoremap g; g;
+    let g:_spacevim_mappings_g['@'] = ['call feedkeys("g@", "n")', 'call operatorfunc']
+    nnoremap g@ g@
 
     let g:_spacevim_mappings_g['#'] = ['call feedkeys("\<Plug>(incsearch-nohl-g#)")', 'search under cursor backward']
     let g:_spacevim_mappings_g['*'] = ['call feedkeys("\<Plug>(incsearch-nohl-g*)")', 'search under cursor forward']

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -79,8 +79,8 @@ function! SpaceVim#mapping#space#init() abort
   call SpaceVim#mapping#space#def('nmap', ['c', 'p'], 'vip<Plug>NERDCommenterComment', 'comment paragraphs', 0, 1)
   call SpaceVim#mapping#space#def('nmap', ['c', 'P'], 'vip<Plug>NERDCommenterInvert', 'toggle comment paragraphs', 0, 1)
 
-  nnoremap <silent> <Plug>CommentToLine :<SID>comment_to_line(0)<Cr>
-  nnoremap <silent> <Plug>CommentToLineInvert :<SID>comment_to_line(1)<Cr>
+  nnoremap <silent> <Plug>CommentToLine :call <SID>comment_to_line(0)<Cr>
+  nnoremap <silent> <Plug>CommentToLineInvert :call <SID>comment_to_line(1)<Cr>
   call SpaceVim#mapping#space#def('nmap', ['c', 't'], '<Plug>CommentToLine', 'comment to line', 0, 1)
   call SpaceVim#mapping#space#def('nmap', ['c', 'T'], '<Plug>CommentToLineInvert', 'toggle comment to line', 0, 1)
 
@@ -336,13 +336,17 @@ function! s:commentOperator(type, ...)
 endfunction
 
 function! s:comment_to_line(invert) abort
-  let line = str2nr(input('line number :'))
+  let input = input('line number :')
+  if empty(input)
+    return
+  endif
+  let line = str2nr(input)
   let ex = line - line('.')
   if ex > 0
     exe 'normal! V'. ex .'j'
   elseif ex == 0
   else
-    exe 'normal! V'. ex .'k'
+    exe 'normal! V'. abs(ex) .'k'
   endif
   if a:invert
     call feedkeys("\<Plug>NERDCommenterInvert")

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -74,7 +74,7 @@ function! SpaceVim#mapping#space#init() abort
   "
   " Toggles the comment state of the selected line(s). If the topmost selected
   " line is commented, all selected lines are uncommented and vice versa.
-  call SpaceVim#mapping#space#def('nnoremap', ['c', 'l'], 'call NERDComment("n", "Toggle")', 'Toggle comment line(s)', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['c', 'l'], 'call feedkeys("\<Plug>NERDCommenterComment")', 'Toggle comment line(s)', 1, 1)
 
   let g:_spacevim_mappings_space.e = {'name' : '+Errors/Encoding'}
   let g:_spacevim_mappings_space.B = {'name' : '+Global-buffers'}
@@ -205,10 +205,11 @@ function! SpaceVim#mapping#space#init() abort
         \ 'clear search highlight', 1)
 endfunction
 
-function! SpaceVim#mapping#space#def(m, keys, cmd, desc, is_cmd) abort
+function! SpaceVim#mapping#space#def(m, keys, cmd, desc, is_cmd, ...) abort
   if s:has_map_to_spc()
     return
   endif
+  let is_visual = a:0 > 0 ? a:1 : 0
   if a:is_cmd
     let cmd = ':<C-u>' . a:cmd . '<CR>' 
     let lcmd = a:cmd
@@ -222,6 +223,11 @@ function! SpaceVim#mapping#space#def(m, keys, cmd, desc, is_cmd) abort
     endif
   endif
   exe a:m . ' <silent> [SPC]' . join(a:keys, '') . ' ' . substitute(cmd, '|', '\\|', 'g')
+  if is_visual
+    if a:m ==# 'nnoremap'
+      exe 'xnoremap <silent> [SPC]' . join(a:keys, '') . ' ' . substitute(cmd, '|', '\\|', 'g')
+    endif
+  endif
   if len(a:keys) == 2
     let g:_spacevim_mappings_space[a:keys[0]][a:keys[1]] = [lcmd, a:desc]
   elseif len(a:keys) == 3

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -76,6 +76,8 @@ function! SpaceVim#mapping#space#init() abort
   " line is commented, all selected lines are uncommented and vice versa.
   call SpaceVim#mapping#space#def('nnoremap', ['c', 'l'], 'call feedkeys("\<Plug>NERDCommenterComment")', 'Toggle comment line(s)', 1, 1)
   call SpaceVim#mapping#space#def('nnoremap', ['c', 'L'], 'call feedkeys("\<Plug>NERDCommenterInvert")', 'Toggle comment line(s)', 1, 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['c', 'p'], 'call feedkeys("vip\<Plug>NERDCommenterComment")', 'Toggle comment line(s)', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['c', 'P'], 'call feedkeys("vip\<Plug>NERDCommenterInvert")', 'Toggle comment line(s)', 1)
   " in nerdcomment if has map to <plug>... the default mapping will be
   " disable, so we add it for compatibility
   nnoremap <Leader>cc :call feedkeys("\<Plug>NERDCommenterComment")<Cr>

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -76,8 +76,8 @@ function! SpaceVim#mapping#space#init() abort
   " line is commented, all selected lines are uncommented and vice versa.
   call SpaceVim#mapping#space#def('nmap', ['c', 'l'], '<Plug>NERDCommenterComment', 'comment lines', 0, 1)
   call SpaceVim#mapping#space#def('nmap', ['c', 'L'], '<Plug>NERDCommenterInvert', 'toggle comment lines', 0, 1)
-  call SpaceVim#mapping#space#def('nmap', ['c', 'p'], 'vip\<Plug>NERDCommenterComment', 'comment paragraphs', 0, 1)
-  call SpaceVim#mapping#space#def('nmap', ['c', 'P'], 'vip\<Plug>NERDCommenterInvert', 'toggle comment paragraphs', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', 'p'], 'vip<Plug>NERDCommenterComment', 'comment paragraphs', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', 'P'], 'vip<Plug>NERDCommenterInvert', 'toggle comment paragraphs', 0, 1)
   " in nerdcomment if has map to <plug>... the default mapping will be
   " disable, so we add it for compatibility
   nmap <Leader>cc <Plug>NERDCommenterComment

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -75,6 +75,13 @@ function! SpaceVim#mapping#space#init() abort
   " Toggles the comment state of the selected line(s). If the topmost selected
   " line is commented, all selected lines are uncommented and vice versa.
   call SpaceVim#mapping#space#def('nnoremap', ['c', 'l'], 'call feedkeys("\<Plug>NERDCommenterComment")', 'Toggle comment line(s)', 1, 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['c', 'L'], 'call feedkeys("\<Plug>NERDCommenterInvert")', 'Toggle comment line(s)', 1, 1)
+  " in nerdcomment if has map to <plug>... the default mapping will be
+  " disable, so we add it for compatibility
+  nnoremap <Leader>cc :call feedkeys("\<Plug>NERDCommenterComment")<Cr>
+  xnoremap <Leader>cc :call feedkeys("\<Plug>NERDCommenterComment")<Cr>
+  nnoremap <Leader>ci :call feedkeys("\<Plug>NERDCommenterInvert")<Cr>
+  xnoremap <Leader>ci :call feedkeys("\<Plug>NERDCommenterInvert")<Cr>
 
   let g:_spacevim_mappings_space.e = {'name' : '+Errors/Encoding'}
   let g:_spacevim_mappings_space.B = {'name' : '+Global-buffers'}

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -74,16 +74,16 @@ function! SpaceVim#mapping#space#init() abort
   "
   " Toggles the comment state of the selected line(s). If the topmost selected
   " line is commented, all selected lines are uncommented and vice versa.
-  call SpaceVim#mapping#space#def('nnoremap', ['c', 'l'], 'call feedkeys("\<Plug>NERDCommenterComment")', 'Toggle comment line(s)', 1, 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['c', 'L'], 'call feedkeys("\<Plug>NERDCommenterInvert")', 'Toggle comment line(s)', 1, 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['c', 'p'], 'call feedkeys("vip\<Plug>NERDCommenterComment")', 'Toggle comment line(s)', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['c', 'P'], 'call feedkeys("vip\<Plug>NERDCommenterInvert")', 'Toggle comment line(s)', 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', 'l'], '<Plug>NERDCommenterComment', 'comment lines', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', 'L'], '<Plug>NERDCommenterInvert', 'toggle comment lines', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', 'p'], 'vip\<Plug>NERDCommenterComment', 'comment paragraphs', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', 'P'], 'vip\<Plug>NERDCommenterInvert', 'toggle comment paragraphs', 0, 1)
   " in nerdcomment if has map to <plug>... the default mapping will be
   " disable, so we add it for compatibility
-  nnoremap <Leader>cc :call feedkeys("\<Plug>NERDCommenterComment")<Cr>
-  xnoremap <Leader>cc :call feedkeys("\<Plug>NERDCommenterComment")<Cr>
-  nnoremap <Leader>ci :call feedkeys("\<Plug>NERDCommenterInvert")<Cr>
-  xnoremap <Leader>ci :call feedkeys("\<Plug>NERDCommenterInvert")<Cr>
+  nmap <Leader>cc <Plug>NERDCommenterComment
+  xmap <Leader>cc <Plug>NERDCommenterComment
+  nmap <Leader>ci <Plug>NERDCommenterInvert
+  xmap <Leader>ci <Plug>NERDCommenterInvert
 
   let g:_spacevim_mappings_space.e = {'name' : '+Errors/Encoding'}
   let g:_spacevim_mappings_space.B = {'name' : '+Global-buffers'}
@@ -235,6 +235,8 @@ function! SpaceVim#mapping#space#def(m, keys, cmd, desc, is_cmd, ...) abort
   if is_visual
     if a:m ==# 'nnoremap'
       exe 'xnoremap <silent> [SPC]' . join(a:keys, '') . ' ' . substitute(cmd, '|', '\\|', 'g')
+    elseif a:m ==# 'nmap'
+      exe 'xmap <silent> [SPC]' . join(a:keys, '') . ' ' . substitute(cmd, '|', '\\|', 'g')
     endif
   endif
   if len(a:keys) == 2

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -78,6 +78,11 @@ function! SpaceVim#mapping#space#init() abort
   call SpaceVim#mapping#space#def('nmap', ['c', 'L'], '<Plug>NERDCommenterInvert', 'toggle comment lines', 0, 1)
   call SpaceVim#mapping#space#def('nmap', ['c', 'p'], 'vip<Plug>NERDCommenterComment', 'comment paragraphs', 0, 1)
   call SpaceVim#mapping#space#def('nmap', ['c', 'P'], 'vip<Plug>NERDCommenterInvert', 'toggle comment paragraphs', 0, 1)
+
+  nnoremap <silent> <Plug>CommentOperator :set opfunc=<SID>commentOperator<Cr>g@
+  let g:_spacevim_mappings_space.c[';'] = ['call feedkeys("\<Plug>CommentOperator")', 'comment operator']
+  nmap <silent> [SPC]c; <Plug>CommentOperator
+
   " in nerdcomment if has map to <plug>... the default mapping will be
   " disable, so we add it for compatibility
   nmap <Leader>cc <Plug>NERDCommenterComment
@@ -302,6 +307,27 @@ function! SpaceVim#mapping#space#langSPC(m, keys, cmd, desc, is_cmd) abort
   endif
   call SpaceVim#mapping#menu(a:desc, '[SPC]' . join(a:keys, ''), lcmd)
   call extend(g:_spacevim_mappings_prefixs['[SPC]'], get(g:, '_spacevim_mappings_space', {}))
+endfunction
+
+function! s:commentOperator(type, ...)
+  let sel_save = &selection
+  let &selection = "inclusive"
+  let reg_save = @@
+
+  if a:0  " Invoked from Visual mode, use gv command.
+    silent exe "normal! gv"
+    call feedkeys("\<Plug>NERDCommenterComment")
+  elseif a:type == 'line'
+    call feedkeys('`[V`]')
+    call feedkeys("\<Plug>NERDCommenterComment")
+  else
+    call feedkeys('`[v`]')
+    call feedkeys("\<Plug>NERDCommenterComment")
+  endif
+
+  let &selection = sel_save
+  let @@ = reg_save
+  set opfunc=
 endfunction
 
 " vim:set et sw=2 cc=80:

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -80,8 +80,8 @@ function! SpaceVim#mapping#space#init() abort
   call SpaceVim#mapping#space#def('nmap', ['c', 'P'], 'vip<Plug>NERDCommenterInvert', 'toggle comment paragraphs', 0, 1)
 
   nnoremap <silent> <Plug>CommentOperator :set opfunc=<SID>commentOperator<Cr>g@
-  let g:_spacevim_mappings_space.c[';'] = ['call feedkeys("\<Plug>CommentOperator")', 'comment operator']
-  nmap <silent> [SPC]c; <Plug>CommentOperator
+  let g:_spacevim_mappings_space[';'] = ['call feedkeys("\<Plug>CommentOperator")', 'comment operator']
+  nmap <silent> [SPC]; <Plug>CommentOperator
 
   " in nerdcomment if has map to <plug>... the default mapping will be
   " disable, so we add it for compatibility

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -79,6 +79,11 @@ function! SpaceVim#mapping#space#init() abort
   call SpaceVim#mapping#space#def('nmap', ['c', 'p'], 'vip<Plug>NERDCommenterComment', 'comment paragraphs', 0, 1)
   call SpaceVim#mapping#space#def('nmap', ['c', 'P'], 'vip<Plug>NERDCommenterInvert', 'toggle comment paragraphs', 0, 1)
 
+  nnoremap <silent> <Plug>CommentToLine :<SID>comment_to_line(0)<Cr>
+  nnoremap <silent> <Plug>CommentToLineInvert :<SID>comment_to_line(1)<Cr>
+  call SpaceVim#mapping#space#def('nmap', ['c', 't'], '<Plug>CommentToLine', 'comment to line', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', 'T'], '<Plug>CommentToLineInvert', 'toggle comment to line', 0, 1)
+
   nnoremap <silent> <Plug>CommentOperator :set opfunc=<SID>commentOperator<Cr>g@
   let g:_spacevim_mappings_space[';'] = ['call feedkeys("\<Plug>CommentOperator")', 'comment operator']
   nmap <silent> [SPC]; <Plug>CommentOperator
@@ -328,6 +333,22 @@ function! s:commentOperator(type, ...)
   let &selection = sel_save
   let @@ = reg_save
   set opfunc=
+endfunction
+
+function! s:comment_to_line(invert) abort
+  let line = str2nr(input('line number :'))
+  let ex = line - line('.')
+  if ex > 0
+    exe 'normal! V'. ex .'j'
+  elseif ex == 0
+  else
+    exe 'normal! V'. ex .'k'
+  endif
+  if a:invert
+    call feedkeys("\<Plug>NERDCommenterInvert")
+  else
+    call feedkeys("\<Plug>NERDCommenterComment")
+  endif
 endfunction
 
 " vim:set et sw=2 cc=80:

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -78,6 +78,7 @@ title:  "Documentation"
         * [Persistent highlighting](#persistent-highlighting)
     * [Editing](#editing)
         * [Text insertion commands](#text-insertion-commands)
+        * [Commenting](#commenting)
         * [Multi-Encodings](#multi-encodings)
     * [Errors handling](#errors-handling)
 * [Achievements](#achievements)
@@ -1113,6 +1114,7 @@ SpaceVim uses `g:spacevim_search_highlight_persist` to keep the searched express
 Text insertion commands (start with `i`):
 
 Key binding | Description
+----------- | -----------
 `SPC i l l` | insert lorem-ipsum list
 `SPC i l p` | insert lorem-ipsum paragraph
 `SPC i l s` | insert lorem-ipsum sentence
@@ -1125,6 +1127,25 @@ Key binding | Description
 `SPC i U 1` | insert UUIDv1 (use universal argument to insert with CID format)
 `SPC i U 4` | insert UUIDv4 (use universal argument to insert with CID format)
 `SPC i U U` | insert UUIDv4 (use universal argument to insert with CID format)
+
+#### Commenting
+
+Comments are handled by [nerdcommenter](https://github.com/scrooloose/nerdcommenter), it’s bound to the following keys.
+
+Key Binding | Description
+----------- | -----------
+`SPC ;` | comment operator
+`SPC c h` | hide/show comments
+`SPC c l` | comment lines
+`SPC c L` | invert comment lines
+`SPC c p` | comment paragraphs
+`SPC c P` | invert comment paragraphs
+`SPC c t` | comment to line
+`SPC c T` | invert comment to line
+`SPC c y` | comment and yank
+`SPC c Y` | invert comment and yank
+
+**Tips:** To comment efficiently a block of line use the combo `SPC ; SPC j l`
 
 #### Multi-Encodings
 


### PR DESCRIPTION
#### Commenting

Comments are handled by [nerdcommenter](https://github.com/scrooloose/nerdcommenter), it’s bound to the following keys.

Key Binding | Description
----------- | -----------
`SPC ;` | comment operator
`SPC c h` | hide/show comments
`SPC c l` | comment lines
`SPC c L` | invert comment lines
`SPC c p` | comment paragraphs
`SPC c P` | invert comment paragraphs
`SPC c t` | comment to line
`SPC c T` | invert comment to line
`SPC c y` | comment and yank
`SPC c Y` | invert comment and yank

**Tips:** To comment efficiently a block of line use the combo `SPC ; {motion}`
