### PR TITLE
Add vim-repeat to edit layer

### DIFF
--- a/autoload/SpaceVim/layers/edit.vim
+++ b/autoload/SpaceVim/layers/edit.vim
@@ -6,6 +6,7 @@ let s:LIST = SpaceVim#api#import('data#list')
 function! SpaceVim#layers#edit#plugins() abort
     let plugins = [
                 \ ['tpope/vim-surround'],
+                \ ['tpope/vim-repeat'],
                 \ ['junegunn/vim-emoji'],
                 \ ['terryma/vim-multiple-cursors'],
                 \ ['terryma/vim-expand-region', { 'loadconf' : 1}],


### PR DESCRIPTION
This is a really nice plugin which adds a user pluggable "." command. It
integrates seamlessly with several plugins, notably tpope/vim-surround
and makes the "." command capable of repeating on the entire surround
command, rather than just a part of the command. ysaw" becomes easily
repeatable!