### PR TITLE
Update JavaScript language server

### DIFF
--- a/autoload/SpaceVim/layers/lsp.vim
+++ b/autoload/SpaceVim/layers/lsp.vim
@@ -71,7 +71,7 @@ endfunction
 let s:enabled_fts = []
 
 let s:lsp_servers = {
-      \ 'javascript' : ['javascript-typescript-stdio'],
+      \ 'javascript' : ['typescript-language-server', '--stdio'],
       \ 'haskell' : ['hie', '--lsp'],
       \ 'c' : ['clangd'],
       \ 'cpp' : ['clangd'],


### PR DESCRIPTION
* Deprecate `javascript-typescript-stdio`
* Add `typescript-language-server`

# PR Prelude

Thank you for working on SpaceVim! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

* `javascript-typescript-stdio` actually uses TypeScript server, and pure TypeScript server has more LSP features.

[cont]: https://github.com/SpaceVim/SpaceVim/blob/dev/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/dev/CODE_OF_CONDUCT.md
