### PR TITLE
Add vim-pydocstring

### DIFF
--- a/.SpaceVim.d/autoload/SpaceVim/dev/reddit.vim
+++ b/.SpaceVim.d/autoload/SpaceVim/dev/reddit.vim
@@ -1,4 +1,4 @@
-let s:url = 
+let s:url = ''
 
 let s:api = '/api/site_admin'
 

--- a/autoload/SpaceVim/layers/lang/python.vim
+++ b/autoload/SpaceVim/layers/lang/python.vim
@@ -18,6 +18,8 @@ function! SpaceVim#layers#lang#python#plugins() abort
             \ 'if' : has('python') || has('python3')}])
     endif
   endif
+  call add(plugins, ['heavenshell/vim-pydocstring',
+        \ { 'on_cmd' : 'Pydocstring'}])
   call add(plugins, ['Vimjas/vim-python-pep8-indent', 
         \ { 'on_ft' : 'python'}])
   call add(plugins, ['tell-k/vim-autoflake', {'merged' : 0}])
@@ -25,6 +27,20 @@ function! SpaceVim#layers#lang#python#plugins() abort
 endfunction
 
 function! SpaceVim#layers#lang#python#config() abort
+  " heavenshell/vim-pydocstring {{{
+
+  " If you execute :Pydocstring at no `def`, `class` line.
+  " g:pydocstring_enable_comment enable to put comment.txt value.
+  let g:pydocstring_enable_comment = 0
+
+  " Disable this option to prevent pydocstring from creating any
+  " key mapping to the `:Pydocstring` command.
+  " Note: this value is overridden if you explicitly create a
+  " mapping in your vimrc, such as if you do:
+  let g:pydocstring_enable_mapping = 0
+
+  " }}}
+
   call SpaceVim#plugins#runner#reg_runner('python', 'python %s')
   call SpaceVim#mapping#space#regesit_lang_mappings('python', funcref('s:language_specified_mappings'))
   call SpaceVim#layers#edit#add_ft_head_tamplate('python',

--- a/autoload/SpaceVim/layers/lang/python.vim
+++ b/autoload/SpaceVim/layers/lang/python.vim
@@ -80,6 +80,16 @@ function! s:language_specified_mappings() abort
   call SpaceVim#mapping#space#langSPC('nmap', ['l','s', 's'],
         \ 'call SpaceVim#plugins#repl#send("selection")',
         \ 'send selection and keep code buffer focused', 1)
+
+  " +Generate {{{
+
+  let g:_spacevim_mappings_space.l.g = {'name' : '+Generate'}
+
+  call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'g', 'd'],
+        \ 'Pydocstring', 'generate docstring', 1)
+
+  " }}}
+
   if SpaceVim#layers#lsp#check_filetype('python')
     nnoremap <silent><buffer> K :call SpaceVim#lsp#show_doc()<CR>
 

--- a/docs/layers/lang/python.md
+++ b/docs/layers/lang/python.md
@@ -15,6 +15,7 @@ description: "This layer is for Python development, provide autocompletion, synt
   - [Buffer formatting](#buffer-formatting)
   - [Format imports](#format-imports)
 - [Key bindings](#key-bindings)
+  - [Code generation](#code-generation)
   - [Inferior REPL process](#inferior-repl-process)
   - [Running current script](#running-current-script)
   - [Testing](#testing)
@@ -68,6 +69,12 @@ pip install --user isort
 ```
 
 ## Key bindings
+
+### Code generation
+
+| Mode   | Key Binding | Description                           |
+| ------ | ----------- | ------------------------------------- |
+| normal | `SPC l g d` | Generate docstring                    |
 
 ### Inferior REPL process
 


### PR DESCRIPTION
# PR Prelude

- [x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Add a plugin into `lang/python` layer, to generate docstring easily.
It's loaded lazily so it doesn't affect start-up performance much.

[cont]: https://github.com/SpaceVim/SpaceVim/blob/dev/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/dev/CODE_OF_CONDUCT.md
