### PR TITLE
Improve denite layer

### DIFF
--- a/autoload/SpaceVim/layers/denite.vim
+++ b/autoload/SpaceVim/layers/denite.vim
@@ -16,6 +16,23 @@ endfunction
 function! SpaceVim#layers#denite#config() abort
   call SpaceVim#mapping#space#def('nnoremap', ['j', 'i'], 'Denite outline', 'jump to a definition in buffer', 1)
   nnoremap <silent> <C-p> :Denite file_rec<cr>
+  let g:_spacevim_mappings.f = {'name' : '+Fuzzy Finder'}
+  call s:defind_fuzzy_finder()
 endfunction
 
+let s:file = expand('<sfile>:~')
+let s:unite_lnum = expand('<slnum>') + 3
+function! s:defind_fuzzy_finder() abort
+  nnoremap <silent> <Leader>fr
+        \ :<C-u>Denite -buffer-name=resume resume<CR>
+  let lnum = expand('<slnum>') + s:unite_lnum - 4
+  let g:_spacevim_mappings.f.r = ['Denite -buffer-name=resume resume',
+        \ 'resume unite window',
+        \ [
+        \ '[Leader f r ] is to resume unite window',
+        \ '',
+        \ 'Definition: ' . s:file . ':' . lnum,
+        \ ]
+        \ ]
+endfunction
 " vim:set et sw=2 cc=80:

--- a/autoload/SpaceVim/layers/denite.vim
+++ b/autoload/SpaceVim/layers/denite.vim
@@ -14,6 +14,8 @@ function! SpaceVim#layers#denite#plugins() abort
 
   " neoyark source <Leader>fh
   call add(plugins, ['Shougo/neoyank.vim', {'merged' : 0}])
+  call add(plugins, ['chemzqm/unite-location', {'merged' : 0}])
+  call add(plugins, ['Shougo/unite-outline', {'merged' : 0}])
   return plugins
 endfunction
 
@@ -57,6 +59,60 @@ function! s:defind_fuzzy_finder() abort
         \ 'fuzzy find yank history',
         \ [
         \ '[Leader f h] is to fuzzy find history and yank content',
+        \ '',
+        \ 'Definition: ' . s:file . ':' . lnum,
+        \ ]
+        \ ]
+  nnoremap <silent> <Leader>fj
+        \ :<C-u>Denite jump<CR>
+  let lnum = expand('<slnum>') + s:unite_lnum - 4
+  let g:_spacevim_mappings.f.j = ['Denite jump',
+        \ 'fuzzy find jump list',
+        \ [
+        \ '[Leader f j] is to fuzzy find jump list',
+        \ '',
+        \ 'Definition: ' . s:file . ':' . lnum,
+        \ ]
+        \ ]
+  nnoremap <silent> <Leader>fl
+        \ :<C-u>Denite location_list<CR>
+  let lnum = expand('<slnum>') + s:unite_lnum - 4
+  let g:_spacevim_mappings.f.l = ['Denite location_list',
+        \ 'fuzzy find location list',
+        \ [
+        \ '[Leader f l] is to fuzzy find location list',
+        \ '',
+        \ 'Definition: ' . s:file . ':' . lnum,
+        \ ]
+        \ ]
+  nnoremap <silent> <Leader>fm
+        \ :<C-u>Denite output:message<CR>
+  let lnum = expand('<slnum>') + s:unite_lnum - 4
+  let g:_spacevim_mappings.f.m = ['Denite output:message',
+        \ 'fuzzy find message',
+        \ [
+        \ '[Leader f m] is to fuzzy find message',
+        \ '',
+        \ 'Definition: ' . s:file . ':' . lnum,
+        \ ]
+        \ ]
+  nnoremap <silent> <Leader>fq
+        \ :<C-u>Denite quickfix<CR>
+  let lnum = expand('<slnum>') + s:unite_lnum - 4
+  let g:_spacevim_mappings.f.q = ['Denite quickfix',
+        \ 'fuzzy find quickfix list',
+        \ [
+        \ '[Leader f q] is to fuzzy find quickfix list',
+        \ '',
+        \ 'Definition: ' . s:file . ':' . lnum,
+        \ ]
+        \ ]
+  nnoremap <silent> <Leader>fo  :<C-u>Denite outline<CR>
+  let lnum = expand('<slnum>') + s:unite_lnum - 4
+  let g:_spacevim_mappings.f.o = ['Denite outline',
+        \ 'fuzzy find outline',
+        \ [
+        \ '[Leader f o] is to fuzzy find outline',
         \ '',
         \ 'Definition: ' . s:file . ':' . lnum,
         \ ]

--- a/autoload/SpaceVim/layers/denite.vim
+++ b/autoload/SpaceVim/layers/denite.vim
@@ -50,5 +50,16 @@ function! s:defind_fuzzy_finder() abort
         \ 'Definition: ' . s:file . ':' . lnum,
         \ ]
         \ ]
+  nnoremap <silent> <Leader>fh
+        \ :<C-u>Denite neoyank<CR>
+  let lnum = expand('<slnum>') + s:unite_lnum - 4
+  let g:_spacevim_mappings.f.h = ['Denite neoyank',
+        \ 'fuzzy find yank history',
+        \ [
+        \ '[Leader f h] is to fuzzy find history and yank content',
+        \ '',
+        \ 'Definition: ' . s:file . ':' . lnum,
+        \ ]
+        \ ]
 endfunction
 " vim:set et sw=2 cc=80:

--- a/autoload/SpaceVim/layers/denite.vim
+++ b/autoload/SpaceVim/layers/denite.vim
@@ -7,15 +7,20 @@
 "=============================================================================
 
 function! SpaceVim#layers#denite#plugins() abort
-  return [
+  let plugins = [
         \ ['Shougo/denite.nvim',{ 'merged' : 0, 'loadconf' : 1}],
         \ ['pocari/vim-denite-emoji', {'merged' : 0}],
         \ ]
+
+  " neoyark source <Leader>fh
+  call add(plugins, ['Shougo/neoyank.vim', {'merged' : 0}])
+  return plugins
 endfunction
 
 function! SpaceVim#layers#denite#config() abort
   call SpaceVim#mapping#space#def('nnoremap', ['j', 'i'], 'Denite outline', 'jump to a definition in buffer', 1)
   nnoremap <silent> <C-p> :Denite file_rec<cr>
+  call SpaceVim#mapping#space#def('nnoremap', ['T', 's'], 'Denite colorscheme', 'fuzzy find colorschemes', 1)
   let g:_spacevim_mappings.f = {'name' : '+Fuzzy Finder'}
   call s:defind_fuzzy_finder()
 endfunction
@@ -28,6 +33,17 @@ function! s:defind_fuzzy_finder() abort
   let lnum = expand('<slnum>') + s:unite_lnum - 4
   let g:_spacevim_mappings.f.r = ['Denite -buffer-name=resume resume',
         \ 'resume unite window',
+        \ [
+        \ '[Leader f r ] is to resume unite window',
+        \ '',
+        \ 'Definition: ' . s:file . ':' . lnum,
+        \ ]
+        \ ]
+  nnoremap <silent> <Leader>fe
+        \ :<C-u>Denite register<CR>
+  let lnum = expand('<slnum>') + s:unite_lnum - 4
+  let g:_spacevim_mappings.f.r = ['Denite register',
+        \ 'fuzzy find registers',
         \ [
         \ '[Leader f r ] is to resume unite window',
         \ '',

--- a/autoload/SpaceVim/layers/unite.vim
+++ b/autoload/SpaceVim/layers/unite.vim
@@ -161,8 +161,7 @@ function! s:defind_fuzzy_finder() abort
         \ 'Definition: ' . s:file . ':' . lnum,
         \ ]
         \ ]
-  nnoremap <silent> <Leader>fo  :<C-u>Unite -buffer-name=outline
-        \ -start-insert -auto-preview -split outline<CR>
+  nnoremap <silent> <Leader>fo  :<C-u>Unite outline<CR>
   let lnum = expand('<slnum>') + s:unite_lnum - 4
   let g:_spacevim_mappings.f.o = ['Unite outline',
         \ 'fuzzy find outline',

--- a/autoload/SpaceVim/layers/unite.vim
+++ b/autoload/SpaceVim/layers/unite.vim
@@ -110,7 +110,7 @@ function! s:defind_fuzzy_finder() abort
         \ :<C-u>Unite history/yank<CR>
   let lnum = expand('<slnum>') + s:unite_lnum - 4
   let g:_spacevim_mappings.f.h = ['Unite history/yank',
-        \ 'fuzzy find history/yank',
+        \ 'fuzzy find yank history',
         \ [
         \ '[Leader f h] is to fuzzy find history and yank content',
         \ '',

--- a/autoload/SpaceVim/layers/unite.vim
+++ b/autoload/SpaceVim/layers/unite.vim
@@ -19,9 +19,9 @@ function! SpaceVim#layers#unite#plugins() abort
         \ ['wsdjeg/unite-radio.vim', {'loadconf' : 1, 'merged' : 0}],
         \ ]
 
-        " \ ['mileszs/ack.vim',{'on_cmd' : 'Ack'}],
-        " \ ['albfan/ag.vim',{'on_cmd' : 'Ag' , 'loadconf' : 1}],
-        " \ ['dyng/ctrlsf.vim',{'on_cmd' : 'CtrlSF', 'on_map' : '<Plug>CtrlSF', 'loadconf' : 1 , 'loadconf_before' : 1}],
+  " \ ['mileszs/ack.vim',{'on_cmd' : 'Ack'}],
+  " \ ['albfan/ag.vim',{'on_cmd' : 'Ag' , 'loadconf' : 1}],
+  " \ ['dyng/ctrlsf.vim',{'on_cmd' : 'CtrlSF', 'on_map' : '<Plug>CtrlSF', 'loadconf' : 1 , 'loadconf_before' : 1}],
 
   " history/yank source <Leader>fh
   call add(plugins, ['Shougo/neoyank.vim', {'merged' : 0}])
@@ -51,6 +51,7 @@ function! SpaceVim#layers#unite#config() abort
   call SpaceVim#mapping#space#def('nnoremap', ['p', '!'], 'call call('
         \ . string(s:_function('s:run_shell_cmd_project')) . ', [])',
         \ 'shell cmd(project root)', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['T', 's'], 'Unite colorscheme', 'fuzzy find colorschemes', 1)
   let g:_spacevim_mappings.f = {'name' : '+Fuzzy Finder'}
   call s:defind_fuzzy_finder()
 endfunction
@@ -171,7 +172,6 @@ function! s:defind_fuzzy_finder() abort
         \ 'Definition: ' . s:file . ':' . lnum,
         \ ]
         \ ]
-    call SpaceVim#mapping#space#def('nnoremap', ['T', 's'], 'Unite colorscheme', 'unite-colorschemes', 1)
 endfunction
 
 function! s:run_shell_cmd() abort

--- a/docs/layers/denite.md
+++ b/docs/layers/denite.md
@@ -1,6 +1,6 @@
 ---
 title: "SpaceVim denite layer"
-description: "Another Unite centric work-flow which use denite"
+description: "This layers provide a heavily customized Denite centric work-flow"
 ---
 
 # [SpaceVim Layers:](https://spacevim.org/layers) denite
@@ -13,3 +13,18 @@ This layer is a heavily customized warpper for denite and it's sources.
 ## Configuration
 
 SpaceVim use `F` as the default customized key bindings prefix for denite layer.
+
+## Key bindings
+
+| Key bindings         | Discription                   |
+| -------------------- | ----------------------------- |
+| `<Leader> f <space>` | Fuzzy find menu:CustomKeyMaps |
+| `<Leader> f e`       | Fuzzy find register           |
+| `<Leader> f f`       | Fuzzy find file               |
+| `<Leader> f h`       | Fuzzy find history/yank       |
+| `<Leader> f j`       | Fuzzy find jump, change       |
+| `<Leader> f l`       | Fuzzy find location list      |
+| `<Leader> f m`       | Fuzzy find output messages    |
+| `<Leader> f o`       | Fuzzy find outline            |
+| `<Leader> f q`       | Fuzzy find quick fix          |
+| `<Leader> f r`       | Resumes Unite window          |

--- a/docs/layers/unite.md
+++ b/docs/layers/unite.md
@@ -9,8 +9,6 @@ description: "This layers provide a heavily customized Unite centric work-flow"
 
 This layer is a heavily customized warpper for unite.vim and unite sources.
 
-![unite](https://cloud.githubusercontent.com/assets/13142418/23955542/26fd5348-09d5-11e7-8253-1f43991439b0.png)
-
 ## Configuration
 
 This is a fuzzy finder layer for SpaceVim, and it is based on unite.vim. In SpaceVim all fuzzy finder layer use same key bindings:


### PR DESCRIPTION
All denite key bindings begins with `<Leader> f`
```
  " The default sources:
  " file: <Leader>ff
  " register: <Leader>fe
  " jump: <Leader>fj
  " messages: <Leader>fm
  " history/yank source <Leader>fh
  " quickfix source <Leader>fq
  " outline source <Leader>fo
  " localtion source <Leader>fl
```

`SPC T s` is for colorscheme.

