### PR TITLE
Update key bindings for debug layer

### DIFF
--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -430,7 +430,17 @@ let g:spacevim_enable_vimfiler_gitstatus = 0
 " Enable/Disable filetypeicon column in vimfiler buffer, default is 0.
 let g:spacevim_enable_vimfiler_filetypeicon = 0
 let g:spacevim_smartcloseignorewin     = ['__Tagbar__' , 'vimfiler:default']
-let g:spacevim_smartcloseignoreft      = ['help', 'tagbar', 'vimfiler', 'SpaceVimRunner', 'SpaceVimREPL', 'SpaceVimQuickFix', 'HelpDescribe']
+let g:spacevim_smartcloseignoreft      = [
+      \ 'help',
+      \ 'tagbar',
+      \ 'vimfiler',
+      \ 'SpaceVimRunner',
+      \ 'SpaceVimREPL',
+      \ 'SpaceVimQuickFix',
+      \ 'HelpDescribe',
+      \ 'VebuggerShell',
+      \ 'VebuggerTerminal',
+      \ ]
 let g:spacevim_altmoveignoreft         = ['Tagbar' , 'vimfiler']
 let g:spacevim_enable_javacomplete2_py = 0
 let g:spacevim_src_root                = 'E:\sources\'

--- a/autoload/SpaceVim/api/file.vim
+++ b/autoload/SpaceVim/api/file.vim
@@ -28,7 +28,7 @@ let s:file_node_extensions = {
       \  'json'     : '',
       \  'js'       : '',
       \  'jsx'      : '',
-      \  'rb'       : '',
+      \  'rb'       : '',
       \  'php'      : '',
       \  'py'       : '',
       \  'pyc'      : '',

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -357,6 +357,12 @@ function! SpaceVim#layers#core#statusline#get(...) abort
     return '%#SpaceVim_statusline_a# VimMail %#SpaceVim_statusline_a_SpaceVim_statusline_b# %{mail#client#win#status().dir}'
   elseif &filetype ==# 'SpaceVimQuickFix'
     return '%#SpaceVim_statusline_a# SpaceVimQuickFix %#SpaceVim_statusline_a_SpaceVim_statusline_b#'
+  elseif &filetype ==# 'VebuggerShell'
+    return '%#SpaceVim_statusline_ia#' . s:winnr(1) . '%#SpaceVim_statusline_ia_SpaceVim_statusline_b#' . s:lsep
+          \ . '%#SpaceVim_statusline_b# VebuggerShell %#SpaceVim_statusline_b_SpaceVim_statusline_c#' . s:lsep
+  elseif &filetype ==# 'VebuggerTerminal'
+    return '%#SpaceVim_statusline_ia#' . s:winnr(1) . '%#SpaceVim_statusline_ia_SpaceVim_statusline_b#' . s:lsep
+          \ . '%#SpaceVim_statusline_b# VebuggerTerminal %#SpaceVim_statusline_b_SpaceVim_statusline_c#' . s:lsep
   endif
   if a:0 > 0
     return s:active()

--- a/autoload/SpaceVim/layers/debug.vim
+++ b/autoload/SpaceVim/layers/debug.vim
@@ -1,9 +1,17 @@
 function! SpaceVim#layers#debug#plugins() abort
-    let plugins = []
-    call add(plugins,['idanarye/vim-vebugger', {'merged' : 0}])
-    return plugins
+  let plugins = []
+  call add(plugins,['idanarye/vim-vebugger', {'merged' : 0}])
+  return plugins
 endfunction
 
 function! SpaceVim#layers#debug#config() abort
-    
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'l'], 'call SpaceVim#layers#debug#launching(&ft)', 'launching debugger', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 't'], 'VBGtoggleBreakpointThisLine', 'Toggle a breakpoint for the current line', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'c'], 'VBGcontinue', 'Continue the execution', 1)
+endfunction
+
+function! SpaceVim#layers#debug#launching(ft) abort
+  if a:ft ==# 'python'
+    exe 'VBGstartPDB ' . bufname('%')
+  endif
 endfunction

--- a/autoload/SpaceVim/layers/debug.vim
+++ b/autoload/SpaceVim/layers/debug.vim
@@ -6,8 +6,17 @@ endfunction
 
 function! SpaceVim#layers#debug#config() abort
   call SpaceVim#mapping#space#def('nnoremap', ['d', 'l'], 'call SpaceVim#layers#debug#launching(&ft)', 'launching debugger', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['d', 't'], 'VBGtoggleBreakpointThisLine', 'Toggle a breakpoint for the current line', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'b'], 'VBGtoggleBreakpointThisLine', 'Toggle a breakpoint for the current line', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'B'], 'VBGclearBreakpoints', 'Clear all breakpoints', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['d', 'c'], 'VBGcontinue', 'Continue the execution', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'o'], 'VBGstepOver', 'step over', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'i'], 'VBGstepIn', 'step into functions', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'o'], 'VBGstepOut', 'step out of current function', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'k'], 'VBGkill', 'Terminates the debugger', 1)
+  let g:_spacevim_mappings_space.d.e = {'name' : '+Evaluate/Execute'}
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'e', 's'], 'VBGevalSelectedText', 'Evaluate and print the selected text', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'e', 'e'], 'VBGevalWordUnderCursor', 'Evaluate the <cword> under the cursor', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'e', 'S'], 'VBGexecuteSelectedText', 'Execute the selected text', 1)
 endfunction
 
 function! SpaceVim#layers#debug#launching(ft) abort

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -22,6 +22,7 @@ function! SpaceVim#mapping#space#init() abort
   let g:_spacevim_mappings_space.l = {'name' : '+Language Specified'}
   let g:_spacevim_mappings_space.s = {'name' : '+Searching'}
   let g:_spacevim_mappings_space.r = {'name' : '+Registers/rings/resume'}
+  let g:_spacevim_mappings_space.d = {'name' : '+Debug'}
   if s:has_map_to_spc()
     return
   endif

--- a/docs/layers/debug.md
+++ b/docs/layers/debug.md
@@ -1,0 +1,38 @@
+---
+title: "SpaceVim debug layer"
+description: "This layer provide debug workflow support in SpaceVim"
+---
+
+# [SpaceVim Layers:](https://spacevim.org/layers) debug
+
+<!-- vim-markdown-toc GFM -->
+
+- [Description](#description)
+- [Install](#install)
+- [Key bindings](#key-bindings)
+
+<!-- vim-markdown-toc -->
+
+## Description
+
+This layer provide a debug workflow for SpaceVim. All of the function is based on [vim-vebugger](https://github.com/idanarye/vim-vebugger).
+
+## Install
+
+To use this configuration layer, add `call SpaceVim#layers#load('debug')` to your custom configuration file.
+
+## Key bindings
+
+| Key Binding | Description                              |
+| ----------- | ---------------------------------------- |
+| `SPC d l`   | launching debugger                       |
+| `SPC d c`   | Continue the execution                   |
+| `SPC d b`   | Toggle a breakpoint for the current line |
+| `SPC d B`   | Clear all breakpoints                    |
+| `SPC d o`   | step over                                |
+| `SPC d i`   | step into functions                      |
+| `SPC d O`   | step out of current function             |
+| `SPC d e s` | Evaluate and print the selected text     |
+| `SPC d e e` | Evaluate the `<cword>` under the cursor  |
+| `SPC d e S` | Execute the selected text                |
+| `SPC d k`   | Terminates the debugger                  |


### PR DESCRIPTION
| Key Binding | Description                              |
| ----------- | ---------------------------------------- |
| `SPC d l`   | launching debugger                       |
| `SPC d c`   | Continue the execution                   |
| `SPC d b`   | Toggle a breakpoint for the current line |
| `SPC d B`   | Clear all breakpoints                    |
| `SPC d o`   | step over                                |
| `SPC d i`   | step into functions                      |
| `SPC d O`   | step out of current function             |
| `SPC d e s` | Evaluate and print the selected text     |
| `SPC d e e` | Evaluate the `<cword>` under the cursor  |
| `SPC d e S` | Execute the selected text                |
| `SPC d k`   | Terminates the debugger                  |



![2017-12-13-21-40-59](https://user-images.githubusercontent.com/13142418/33941951-fae9ff14-dfd9-11e7-81b8-512787f6313b.gif)

plugin: https://github.com/idanarye/vim-vebugger