### PR TITLE
plugin: json-vim: update to newer, forked version

### DIFF
--- a/autoload/SpaceVim/layers/lang.vim
+++ b/autoload/SpaceVim/layers/lang.vim
@@ -10,7 +10,7 @@ function! SpaceVim#layers#lang#plugins() abort
                 \ ['juvenn/mustache.vim',                    { 'on_ft' : ['mustache']}],
                 \ ['leafgarland/typescript-vim',             { 'on_ft' : ['typescript']}],
                 \ ['kchmck/vim-coffee-script',               { 'on_ft' : ['coffee']}],
-                \ ['leshill/vim-json',                       { 'on_ft' : ['javascript','json']}],
+                \ ['elzr/vim-json',                          { 'on_ft' : ['javascript','json']}],
                 \ ['elixir-lang/vim-elixir',                 { 'on_ft' : 'elixir'}],
                 \ ['PotatoesMaster/i3-vim-syntax',           { 'on_ft' : 'i3'}],
                 \ ['isundil/vim-irssi-syntax',               { 'on_ft' : 'irssi'}],


### PR DESCRIPTION
Updated the lang layer to use elzr/vim-json's fork or the old plugin
(leshill/vim-json). Now the actual used plugin is consistent with the
documentation, which pointed to elzr/vim-json before