### PR TITLE
Made gitcommit completion source changeable

### DIFF
--- a/config/plugins/deoplete.vim
+++ b/config/plugins/deoplete.vim
@@ -68,7 +68,7 @@ let g:deoplete#omni#input_patterns.gitcommit = get(g:deoplete#omni#input_pattern
       \'[ ]#[ 0-9a-zA-Z]*',
       \])
 
-let g:deoplete#ignore_sources.gitcommit = ['neosnippet']
+let g:deoplete#ignore_sources.gitcommit = get(g:deoplete#ignore_sources, 'gitcommit', ['neosnippet'])
 
 " lua
 let g:deoplete#omni_patterns.lua = get(g:deoplete#omni_patterns, 'lua', '.')


### PR DESCRIPTION
Made gitcommit completion source changeable.
* Made `deoplete#ignore_sources.gitcommit` in `config/plugins/deoplete.vim` changeable.
    (This is useful when inputting date time into commit message by using neosnippet.)