### PR TITLE
Enable deoplete in vim8 && lsp support

### DIFF
--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -544,7 +544,7 @@ function! SpaceVim#end() abort
       call add(g:spacevim_plugin_groups, 'colorscheme')
     endif
 
-    if has('nvim')
+    if has('python3')
       let g:spacevim_autocomplete_method = 'deoplete'
     elseif has('lua')
       let g:spacevim_autocomplete_method = 'neocomplete'

--- a/autoload/SpaceVim/layers/autocomplete.vim
+++ b/autoload/SpaceVim/layers/autocomplete.vim
@@ -58,6 +58,10 @@ function! SpaceVim#layers#autocomplete#plugins() abort
           \ 'on_event' : 'InsertEnter',
           \ 'loadconf' : 1,
           \ }])
+    if !has('nvim')
+      call add(plugins, ['SpaceVim/nvim-yarp',  {'merged': 0}])
+      call add(plugins, ['SpaceVim/vim-hug-neovim-rpc',  {'merged': 0}])
+    endif
   endif
   if has('patch-7.4.774')
     call add(plugins, ['Shougo/echodoc.vim', {
@@ -67,6 +71,7 @@ function! SpaceVim#layers#autocomplete#plugins() abort
           \ }])
   endif
   call add(plugins, ['tenfyzhong/CompleteParameter.vim',  {'merged': 0}])
+  call add(plugins, ['SpaceVim/LanguageClient-neovim',  {'merged': 0}])
   return plugins
 endfunction
 

--- a/config/plugins/deoplete.vim
+++ b/config/plugins/deoplete.vim
@@ -91,6 +91,11 @@ let g:deoplete#keyword_patterns.clojure = '[\w!$%&*+/:<=>?@\^_~\-\.#]*'
 " public settings
 call deoplete#custom#set('_', 'matchers', ['matcher_full_fuzzy'])
 let g:deoplete#ignore_sources._ = get(g:deoplete#ignore_sources, '_', ['around', 'LanguageClient'])
+for key in keys(g:deoplete#ignore_sources)
+  if key != '_' && index(keys(get(g:, 'LanguageClient_serverCommands', {})), key) == -1
+    let g:deoplete#ignore_sources[key] = g:deoplete#ignore_sources[key] + ['around', 'LanguageClient']
+  endif
+endfor
 inoremap <expr><C-h> deoplete#mappings#smart_close_popup()."\<C-h>"
 inoremap <expr><BS> deoplete#mappings#smart_close_popup()."\<C-h>"
 set isfname-==

--- a/config/plugins/deoplete.vim
+++ b/config/plugins/deoplete.vim
@@ -90,7 +90,7 @@ let g:deoplete#keyword_patterns.clojure = '[\w!$%&*+/:<=>?@\^_~\-\.#]*'
 
 " public settings
 call deoplete#custom#set('_', 'matchers', ['matcher_full_fuzzy'])
-let g:deoplete#ignore_sources._ = get(g:deoplete#ignore_sources, '_', ['around'])
+let g:deoplete#ignore_sources._ = get(g:deoplete#ignore_sources, '_', ['around', 'LanguageClient'])
 inoremap <expr><C-h> deoplete#mappings#smart_close_popup()."\<C-h>"
 inoremap <expr><BS> deoplete#mappings#smart_close_popup()."\<C-h>"
 set isfname-==

--- a/docs/layers/autocomplete.md
+++ b/docs/layers/autocomplete.md
@@ -5,15 +5,17 @@ title: "SpaceVim autocomplete layer"
 # [SpaceVim Layers:](https://spacevim.org/layers) autocomplete
 
 <!-- vim-markdown-toc GFM -->
-* [Description](#description)
-* [Install](#install)
-* [Configuration](#configuration)
-    * [Key bindings](#key-bindings)
-    * [Snippets directories](#snippets-directories)
-    * [Show snippets in auto-completion popup](#show-snippets-in-auto-completion-popup)
-* [Key bindings](#key-bindings-1)
-    * [auto-complete](#auto-complete)
-    * [Neosnippet](#neosnippet)
+
+- [Description](#description)
+- [Install](#install)
+- [Configuration](#configuration)
+  - [Key bindings](#key-bindings)
+  - [Snippets directories](#snippets-directories)
+  - [Show snippets in auto-completion popup](#show-snippets-in-auto-completion-popup)
+- [LSP supported](#lsp-supported)
+- [Key bindings](#key-bindings-1)
+  - [auto-complete](#auto-complete)
+  - [Neosnippet](#neosnippet)
 
 <!-- vim-markdown-toc -->
 
@@ -94,6 +96,8 @@ call SpaceVim#layers#load('autocomplete', {
         \ 'auto-completion-enable-snippets-in-popup' : 0
         \ })
 ```
+
+## LSP supported
 
 ## Key bindings
 


### PR DESCRIPTION
These plugins will be added:

[roxma/vim-hug-neovim-rpc](https://github.com/roxma/vim-hug-neovim-rpc)
[roxma/nvim-yarp](https://github.com/roxma/nvim-yarp)
[autozimu/LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim)

Before this PR is merged, we just use forked repo, and fix some issues, send PR to the origin repo.

error:

```
ImportError: /home/wsdjeg/.local/lib/python3.6/site-packages/greenlet.cpython-36m-x86_64-linux-gnu.so: undefined symbol: PyExc_ValueError
```

fixed by:

```
pip2 uninstall --user greenlet
pip3 uninstall --user greenlet
sudo pacman -S python-greenlet python2-greenlet
```
```