### PR TITLE
fix layers html table

### DIFF
--- a/docs/layers/index.md
+++ b/docs/layers/index.md
@@ -83,6 +83,7 @@ call SpaceVim#layers#disable('shell')
 | [tags](https://spacevim.org/layers/tags/)    |   This layer provide tags manager for project | 
 | [tools#dash](https://spacevim.org/layers/tools/dash/)    |   This layer provides Dash integration for SpaceVim | 
 | [ui](https://spacevim.org/layers/ui/)    |   Awesome UI layer for SpaceVim, provide IDE-like UI for neovim and vim in both TUI and GUI | 
+
 <!-- SpaceVim layer list end -->
 
 <!-- vim:set nowrap: -->


### PR DESCRIPTION
# PR Prelude

Thank you for working on SpaceVim! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This makes the markdown table parsed properly while html is generated. Right now, on https://spacevim.org/layers/#available-layers, it looks like below:

![layers-table](https://user-images.githubusercontent.com/1886670/36639700-1a11f2a6-19d8-11e8-9c44-e0d9a44952af.png)

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md
