### PR TITLE
Minor fix for Vim help language setting example

### DIFF
--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -525,7 +525,7 @@ function! SpaceVim#end() abort
     endfor
     if g:spacevim_vim_help_language ==# 'cn'
       call add(g:spacevim_plugin_groups, 'chinese')
-    elseif g:spacevim_vim_help_language ==# 'japanese'
+    elseif g:spacevim_vim_help_language ==# 'ja'
       call add(g:spacevim_plugin_groups, 'japanese')
     endif
     if g:spacevim_use_colorscheme==1

--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -212,7 +212,7 @@ let g:spacevim_use_colorscheme         = 1
 " Set the help language of vim. Default is 'en'. 
 " You can change it to Chinese.
 " >
-"   let g:spacevim_vim_help_language = 'chinese'
+"   let g:spacevim_vim_help_language = 'cn'
 " <
 let g:spacevim_vim_help_language       = 'en'
 ""

--- a/doc/SpaceVim.txt
+++ b/doc/SpaceVim.txt
@@ -246,7 +246,7 @@ might require adding the following to ~/.tmux.conf:
                                                 *g:spacevim_vim_help_language*
 Set the help language of vim. Default is 'en'.  You can change it to Chinese.
 >
-  let g:spacevim_vim_help_language = 'chinese'
+  let g:spacevim_vim_help_language = 'cn'
 <
 
                                                          *g:spacevim_language*


### PR DESCRIPTION
* Minor fix for Vim help language setting example (`chinese` -> `cn`)