### PR TITLE
Added filetypes for Emmet

### DIFF
--- a/autoload/SpaceVim/autocmds.vim
+++ b/autoload/SpaceVim/autocmds.vim
@@ -18,7 +18,7 @@ function! SpaceVim#autocmds#init() abort
     autocmd FileType jsp call JspFileTypeInit()
     autocmd QuitPre * call SpaceVim#plugins#windowsmanager#UpdateRestoreWinInfo()
     autocmd WinEnter * call SpaceVim#plugins#windowsmanager#MarkBaseWin()
-    autocmd FileType html,css,jsp EmmetInstall
+    autocmd FileType html,css,scss,sass,less,javascript,jsp EmmetInstall
     autocmd BufRead,BufNewFile *.pp setfiletype puppet
     if g:spacevim_enable_cursorline == 1
       autocmd BufEnter,WinEnter,InsertLeave * setl cursorline


### PR DESCRIPTION
# Added filetypes for Emmet

Added filetypes for Emmet.

## Added Emmet languages
* `scss`
* `sass`
* `less`
* `stylus`
* `javascript` (JSX-style, `javascript.jsx` is better but current plugin cannot detect JSX-style).