### PR TITLE
Fix typo in install script

### DIFF
--- a/docs/install.sh
+++ b/docs/install.sh
@@ -93,7 +93,7 @@ System="$(uname -s)"
 # need_cmd {{{
 need_cmd () {
   if ! hash "$1" &>/dev/null; then
-    error "Need '$1' (command not fount)"
+    error "Need '$1' (command not found)"
     exit 1
   fi
 }


### PR DESCRIPTION
# PR Prelude

- [x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

It's easier to change SpaceVim's installer script than to update the English language dictionaries.

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md
