### PR TITLE
Fixed plugin 'vim-rtags' initialization errors

### DIFF
--- a/autoload/SpaceVim/layers/lang/c.vim
+++ b/autoload/SpaceVim/layers/lang/c.vim
@@ -47,7 +47,7 @@ function! SpaceVim#layers#lang#c#plugins() abort
   else
     call add(plugins, ['Rip-Rip/clang_complete'])
   endif
-  call add(plugins, ['lyuts/vim-rtags', { 'if' : has('python3')}])
+  call add(plugins, ['lyuts/vim-rtags', { 'if' : has('python')}])
   return plugins
 endfunction
 


### PR DESCRIPTION
Plugin 'lyuts/vim-rtags' has not supported python3 yet.
Issue Link [Python 3 support requirement](https://github.com/lyuts/vim-rtags/issues/86).