### PR TITLE
Update autocomple layer

### DIFF
--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -537,6 +537,16 @@ endfunction
 
 function! SpaceVim#end() abort
 
+  if g:spacevim_enable_neocomplcache
+    let g:spacevim_autocomplete_method = 'neocomplcache'
+  endif
+  if g:spacevim_enable_ycm
+    if has('python') || has('python3')
+      let g:spacevim_autocomplete_method = 'ycm'
+    else
+      call SpaceVim#logger#warn('YCM need +python or +python3 support, force to using ' . g:spacevim_autocomplete_method)
+    endif
+  endif
   if g:spacevim_keep_server_alive
     call SpaceVim#server#export_server()
   endif
@@ -580,15 +590,11 @@ function! SpaceVim#end() abort
       let g:spacevim_autocomplete_method = 'deoplete'
     elseif has('lua')
       let g:spacevim_autocomplete_method = 'neocomplete'
+    elseif has('python')
+      let g:spacevim_autocomplete_method = 'completor'
     elseif has('timers')
       let g:spacevim_autocomplete_method = 'asyncomplete'
     else
-      let g:spacevim_autocomplete_method = 'neocomplcache'
-    endif
-    if g:spacevim_enable_ycm
-      let g:spacevim_autocomplete_method = 'ycm'
-    endif
-    if g:spacevim_enable_neocomplcache
       let g:spacevim_autocomplete_method = 'neocomplcache'
     endif
   endif

--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -580,6 +580,8 @@ function! SpaceVim#end() abort
       let g:spacevim_autocomplete_method = 'deoplete'
     elseif has('lua')
       let g:spacevim_autocomplete_method = 'neocomplete'
+    elseif has('timers')
+      let g:spacevim_autocomplete_method = 'asyncomplete'
     else
       let g:spacevim_autocomplete_method = 'neocomplcache'
     endif

--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -98,7 +98,32 @@ let g:spacevim_realtime_leader_guide   = 1
 "   let g:spacevim_enable_key_frequency = 1
 " <
 let g:spacevim_enable_key_frequency = 0
-let g:spacevim_autocomplete_method     = ''
+if has('python3')
+  ""
+  " Set the autocomplete engine of spacevim, the default logic is:
+  " >
+  "   if has('python3')
+  "     let g:spacevim_autocomplete_method = 'deoplete'
+  "   elseif has('lua')
+  "     let g:spacevim_autocomplete_method = 'neocomplete'
+  "   elseif has('python')
+  "     let g:spacevim_autocomplete_method = 'completor'
+  "   elseif has('timers')
+  "     let g:spacevim_autocomplete_method = 'asyncomplete'
+  "   else
+  "     let g:spacevim_autocomplete_method = 'neocomplcache'
+  "   endif
+  " <
+  let g:spacevim_autocomplete_method = 'deoplete'
+elseif has('lua')
+  let g:spacevim_autocomplete_method = 'neocomplete'
+elseif has('python')
+  let g:spacevim_autocomplete_method = 'completor'
+elseif has('timers')
+  let g:spacevim_autocomplete_method = 'asyncomplete'
+else
+  let g:spacevim_autocomplete_method = 'neocomplcache'
+endif
 ""
 " SpaceVim default checker is neomake. If you want to use syntastic, use:
 " >
@@ -586,17 +611,6 @@ function! SpaceVim#end() abort
       call add(g:spacevim_plugin_groups, 'colorscheme')
     endif
 
-    if has('python3')
-      let g:spacevim_autocomplete_method = 'deoplete'
-    elseif has('lua')
-      let g:spacevim_autocomplete_method = 'neocomplete'
-    elseif has('python')
-      let g:spacevim_autocomplete_method = 'completor'
-    elseif has('timers')
-      let g:spacevim_autocomplete_method = 'asyncomplete'
-    else
-      let g:spacevim_autocomplete_method = 'neocomplcache'
-    endif
   endif
   ""
   " generate tags for SpaceVim

--- a/autoload/SpaceVim/layers/autocomplete.vim
+++ b/autoload/SpaceVim/layers/autocomplete.vim
@@ -62,6 +62,16 @@ function! SpaceVim#layers#autocomplete#plugins() abort
       call add(plugins, ['SpaceVim/nvim-yarp',  {'merged': 0}])
       call add(plugins, ['SpaceVim/vim-hug-neovim-rpc',  {'merged': 0}])
     endif
+  elseif g:spacevim_autocomplete_method == 'asyncomplete'
+    call add(plugins, ['prabirshrestha/asyncomplete.vim', {
+          \ 'loadconf' : 1,
+          \ 'merged' : 0,
+          \ }])
+  elseif g:spacevim_autocomplete_method == 'completor'
+    call add(plugins, ['maralla/completor.vim', {
+          \ 'loadconf' : 1,
+          \ 'merged' : 0,
+          \ }])
   endif
   if has('patch-7.4.774')
     call add(plugins, ['Shougo/echodoc.vim', {

--- a/autoload/SpaceVim/layers/autocomplete.vim
+++ b/autoload/SpaceVim/layers/autocomplete.vim
@@ -67,6 +67,10 @@ function! SpaceVim#layers#autocomplete#plugins() abort
           \ 'loadconf' : 1,
           \ 'merged' : 0,
           \ }])
+    call add(plugins, ['prabirshrestha/asyncomplete-buffer.vim', {
+          \ 'loadconf' : 1,
+          \ 'merged' : 0,
+          \ }])
   elseif g:spacevim_autocomplete_method == 'completor'
     call add(plugins, ['maralla/completor.vim', {
           \ 'loadconf' : 1,

--- a/autoload/SpaceVim/layers/autocomplete.vim
+++ b/autoload/SpaceVim/layers/autocomplete.vim
@@ -72,6 +72,12 @@ function! SpaceVim#layers#autocomplete#plugins() abort
           \ 'loadconf' : 1,
           \ 'merged' : 0,
           \ }])
+    if g:spacevim_snippet_engine ==# 'neosnippet'
+      call add(plugins, ['maralla/completor-neosnippet', {
+            \ 'loadconf' : 1,
+            \ 'merged' : 0,
+            \ }])
+    endif
   endif
   if has('patch-7.4.774')
     call add(plugins, ['Shougo/echodoc.vim', {

--- a/autoload/SpaceVim/layers/autocomplete.vim
+++ b/autoload/SpaceVim/layers/autocomplete.vim
@@ -71,6 +71,10 @@ function! SpaceVim#layers#autocomplete#plugins() abort
           \ 'loadconf' : 1,
           \ 'merged' : 0,
           \ }])
+    call add(plugins, ['yami-beta/asyncomplete-omni.vim', {
+          \ 'loadconf' : 1,
+          \ 'merged' : 0,
+          \ }])
   elseif g:spacevim_autocomplete_method == 'completor'
     call add(plugins, ['maralla/completor.vim', {
           \ 'loadconf' : 1,

--- a/autoload/SpaceVim/layers/lang/vim.vim
+++ b/autoload/SpaceVim/layers/lang/vim.vim
@@ -7,6 +7,12 @@ function! SpaceVim#layers#lang#vim#plugins() abort
   call add(plugins,['tweekmonster/exception.vim'])
   call add(plugins,['mhinz/vim-lookup'])
   call add(plugins,['Shougo/neco-vim',              { 'on_event' : 'InsertEnter', 'loadconf_before' : 1}])
+  if g:spacevim_autocomplete_method == 'asyncomplete'
+    call add(plugins, ['prabirshrestha/asyncomplete-necovim.vim', {
+          \ 'loadconf' : 1,
+          \ 'merged' : 0,
+          \ }])
+  endif
   call add(plugins,['tweekmonster/helpful.vim',      {'on_cmd': 'HelpfulVersion'}])
   return plugins
 endfunction
@@ -18,11 +24,11 @@ endfunction
 
 function! s:language_specified_mappings() abort
   call SpaceVim#mapping#space#langSPC('nmap', ['l','e'],  'call call('
-                \ . string(function('s:eval_cursor')) . ', [])',
-                \ 'echo eval under cursor', 1)
+        \ . string(function('s:eval_cursor')) . ', [])',
+        \ 'echo eval under cursor', 1)
   call SpaceVim#mapping#space#langSPC('nmap', ['l','v'],  'call call('
-                \ . string(function('s:helpversion_cursor')) . ', [])',
-                \ 'echo helpversion under cursor', 1)
+        \ . string(function('s:helpversion_cursor')) . ', [])',
+        \ 'echo helpversion under cursor', 1)
 endfunction
 
 function! s:eval_cursor() abort

--- a/config/plugins/asyncomplete-buffer.vim
+++ b/config/plugins/asyncomplete-buffer.vim
@@ -1,0 +1,6 @@
+au User asyncomplete_setup call asyncomplete#register_source(asyncomplete#sources#buffer#get_source_options({
+    \ 'name': 'B',
+    \ 'whitelist': ['*'],
+    \ 'blacklist': ['go'],
+    \ 'completor': function('asyncomplete#sources#buffer#completor'),
+    \ }))

--- a/config/plugins/asyncomplete-necovim.vim
+++ b/config/plugins/asyncomplete-necovim.vim
@@ -1,0 +1,5 @@
+au User asyncomplete_setup call asyncomplete#register_source(asyncomplete#sources#necovim#get_source_options({
+    \ 'name': 'necovim',
+    \ 'whitelist': ['vim'],
+    \ 'completor': function('asyncomplete#sources#necovim#completor'),
+    \ }))

--- a/config/plugins/asyncomplete-omni.vim
+++ b/config/plugins/asyncomplete-omni.vim
@@ -1,0 +1,6 @@
+au User asyncomplete_setup call asyncomplete#register_source(asyncomplete#sources#omni#get_source_options({
+      \ 'name': 'omni',
+      \ 'whitelist': ['*'],
+      \ 'blacklist': ['html'],
+      \ 'completor': function('asyncomplete#sources#omni#completor')
+      \  }))

--- a/doc/SpaceVim.txt
+++ b/doc/SpaceVim.txt
@@ -138,6 +138,22 @@ enable it:
   let g:spacevim_enable_key_frequency = 1
 <
 
+                                              *g:spacevim_autocomplete_method*
+Set the autocomplete engine of spacevim, the default logic is:
+>
+  if has('python3')
+    let g:spacevim_autocomplete_method = 'deoplete'
+  elseif has('lua')
+    let g:spacevim_autocomplete_method = 'neocomplete'
+  elseif has('python')
+    let g:spacevim_autocomplete_method = 'completor'
+  elseif has('timers')
+    let g:spacevim_autocomplete_method = 'asyncomplete'
+  else
+    let g:spacevim_autocomplete_method = 'neocomplcache'
+  endif
+<
+
                                                    *g:spacevim_enable_neomake*
 SpaceVim default checker is neomake. If you want to use syntastic, use:
 >


### PR DESCRIPTION
hi @maralla @prabirshrestha

Thanks for your work for vim's completions plugins, SpaceVim is a modularization vim config, it support neovim and vim8 in many case.

for autocompletion, the latest version of spacevim use deoplete ycm neocomplete etc, but it does not works well in many cases. for example: vim whithout python or python3 supports, 

I would like to add your plugins into spacevim, and the default logic is:

```vim
    " spacevim init 
    if has('python3')
      let g:spacevim_autocomplete_method = 'deoplete'
    elseif has('lua')
      let g:spacevim_autocomplete_method = 'neocomplete'
    elseif has('python')
      let g:spacevim_autocomplete_method = 'completor'
    elseif has('timers')
      let g:spacevim_autocomplete_method = 'asyncomplete'
    else
      let g:spacevim_autocomplete_method = 'neocomplcache'
    endif
" load custome config
" user can set the autocomplete methon or enable ycm 
"
"
"
    if g:spacevim_enable_neocomplcache
      let g:spacevim_autocomplete_method = 'neocomplcache'
    endif
    if g:spacevim_enable_ycm
      if has('python') || has('python3')
        let g:spacevim_autocomplete_method = 'ycm'
      else
        call SpaceVim#logger#warn('YCM need +python or +python3 support, force to using ' . g:spacevim_autocomplete_method)
      endif
    endif

```