### PR TITLE
Fix language client config

### DIFF
--- a/autoload/SpaceVim/layers/lsp.vim
+++ b/autoload/SpaceVim/layers/lsp.vim
@@ -3,7 +3,7 @@ function! SpaceVim#layers#lsp#plugins() abort
 
   if has('nvim')
     call add(plugins, ['SpaceVim/LanguageClient-neovim',
-          \ { 'merged': 0, 'if': has('python3') }])
+          \ { 'merged': 0, 'if': has('python3'), 'loadconf_before': 1 }])
   else
     call add(plugins, ['prabirshrestha/async.vim', {'merged' : 0}])
     call add(plugins, ['prabirshrestha/vim-lsp', {'merged' : 0}])
@@ -13,57 +13,10 @@ function! SpaceVim#layers#lsp#plugins() abort
 endfunction
 
 function! SpaceVim#layers#lsp#config() abort
-  " SpaceVim/LanguageClient-neovim {{{
-  let g:LanguageClient_diagnosticsDisplay = {
-        \ 1: {
-        \ 'name': 'Error',
-        \ 'signText': g:spacevim_error_symbol,
-        \ },
-        \ 2: {
-        \ 'name': 'Warning',
-        \ 'signText': g:spacevim_warning_symbol,
-        \ },
-        \ 3: {
-        \ 'name': 'Information',
-        \ 'signText': g:spacevim_info_symbol,
-        \ },
-        \ 4: {
-        \ 'name': 'Hint',
-        \ 'signText': g:spacevim_info_symbol,
-        \ },
-        \ }
-
-  if g:spacevim_enable_neomake
-    let g:LanguageClient_diagnosticsDisplay[1].texthl = 'NeomakeError'
-    let g:LanguageClient_diagnosticsDisplay[1].signTexthl = 'NeomakeErrorSign'
-
-    let g:LanguageClient_diagnosticsDisplay[2].texthl = 'NeomakeWarning'
-    let g:LanguageClient_diagnosticsDisplay[2].signTexthl = 
-          \ 'NeomakeWarningSign'
-
-    let g:LanguageClient_diagnosticsDisplay[3].texthl = 'NeomakeInfo'
-    let g:LanguageClient_diagnosticsDisplay[3].signTexthl = 'NeomakeInfoSign'
-
-    let g:LanguageClient_diagnosticsDisplay[4].texthl = 'NeomakeMessage'
-    let g:LanguageClient_diagnosticsDisplay[4].signTexthl = 
-          \ 'NeomakeMessageSign'
-  elseif g:spacevim_enable_ale
-    let g:LanguageClient_diagnosticsDisplay[1].texthl = 'ALEError'
-    let g:LanguageClient_diagnosticsDisplay[1].signTexthl = 'ALEErrorSign'
-
-    let g:LanguageClient_diagnosticsDisplay[2].texthl = 'ALEWarning'
-    let g:LanguageClient_diagnosticsDisplay[2].signTexthl = 'ALEWarningSign'
-
-    let g:LanguageClient_diagnosticsDisplay[3].texthl = 'ALEInfo'
-    let g:LanguageClient_diagnosticsDisplay[3].signTexthl = 'ALEInfoSign'
-
-    let g:LanguageClient_diagnosticsDisplay[4].texthl = 'ALEInfo'
-    let g:LanguageClient_diagnosticsDisplay[4].signTexthl = 'ALEInfoSign'
-  endif
-
-  let g:LanguageClient_autoStart = 1
+  " prabirshrestha/vim-lsp {{{
   let g:lsp_async_completion = 1
   " }}}
+
   for ft in s:enabled_fts
     call SpaceVim#lsp#reg_server(ft, s:lsp_servers[ft])
   endfor

--- a/config/plugins_before/LanguageClient-neovim.vim
+++ b/config/plugins_before/LanguageClient-neovim.vim
@@ -1,0 +1,56 @@
+"=============================================================================
+" LanguageClient-neovim.vim
+" Copyright (c) 2012-2016 Shidong Wang & Contributors
+" Author: Seong Yong-ju <sei40kr@gmail.com>
+" URL: https://spacevim.org
+" License: MIT license
+"=============================================================================
+
+let g:LanguageClient_autoStart = 1
+
+let g:LanguageClient_diagnosticsDisplay = {
+      \ 1: {
+      \ 'name': 'Error',
+      \ 'signText': g:spacevim_error_symbol,
+      \ },
+      \ 2: {
+      \ 'name': 'Warning',
+      \ 'signText': g:spacevim_warning_symbol,
+      \ },
+      \ 3: {
+      \ 'name': 'Information',
+      \ 'signText': g:spacevim_info_symbol,
+      \ },
+      \ 4: {
+      \ 'name': 'Hint',
+      \ 'signText': g:spacevim_info_symbol,
+      \ },
+      \ }
+
+if g:spacevim_enable_neomake
+  let g:LanguageClient_diagnosticsDisplay[1].texthl = 'NeomakeError'
+  let g:LanguageClient_diagnosticsDisplay[1].signTexthl = 'NeomakeErrorSign'
+
+  let g:LanguageClient_diagnosticsDisplay[2].texthl = 'NeomakeWarning'
+  let g:LanguageClient_diagnosticsDisplay[2].signTexthl = 
+        \ 'NeomakeWarningSign'
+
+  let g:LanguageClient_diagnosticsDisplay[3].texthl = 'NeomakeInfo'
+  let g:LanguageClient_diagnosticsDisplay[3].signTexthl = 'NeomakeInfoSign'
+
+  let g:LanguageClient_diagnosticsDisplay[4].texthl = 'NeomakeMessage'
+  let g:LanguageClient_diagnosticsDisplay[4].signTexthl = 
+        \ 'NeomakeMessageSign'
+elseif g:spacevim_enable_ale
+  let g:LanguageClient_diagnosticsDisplay[1].texthl = 'ALEError'
+  let g:LanguageClient_diagnosticsDisplay[1].signTexthl = 'ALEErrorSign'
+
+  let g:LanguageClient_diagnosticsDisplay[2].texthl = 'ALEWarning'
+  let g:LanguageClient_diagnosticsDisplay[2].signTexthl = 'ALEWarningSign'
+
+  let g:LanguageClient_diagnosticsDisplay[3].texthl = 'ALEInfo'
+  let g:LanguageClient_diagnosticsDisplay[3].signTexthl = 'ALEInfoSign'
+
+  let g:LanguageClient_diagnosticsDisplay[4].texthl = 'ALEInfo'
+  let g:LanguageClient_diagnosticsDisplay[4].signTexthl = 'ALEInfoSign'
+endif


### PR DESCRIPTION
# Changes

* Extract config for LanguageClient-neovim.vim to a file
* Fix an issue the client ignores settings after launching Neovim with no parameters

# PR Prelude

Thank you for working on SpaceVim! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

To fix an issue SpaceVim won't configure the signs of errors of LSP linter, when no file specified on launch

[cont]: https://github.com/SpaceVim/SpaceVim/blob/dev/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/dev/CODE_OF_CONDUCT.md
