### PR TITLE
Add SPC t m p for toggle cursor position

### DIFF
--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -53,7 +53,7 @@ let s:modes = {
             \ },
             \ }
 
-let s:loaded_sections = ['syntax checking', 'major mode', 'minor mode lighters', 'version control info']
+let s:loaded_sections = ['syntax checking', 'major mode', 'minor mode lighters', 'version control info', 'cursorpos']
 
 function! s:battery_status() abort
     if executable('acpi')
@@ -156,6 +156,10 @@ function! s:whitespace() abort
     endif
 endfunction
 
+function! s:cursorpos() abort
+    return ' %l:%c '
+endfunction
+
 
 function! s:modes() abort
     let m = ' ❖ '
@@ -240,7 +244,10 @@ function! s:active() abort
     if index(s:loaded_sections, 'battery status') != -1
         call add(rsec, s:battery_status())
     endif
-    call add(rsec, '%{" " . &ff . "|" . (&fenc!=""?&fenc:&enc) . " "}')
+    call add(rsec, '%{" " . &ff . " | " . (&fenc!=""?&fenc:&enc) . " "}')
+    if index(s:loaded_sections, 'cursorpos') != -1
+        call add(rsec, s:cursorpos())
+    endif
     call add(rsec, ' %P ')
     if index(s:loaded_sections, 'time') != -1
         call add(rsec, s:time())
@@ -343,6 +350,8 @@ function! SpaceVim#layers#core#statusline#config() abort
                 \ 'toggle the battery status', 1)
     call SpaceVim#mapping#space#def('nnoremap', ['t', 'm', 't'], 'call SpaceVim#layers#core#statusline#toggle_section("time")',
                 \ 'toggle the time', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['t', 'm', 'p'], 'call SpaceVim#layers#core#statusline#toggle_section("cursorpos")',
+                \ 'toggle the cursor position', 1)
     call SpaceVim#mapping#space#def('nnoremap', ['t', 'm', 'T'], 'if &laststatus == 2 | let &laststatus = 0 | else | let &laststatus = 2 | endif',
                 \ 'toggle the statuline itself', 1)
     function! TagbarStatusline(...) abort

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -397,7 +397,7 @@ Key Binding	| Description
 `SPC t m m` | toggle the minor mode lighters
 `SPC t m M` | toggle the major mode
 `SPC t m n` | toggle the cat! (if colors layer is declared in your dotfile)
-`SPC t m p` | toggle the point character position
+`SPC t m p` | toggle the cursor position
 `SPC t m t` | toggle the time
 `SPC t m T` | toggle the mode line itself
 `SPC t m v` | toggle the version control info


### PR DESCRIPTION
`SPC t m p` will toggle between:
![2017-07-01_395x63](https://user-images.githubusercontent.com/13142418/27762215-4a409fe8-5ea0-11e7-90b9-0a3a6e62e61d.png)
**and**
![2017-07-01_337x73](https://user-images.githubusercontent.com/13142418/27762216-4a5c685e-5ea0-11e7-8d56-3d01ac1a4caa.png)

the first picture will be the default when spacevim startup.


close #692