### PR TITLE
Remove g:delimitMate_matchpairs setting.

### DIFF
--- a/autoload/SpaceVim/layers/autocomplete.vim
+++ b/autoload/SpaceVim/layers/autocomplete.vim
@@ -65,7 +65,6 @@ endfunction
 
 
 function! SpaceVim#layers#autocomplete#config() abort
-  let g:delimitMate_matchpairs = '[:],{:},<:>'
   inoremap <silent><expr> ( complete_parameter#pre_complete("()")
 
   "mapping

--- a/autoload/SpaceVim/layers/autocomplete.vim
+++ b/autoload/SpaceVim/layers/autocomplete.vim
@@ -65,7 +65,10 @@ endfunction
 
 
 function! SpaceVim#layers#autocomplete#config() abort
-  inoremap <silent><expr> ( complete_parameter#pre_complete("()")
+  imap <expr>( 
+        \ pumvisible() ? 
+        \ complete_parameter#pre_complete("()") : 
+        \ "\<Plug>delimitMate("
 
   "mapping
   imap <silent><expr><TAB> SpaceVim#mapping#tab()


### PR DESCRIPTION
Let `)`(delimitMate mapping) can work.
Remove '<:>' mapping, let the `less then` operator can work.

Fixes #772