### PR TITLE
wget isn't installed on all systems by default (like mine). Use curl …

### DIFF
--- a/docs/install.sh
+++ b/docs/install.sh
@@ -212,7 +212,7 @@ download_font () {
         success "Downloaded $1"
     else
         info "Downloading $1"
-        wget -q -O "$path" "$url"
+        curl -s -o "$path" "$url"
         success "Downloaded $1"
     fi
 }


### PR DESCRIPTION
…instead

# PR Prelude

Thank you for working on SpaceVim! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [ x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [ x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful
install.sh assumes that wget is installed on system. Many systems, like mine, don't have wget installed by default. Using curl simplifies things as curl is installed on wider range of systems. Tested on Arch, FreeBSD, and OS X High Sierra with fish, bash, and zsh shell.

[Please explain **in detail** why the changes in this PR are needed.]
Without these changes, downloading of fonts via wget fails.

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md
