### PR TITLE
Fix typos in lang#c layer

### DIFF
--- a/autoload/SpaceVim/layers/lang/c.vim
+++ b/autoload/SpaceVim/layers/lang/c.vim
@@ -115,7 +115,7 @@ function! s:language_specified_mappings() abort
   call SpaceVim#mapping#space#langSPC('nmap', ['l','r'],
         \ 'call SpaceVim#plugins#runner#open()',
         \ 'execute current file', 1)
-  if SpaceVim#layers#lsp#check_filetype('python')
+  if SpaceVim#layers#lsp#check_filetype('c')
     nnoremap <silent><buffer> K :call SpaceVim#lsp#show_doc()<CR>
 
     call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'd'],
@@ -159,7 +159,7 @@ elseif g:spacevim_enable_ale
     " g:ale_c_clang_options
     for ft in a:fts
       let g:ale_{ft}_clang_options = ' -fsyntax-only -Wall -Wextra -I./ ' . join(a:argv, ' ')
-      let g:ale_{ft}_clang_executabl = s:clang_executable
+      let g:ale_{ft}_clang_executable = s:clang_executable
     endfor
   endfunction
 else


### PR DESCRIPTION
# PR Prelude

- [x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Fix typos in lang#c layer. It enables to use LSP features (documentation, go to declaration...) in C/C++ languages.

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md
