### PR TITLE
`eslint --fix` for javascript

### DIFF
--- a/autoload/SpaceVim/layers/lang/javascript.vim
+++ b/autoload/SpaceVim/layers/lang/javascript.vim
@@ -17,6 +17,17 @@ endfunction
 
 function! SpaceVim#layers#lang#javascript#config() abort
   call SpaceVim#mapping#gd#add('javascript', function('s:gotodef'))
+  if !exists(g:spacevim_javascript_autofix)
+    let g:spacevim_javascript_autofix = 1
+  endif
+  if (g:spacevim_javascript_autofix) 
+    " Only use eslint
+    let g:neomake_javascript_enabled_makers = ['eslint']
+    " Use the fix option of eslint
+    let g:neomake_javascript_eslint_args = ['-f', 'compact', '--fix']
+    au User NeomakeFinished checktime
+    au FocusGained * checktime
+  endif
 endfunction
 
 function! s:gotodef() abort


### PR DESCRIPTION
`eslint --fix` can auto fix common linting problems and style the javascript code.  I think it would be good if we turn on it by default rather than forcing users calling them by `!eslint --fix %` by hand.  

Here I contribute a config in my `init.vim` to turn on the `eslint --fix`; and for anyone who want to disable `eslint --fix`, they can add `let g:spacevim_javascript_autofix = 0` before loading the javascript layer.

Thanks a lot for `SpaceVim`~