### PR TITLE
Fix an issue occurd in ALE-enabled environment 

### DIFF
--- a/autoload/SpaceVim/layers/checkers.vim
+++ b/autoload/SpaceVim/layers/checkers.vim
@@ -21,6 +21,9 @@ endfunction
 
 
 function! SpaceVim#layers#checkers#config() abort
+  let g:neomake_cursormoved_delay = get(g:, 'neomake_cursormoved_delay', 300)
+  let g:ale_echo_delay = get(g:, 'ale_echo_delay', 300)
+
   call SpaceVim#mapping#space#def('nnoremap', ['e', 'c'], 'call call('
         \ . string(s:_function('s:clear_errors')) . ', [])',
         \ 'clear all errors', 1)
@@ -40,32 +43,38 @@ function! SpaceVim#layers#checkers#config() abort
 
   augroup SpaceVim_layer_checker
     autocmd!
-    if g:spacevim_enable_neomake 
-      autocmd User NeomakeFinished nested let &l:statusline = SpaceVim#layers#core#statusline#get(1)
+    if g:spacevim_enable_neomake
+      autocmd User NeomakeFinished nested
+            \ let &l:statusline = SpaceVim#layers#core#statusline#get(1)
+
+      " when move cursor, the error message will be shown below current line
+      " after a delay
+      autocmd CursorMoved * call <SID>neomake_cursor_move_delay()
+
+      " when switch to Insert mode, stop timer and clear the signature
+      if exists('##CmdLineEnter')
+        autocmd InsertEnter,WinLeave,CmdLineEnter *
+              \ call <SID>neomake_signatures_clear() | redraw
+      else
+        autocmd InsertEnter,WinLeave * call <SID>neomake_signatures_clear() | redraw
+      endif
     elseif g:spacevim_enable_ale
-      autocmd User ALELint let &l:statusline = SpaceVim#layers#core#statusline#get(1)
-    endif
-    " when move cursor, the error message will be shown below current line
-    " after a delay
-    autocmd CursorMoved * call <SID>cursor_move_delay()
-    " when switch to Insert mode, stop timer and clear the signature
-    if exists('##CmdLineEnter')
-      autocmd InsertEnter,WinLeave,CmdLineEnter * call <SID>signatures_clear() | redraw
-    else
-      autocmd InsertEnter,WinLeave * call <SID>signatures_clear() | redraw
+      autocmd User ALELint 
+            \ let &l:statusline = SpaceVim#layers#core#statusline#get(1)
     endif
   augroup END
 endfunction
 
-function! s:cursor_move_delay() abort
-  call s:signatures_clear()
-  let s:cursormoved_timer = timer_start(get(g:, 'neomake_cursormoved_delay', 300), function('s:signatures_current_error'))
+function! s:neomake_cursor_move_delay() abort
+  call s:neomake_signatures_clear()
+  let s:neomake_cursormoved_timer = timer_start(g:neomake_cursormoved_delay,
+        \ function('s:neomake_signatures_current_error'))
 endfunction
 
 let s:last_echoed_error = ''
 let s:clv = &conceallevel
-function! s:signatures_current_error(...) abort
-  call s:signatures_clear()
+function! s:neomake_signatures_current_error(...) abort
+  call s:neomake_signatures_clear()
   let message = neomake#GetCurrentErrorMsg()
   if empty(message)
     if exists('s:last_echoed_error')
@@ -85,9 +94,9 @@ function! s:signatures_current_error(...) abort
   call s:SIG.info(line('.') + 1, 1, message)
 endfunction
 
-function! s:signatures_clear() abort
-  if exists('s:cursormoved_timer') && s:cursormoved_timer != 0
-    call timer_stop(s:cursormoved_timer)
+function! s:neomake_signatures_clear() abort
+  if exists('s:neomake_cursormoved_timer') && s:neomake_cursormoved_timer != 0
+    call timer_stop(s:neomake_cursormoved_timer)
   endif
   let s:last_echoed_error = ''
   let &conceallevel = s:clv
@@ -104,13 +113,15 @@ endfunction
 
 function! s:error_transient_state() abort
   if g:spacevim_enable_neomake
-    let has_errors = neomake#statusline#LoclistCounts()
+    let num_errors = neomake#statusline#LoclistCounts()
   elseif g:spacevim_enable_ale
-    let has_errors = ''
+    let counts = ale#statusline#Count(buffer_name('%'))
+    let num_errors = counts.error + counts.warning + counts.style_error
+          \ + counts.style_warning
   else
-    let has_errors = ''
+    let num_errors = 0
   endif
-  if empty(has_errors)
+  if empty(num_errors)
     echo 'no buffers contain error message locations'
     return
   endif


### PR DESCRIPTION
## Changes

Fix an issue occurd in ALE-enabled environment 

* Disable caret move hooks unless using Neomake
* Minor fix for ALE plugin configurations

This PR fixes errors happening when opening buffers without Neomake.
I disabled message update feature when not using Neomake, because it's already implemented ALE plugin itself.