### PR TITLE
Add a new plugin into javascript layer

### DIFF
--- a/autoload/SpaceVim/layers/lang/javascript.vim
+++ b/autoload/SpaceVim/layers/lang/javascript.vim
@@ -3,6 +3,7 @@ function! SpaceVim#layers#lang#javascript#plugins() abort
      \ ['MaxMEllon/vim-jsx-pretty', { 'on_ft': 'javascript' }],
      \ ['Galooshi/vim-import-js', {
      \ 'on_ft': 'javascript', 'build' : 'npm install -g import-js' }],
+     \ ['heavenshell/vim-jsdoc', { 'on_cmd': 'JsDoc' }],
      \ ['maksimr/vim-jsbeautify', { 'on_ft': 'javascript' }],
      \ ['mmalecki/vim-node.js', { 'on_ft': 'javascript' }],
      \ ['moll/vim-node', { 'on_ft': 'javascript' }],
@@ -100,6 +101,22 @@ function! s:on_ft() abort
   inoremap <silent><buffer> <C-j>i <Esc>:ImportJSWord<CR>a
   inoremap <silent><buffer> <C-j>f <Esc>:ImportJSFix<CR>a
   inoremap <silent><buffer> <C-j>g <Esc>:ImportJSGoto<CR>a
+  " }}}
+
+  " heavenshell/vim-jsdoc {{{
+
+  " Allow prompt for interactive input.
+  let g:jsdoc_allow_input_prompt = 1
+
+  " Prompt for a function description
+  let g:jsdoc_input_description = 1
+
+  " Set value to 1 to turn on detecting underscore starting functions as private convention
+  let g:jsdoc_underscore_private = 1
+
+  " Enable to use ECMAScript6's Shorthand function, Arrow function.
+  let g:jsdoc_enable_es6 = 1
+
   " }}}
 
   if SpaceVim#layers#lsp#check_filetype('javascript')

--- a/autoload/SpaceVim/layers/lang/javascript.vim
+++ b/autoload/SpaceVim/layers/lang/javascript.vim
@@ -133,6 +133,11 @@ function! s:on_ft() abort
           \ 'rename symbol', 1)
   endif
 
+  let g:_spacevim_mappings_space.l.g = {'name' : '+Generate'}
+
+  call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'g', 'd'], 'JsDoc',
+        \ 'generate JSDoc', 1)
+
   call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'r'],
         \ 'call SpaceVim#plugins#runner#open()', 'execute current file', 1)
 endfunction

--- a/docs/layers/lang/javascript.md
+++ b/docs/layers/lang/javascript.md
@@ -11,6 +11,9 @@ description: "This layer is for JaveScript development"
 - [Install](#install)
 - [Features](#features)
 - [Layer configuration](#layer-configuration)
+- [Key bindings](#key-bindings)
+  - [Import key bindings](#import-key-bindings)
+  - [Generate key bindings](#generate-key-bindings)
 
 <!-- vim-markdown-toc -->
 
@@ -41,3 +44,23 @@ call SpaceVim#layers#load('lang#javascript',
             \ )
 
 ```
+
+## Key bindings
+
+### Import key bindings
+
+| Key Binding          | Description                     |
+| -------------------- | ------------------------------- |
+| `F4` (Insert/Normal) | Import symbol under cursor      |
+| `SPC j i`            | Import symbol under cursor      |
+| `SPC j f`            | Import missing symbols          |
+| `SPC j g`            | Jump to module under cursor     |
+| `<C-j>i` (Insert)    | Import symbol under cursor      |
+| `<C-j>f` (Insert)    | Import missing symbols          |
+| `<C-j>g` (Insert)    | Jump to module under cursor     |
+
+### Generate key bindings
+
+| Mode          | Key Binding | Description                           |
+| ------------- | ----------- | ------------------------------------- |
+| normal        | `SPC l g d` | Generate JSDoc                        |


### PR DESCRIPTION
# Changes

Add a new plugin `heavenshell/vim-jsdoc`, to generate JSDoc annotations
interactively.

# PR Prelude

Thank you for working on SpaceVim! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This plugin provides code generation for JSDoc annotation.
It reads function signature automatically and it can be loaded lazily.

[cont]: https://github.com/SpaceVim/SpaceVim/blob/dev/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/dev/CODE_OF_CONDUCT.md
