### PR TITLE
Fix an issue of Vimfiler

### DIFF
--- a/autoload/SpaceVim/layers/unite.vim
+++ b/autoload/SpaceVim/layers/unite.vim
@@ -74,7 +74,7 @@ function! SpaceVim#layers#unite#plugins() abort
   endif
 
   if g:spacevim_filemanager ==# 'vimfiler'
-    call add(plugins, ['Shougo/vimfiler.vim',{'merged' : 0, 'loadconf' : 1 , 'loadconf_before' : 1, 'on_cmd' : 'VimFiler'}])
+    call add(plugins, ['Shougo/vimfiler.vim',{'merged' : 0, 'loadconf' : 1 , 'loadconf_before' : 1, 'on_cmd' : ['VimFiler', 'VimFilerBufferDir']}])
   endif
   return plugins
 endfunction


### PR DESCRIPTION
Fix an issue Vimfiler won't be loaded in some situations.

# Changes

* Add `VimFilerBufferDir` to dein option `on_cmd`

# PR Prelude

- [x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This PR fixes an issue Vimfiler won't be loaded when `SPC b t` pressed before loading Vimfiler.

[cont]: https://github.com/SpaceVim/SpaceVim/blob/dev/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/dev/CODE_OF_CONDUCT.md
