### PR TITLE
Add background searching feature

### DIFF
--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -241,6 +241,7 @@ function! s:active() abort
     if index(s:loaded_sections, 'version control info') != -1
         call add(lsec, s:git_branch())
     endif
+    call add(lsec, SpaceVim#plugins#searcher#count())
     if index(s:loaded_sections, 'battery status') != -1
         call add(rsec, s:battery_status())
     endif

--- a/autoload/SpaceVim/mapping/search.vim
+++ b/autoload/SpaceVim/mapping/search.vim
@@ -50,3 +50,16 @@ function! SpaceVim#mapping#search#grep(key, scope)
     let g:unite_source_grep_default_opts = save_opt
     let g:unite_source_grep_recursive_opt = save_ropt
 endfunction
+
+function! SpaceVim#mapping#search#default_tool()
+    if has_key(s:search_tools, 'default_exe')
+        return s:search_tools.default_exe
+    else
+        for t in g:spacevim_search_tools
+            if executable(t)
+                let s:search_tools.default_exe = t
+                return t
+            endif
+        endfor
+    endif
+endfunction

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -105,6 +105,11 @@ function! SpaceVim#mapping#space#init() abort
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'p'], 'Unite grep:.', 'grep in project', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'P'], "execute 'Unite grep:.::' . expand(\"<cword>\") . '  -start-insert'",
         \ 'grep in project', 1)
+  " Searching background
+  call SpaceVim#mapping#space#def('nnoremap', ['s', 'j'], 'call SpaceVim#plugins#searcher#find()', 'Background search keywords in project', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['s', 'J'], 'call SpaceVim#plugins#searcher#find(expand("<cword>"))',
+        \ 'Background search cursor words in project', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['s', 'l'], 'call SpaceVim#plugins#searcher#list()', 'List all searching results', 1)
 
   " Searching tools
   " ag

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -106,8 +106,10 @@ function! SpaceVim#mapping#space#init() abort
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'P'], "execute 'Unite grep:.::' . expand(\"<cword>\") . '  -start-insert'",
         \ 'grep in project', 1)
   " Searching background
-  call SpaceVim#mapping#space#def('nnoremap', ['s', 'j'], 'call SpaceVim#plugins#searcher#find()', 'Background search keywords in project', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['s', 'J'], 'call SpaceVim#plugins#searcher#find(expand("<cword>"))',
+  call SpaceVim#mapping#space#def('nnoremap', ['s', 'j'],
+        \ 'call SpaceVim#plugins#searcher#find("", SpaceVim#mapping#search#default_tool())', 'Background search keywords in project', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['s', 'J'],
+        \ 'call SpaceVim#plugins#searcher#find(expand("<cword>"),SpaceVim#mapping#search#default_tool())',
         \ 'Background search cursor words in project', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'l'], 'call SpaceVim#plugins#searcher#list()', 'List all searching results', 1)
 
@@ -124,6 +126,10 @@ function! SpaceVim#mapping#space#init() abort
         \ 'search in arbitrary directory  with ag', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'a', 'F'], 'call SpaceVim#mapping#search#grep("a", "F")',
         \ 'search cursor word in arbitrary directory  with ag', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['s', 'a', 'j'], 'call SpaceVim#plugins#searcher#find("", "ag")',
+        \ 'Background search cursor words in project with ag', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['s', 'a', 'J'], 'call SpaceVim#plugins#searcher#find(expand("<cword>"), "ag")',
+        \ 'Background search cursor words in project with ag', 1)
   " grep
   let g:_spacevim_mappings_space.s.g = {'name' : '+grep'}
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'g', 'b'], 'call SpaceVim#mapping#search#grep("g", "b")',
@@ -137,6 +143,10 @@ function! SpaceVim#mapping#space#init() abort
         \ 'search in arbitrary directory  with grep', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'g', 'F'], 'call SpaceVim#mapping#search#grep("g", "F")',
         \ 'search cursor word in arbitrary directory  with grep', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['s', 'g', 'j'], 'call SpaceVim#plugins#searcher#find("", "grep")',
+        \ 'Background search cursor words in project with grep', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['s', 'g', 'J'], 'call SpaceVim#plugins#searcher#find(expand("<cword>"), "grep")',
+        \ 'Background search cursor words in project with grep', 1)
   " ack
   let g:_spacevim_mappings_space.s.k = {'name' : '+ack'}
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'k', 'b'], 'call SpaceVim#mapping#search#grep("k", "b")', 'search in all buffers with ack', 1)
@@ -149,6 +159,10 @@ function! SpaceVim#mapping#space#init() abort
         \ 'search in arbitrary directory  with ack', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'k', 'F'], 'call SpaceVim#mapping#search#grep("k", "F")',
         \ 'search cursor word in arbitrary directory  with ack', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['s', 'k', 'j'], 'call SpaceVim#plugins#searcher#find("", "ack")',
+        \ 'Background search cursor words in project with ack', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['s', 'k', 'J'], 'call SpaceVim#plugins#searcher#find(expand("<cword>"), "ack")',
+        \ 'Background search cursor words in project with ack', 1)
   " rg
   let g:_spacevim_mappings_space.s.r = {'name' : '+rg'}
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'r', 'b'], 'call SpaceVim#mapping#search#grep("r", "b")', 'search in all buffers with rt', 1)
@@ -161,6 +175,10 @@ function! SpaceVim#mapping#space#init() abort
         \ 'search in arbitrary directory  with rt', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'r', 'F'], 'call SpaceVim#mapping#search#grep("r", "F")',
         \ 'search cursor word in arbitrary directory  with rt', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['s', 'r', 'j'], 'call SpaceVim#plugins#searcher#find("", "rg")',
+        \ 'Background search cursor words in project with rg', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['s', 'r', 'J'], 'call SpaceVim#plugins#searcher#find(expand("<cword>"), "rg")',
+        \ 'Background search cursor words in project with rg', 1)
   " pt
   let g:_spacevim_mappings_space.s.t = {'name' : '+pt'}
   call SpaceVim#mapping#space#def('nnoremap', ['s', 't', 'b'], 'call SpaceVim#mapping#search#grep("t", "b")', 'search in all buffers with pt', 1)
@@ -173,6 +191,10 @@ function! SpaceVim#mapping#space#init() abort
         \ 'search in arbitrary directory  with pt', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['s', 't', 'F'], 'call SpaceVim#mapping#search#grep("t", "F")',
         \ 'search cursor word in arbitrary directory  with pt', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['s', 't', 'j'], 'call SpaceVim#plugins#searcher#find("", "pt")',
+        \ 'Background search cursor words in project with pt', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['s', 't', 'J'], 'call SpaceVim#plugins#searcher#find(expand("<cword>"), "pt")',
+        \ 'Background search cursor words in project with pt', 1)
 
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'c'], 'noh',
         \ 'clear search highlight', 1)

--- a/autoload/SpaceVim/plugins/searcher.vim
+++ b/autoload/SpaceVim/plugins/searcher.vim
@@ -1,11 +1,11 @@
 let s:rst = []
-function! SpaceVim#plugins#searcher#find(...)
-    if a:0 == 0
+function! SpaceVim#plugins#searcher#find(expr, exe)
+    if empty(a:expr)
         let expr = input('search expr: ')
     else
-        let expr = a:1
+        let expr = a:expr
     endif
-    call jobstart(['ag', expr], {
+    call jobstart(s:get_search_cmd(a:exe, expr), {
                 \ 'on_stdout' : function('s:search_stdout'),
                 \ 'on_exit' : function('s:search_exit'),
                 \ })
@@ -23,6 +23,14 @@ function! s:search_stdout(id, data, event) abort
                         \ })
         endif
     endfor
+endfunction
+
+function! s:get_search_cmd(exe, expr) abort
+    if a:exe == 'grep'
+        return ['grep', '-inHR', '--exclude-dir', '.git', a:expr, '.']
+    else
+        return [a:exe, a:expr]
+    endif
 endfunction
 
 function! s:search_exit(id, data, event) abort

--- a/autoload/SpaceVim/plugins/searcher.vim
+++ b/autoload/SpaceVim/plugins/searcher.vim
@@ -1,0 +1,47 @@
+let s:rst = []
+function! SpaceVim#plugins#searcher#find(...)
+    if a:0 == 0
+        let expr = input('search expr: ')
+    else
+        let expr = a:1
+    endif
+    call jobstart(['ag', expr], {
+                \ 'on_stdout' : function('s:search_stdout'),
+                \ 'on_exit' : function('s:search_exit'),
+                \ })
+endfunction
+function! s:search_stdout(id, data, event) abort
+    for data in a:data
+        let info = split(data, '\:\d\+\:')
+        if len(info) == 2
+            let [fname, text] = info
+            let lnum = matchstr(data, '\:\d\+\:')[1:-2]
+            call add(s:rst, {
+                        \ 'filename' : fnamemodify(fname, ':p'),
+                        \ 'lnum' : lnum,
+                        \ 'text' : text,
+                        \ })
+        endif
+    endfor
+endfunction
+
+function! s:search_exit(id, data, event) abort
+    let &l:statusline = SpaceVim#layers#core#statusline#get(1)
+endfunction
+
+
+function! SpaceVim#plugins#searcher#list()
+    call setqflist(s:rst)
+    let s:rst = []
+    copen
+endfunction
+
+function! SpaceVim#plugins#searcher#count()
+    if empty(s:rst)
+        return ''
+    else
+        return ' ' . len(s:rst) . ' items '
+    endif
+endfunction
+
+

--- a/autoload/SpaceVim/plugins/searcher.vim
+++ b/autoload/SpaceVim/plugins/searcher.vim
@@ -28,6 +28,8 @@ endfunction
 function! s:get_search_cmd(exe, expr) abort
     if a:exe == 'grep'
         return ['grep', '-inHR', '--exclude-dir', '.git', a:expr, '.']
+    elseif a:exe == 'rg'
+        return ['rg', '-n', a:expr]
     else
         return [a:exe, a:expr]
     endif

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1084,6 +1084,7 @@ Key Binding | Description
 `SPC *` or `SPC s P` | search with the first found tool with default input
 `SPC s a p` | ag
 `SPC s a P` | ag with default text
+`SPC s g p` | grep
 `SPC s g p` | grep with default text
 `SPC s k p` | ack
 `SPC s k P` | ack with default text

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -74,6 +74,7 @@ title:  "Documentation"
             * [Searching in all loaded buffers](#searching-in-all-loaded-buffers)
             * [Searching in an arbitrary directory](#searching-in-an-arbitrary-directory)
             * [Searching in a project](#searching-in-a-project)
+            * [Background searching in a project](#background-searching-in-a-project)
             * [Searching the web](#searching-the-web)
         * [Persistent highlighting](#persistent-highlighting)
     * [Editing](#editing)
@@ -1092,6 +1093,26 @@ Key Binding | Description
 `SPC s r P` | rg with default text
 
 **Hint**: It is also possible to search in a project without needing to open a file beforehand. To do so use `SPC p p` and then `C-s` on a given project to directly search into it like with `SPC s p`. (TODO)
+
+##### Background searching in a project
+
+Background search keyword in a project, when searching done, the count will be shown on the statusline.
+
+Key Binding	| Description
+----------- | -----------
+`SPC s j` | searching input expr background with the first found tool
+`SPC s J` | searching cursor word background with the first found tool
+`SPC s l` | List all searching result in quickfix buffer
+`SPC s a j` | ag
+`SPC s a J` | ag with default text
+`SPC s g j` | grep
+`SPC s g J` | grep with default text
+`SPC s k j` | ack
+`SPC s k J` | ack with default text
+`SPC s t j` | pt
+`SPC s t J` | pt with default text
+`SPC s r j` | rg
+`SPC s r J` | rg with default text
 
 ##### Searching the web
 

--- a/init.vim
+++ b/init.vim
@@ -1,1 +1,2 @@
 execute 'source' fnamemodify(expand('<sfile>'), ':h').'/config/main.vim'
+" abfgkprt

--- a/init.vim
+++ b/init.vim
@@ -1,2 +1,1 @@
 execute 'source' fnamemodify(expand('<sfile>'), ':h').'/config/main.vim'
-" abfgkprt


### PR DESCRIPTION
HI @Shougo @memedayangyang
I have add background searching feature in spacevim, here is the mappings:

Key Binding	| Description
----------- | -----------
`SPC s j` | searching input expr background
`SPC s J` | searching cursor word background
`SPC s l` | List all searching result in quickfix buffer

here is how to use this feature:
there are two ways to search background:
1. press  `SPC s j`, will show a  input prompt : 
![2017-07-02_390x57](https://user-images.githubusercontent.com/13142418/27768233-cb939d2a-5f40-11e7-9d78-d641e89972e9.png)
then you can input the expr you want to search
2. press `SPC s J`, will search cursor word background:

when searching done:
you will see info in statusline, ( here show you there are  149 items)
![2017-07-02_717x58](https://user-images.githubusercontent.com/13142418/27768246-0cbbfb94-5f41-11e7-88be-2f31d1cf937b.png)

then you can use `SPC s l` to list all searching result in quickfix buffer.

close #597 