### PR TITLE
Add buffer # keymap

### DIFF
--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -86,6 +86,8 @@ function! SpaceVim#mapping#space#init() abort
         \ ]
         \ ]
         \ , 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['b', '#'], 'buffer #', 'Previously active buffer (:b #)', 1)
+
   "
   " Comments sections
   "


### PR DESCRIPTION
Add keymap `SPC b #` to command `buffer #` to open the previously opened buffer.  I think it is quite a useful command especially when you open multi-buffers but temporally focus on two buffers.