### PR TITLE
[SPC b t] Open Vimfiler by buffer file dir

### DIFF
--- a/autoload/SpaceVim/layers/default.vim
+++ b/autoload/SpaceVim/layers/default.vim
@@ -158,6 +158,7 @@ function! SpaceVim#layers#default#config() abort
   if g:spacevim_filemanager ==# 'vimfiler'
     call SpaceVim#mapping#space#def('nnoremap', ['f', 't'], 'VimFiler', 'toggle_file_tree', 1)
     call SpaceVim#mapping#space#def('nnoremap', ['f', 'T'], 'VimFiler -no-toggle', 'show_file_tree', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['b', 't'], 'VimFilerBufferDir -no-toggle', 'show_file_tree_at_buffer_dir', 1)
   elseif g:spacevim_filemanager ==# 'nerdtree'
     call SpaceVim#mapping#space#def('nnoremap', ['f', 't'], 'NERDTreeToggle', 'toggle_file_tree', 1)
     call SpaceVim#mapping#space#def('nnoremap', ['f', 't'], 'NERDTree', 'toggle_file_tree', 1)


### PR DESCRIPTION
By default, `:Vimfiler` opens file tree at project dir, but sometimes we may prefer to look around (for example by "../" or "child/" at current buffer file dir).  Therefore I add a key binding under `SPC b` for that.
