### PR TITLE
resolve conflicts between tmux layer and edit layer

### DIFF
--- a/autoload/SpaceVim/layers/edit.vim
+++ b/autoload/SpaceVim/layers/edit.vim
@@ -29,8 +29,8 @@ function! SpaceVim#layers#edit#plugins() abort
 endfunction
 
 function! SpaceVim#layers#edit#config() abort
-    let g:multi_cursor_next_key=get(g:, 'multi_cursor_next_key', '<C-j>')
-    let g:multi_cursor_prev_key=get(g:, 'multi_cursor_prev_key', '<C-k>')
+    let g:multi_cursor_next_key=get(g:, 'multi_cursor_next_key', '<C-n>')
+    let g:multi_cursor_prev_key=get(g:, 'multi_cursor_prev_key', '<C-u>')
     let g:multi_cursor_skip_key=get(g:, 'multi_cursor_skip_key', '<C-x>')
     let g:multi_cursor_quit_key=get(g:, 'multi_cursor_quit_key', '<Esc>')
     let g:user_emmet_install_global = 0

--- a/autoload/SpaceVim/layers/edit.vim
+++ b/autoload/SpaceVim/layers/edit.vim
@@ -30,7 +30,7 @@ endfunction
 
 function! SpaceVim#layers#edit#config() abort
     let g:multi_cursor_next_key=get(g:, 'multi_cursor_next_key', '<C-n>')
-    let g:multi_cursor_prev_key=get(g:, 'multi_cursor_prev_key', '<C-u>')
+    let g:multi_cursor_prev_key=get(g:, 'multi_cursor_prev_key', '<C-m>')
     let g:multi_cursor_skip_key=get(g:, 'multi_cursor_skip_key', '<C-x>')
     let g:multi_cursor_quit_key=get(g:, 'multi_cursor_quit_key', '<Esc>')
     let g:user_emmet_install_global = 0

--- a/autoload/SpaceVim/layers/tmux.vim
+++ b/autoload/SpaceVim/layers/tmux.vim
@@ -5,8 +5,7 @@
 " seamlessly.
 " This layer is not added by default. To include it, add
 " `SpaceVim#layers#load('tmux')` to your `~/.SpaceVim.d/init.vim`.
-" This layer currently overwrites some SpaceVim keybinds including multiple
-" cursors. If you are having issues with <C-h> in a neovim buffer, see
+" If you are having issues with <C-h> in a neovim buffer, see
 " `https://github.com/neovim/neovim/issues/2048#issuecomment-78045837`
 "
 " @subsection mappings

--- a/autoload/SpaceVim/layers/tools.vim
+++ b/autoload/SpaceVim/layers/tools.vim
@@ -66,11 +66,11 @@ function! SpaceVim#layers#tools#config() abort
   " List of colors that you do not want. ANSI code or #RRGGBB
   let g:rainbow#blacklist = [233, 234]
   nnoremap <Leader>fz :FZF<CR>
-  if maparg('<C-l>', 'v') ==# ''
-    vnoremap <silent> <C-l> <Esc>:Ydv<CR>
+  if maparg('<C-_>', 'v') ==# ''
+    vnoremap <silent> <C-_> <Esc>:Ydv<CR>
   endif
-  if maparg('<C-l>', 'n') ==# ''
-    nnoremap <silent> <C-l> <Esc>:Ydc<CR>
+  if maparg('<C-_>', 'n') ==# ''
+    nnoremap <silent> <C-_> <Esc>:Ydc<CR>
   endif
   map <Leader>td <Plug>TaskList
   noremap <silent> <F8> :TlistToggle<CR>


### PR DESCRIPTION
https://github.com/SpaceVim/SpaceVim/issues/925
To resolve the conflicts, I subsitute the old key binding 'c-j' and 'c-k' with 'c-n' and 'c-u' which relate to multiple-cursors plugin.On the ohter hand, I replace the key binding 'c-l' with 'c-\_'(means C-/) relating to consult the youdao online dictionary.
The default key binding metioned above for vim or neovim lists below:
C-n move down one line
C-u up half screen
C-_  unbound
