### PR TITLE
Supporting eex in the elixir layer

### DIFF
--- a/autoload/SpaceVim/layers/lang/elixir.vim
+++ b/autoload/SpaceVim/layers/lang/elixir.vim
@@ -9,7 +9,7 @@
 
 function! SpaceVim#layers#lang#elixir#plugins() abort
   let plugins = []
-  call add(plugins, ['elixir-editors/vim-elixir', {'on_ft' : 'elixir'}])
+  call add(plugins, ['elixir-editors/vim-elixir', {'on_ft' : ['elixir', 'eelixir']}])
   call add(plugins, ['slashmili/alchemist.vim', {'on_ft' : 'elixir'}])
   return plugins
 endfunction


### PR DESCRIPTION
- [x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

The vim-elixir supports ftype elixir and eelixir which is used in `eex` templates. This is commonly used in HTML projects. I wasn't able to find any testing related to the elixir layer. 

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md
