### PR TITLE
Fixed cursor mode-sensitive issue

### DIFF
--- a/config/neovim.vim
+++ b/config/neovim.vim
@@ -28,7 +28,7 @@ else
         set guicursor=
     elseif g:spacevim_terminal_cursor_shape == 1
         " enable non-blinking mode-sensitive cursor
-        set guicursor=a:block-blinkon0
+        set guicursor=n-v-c:block-blinkon0,i-ci-ve:ver25-blinkon0,r-cr:hor20,o:hor50
     elseif g:spacevim_terminal_cursor_shape == 2
         " enable blinking mode-sensitive cursor
         set guicursor=n-v-c:block-blinkon10,i-ci-ve:ver25-blinkon10,r-cr:hor20,o:hor50


### PR DESCRIPTION
# Fixed cursor mode-sensitive issue

Fixed an issue that cursor shape won't change by mode even if `g:spacevim_terminal_cursor_shape` is 1, it is described as mode-sensitive.
