### PR TITLE
Fix 'defined' typos in plugin help

### DIFF
--- a/autoload/SpaceVim/plugins/help.vim
+++ b/autoload/SpaceVim/plugins/help.vim
@@ -13,12 +13,12 @@ endfunction
 
 
 function! SpaceVim#plugins#help#describe_key()
-    let definded = 1
+    let defined = 1
     let root = s:key_describ
     let prompt = 'Describe key:'
     let keys = []
     call s:build_mpt(prompt)
-    while definded
+    while defined
         let key = getchar()
         let name = s:KEY.nr2name(key)
         call add(keys, name)
@@ -31,16 +31,16 @@ function! SpaceVim#plugins#help#describe_key()
                 else
                     call s:build_mpt(['can not find describe for ', join(keys, ' - ')])
                 endif
-                let definded = 0
+                let defined = 0
             else
                 call s:build_mpt([prompt, join(keys + [''], ' - ')])
             endif
         else
             redraw!
             echohl Comment
-            echo   join(keys, ' - ') . ' is undfinded'
+            echo   join(keys, ' - ') . ' is undefined'
             echohl NONE
-            let definded = 0
+            let defined = 0
         endif
     endwhile
 endfunction


### PR DESCRIPTION
# PR Prelude

Thank you for working on SpaceVim! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

It's just a typo fix!

[cont]: https://github.com/SpaceVim/SpaceVim/blob/dev/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/dev/CODE_OF_CONDUCT.md
