### PR TITLE
Fixes #1597, changes typo on file_rec

### DIFF
--- a/autoload/SpaceVim/layers/denite.vim
+++ b/autoload/SpaceVim/layers/denite.vim
@@ -30,7 +30,7 @@ function! SpaceVim#layers#denite#config() abort
   call s:defind_fuzzy_finder()
   let lnum = expand('<slnum>') + s:lnum - 1
   call SpaceVim#mapping#space#def('nnoremap', ['f', 'f'],
-        \ 'DeniteBufferDir file_recd',
+        \ 'DeniteBufferDir file_rec',
         \ ['Find files in the directory of the current buffer',
         \ [
         \ '[SPC f f] is to find files in the directory of the current buffer',


### PR DESCRIPTION
- [x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Fix a one letter typo to change `file_recd` back to `file_rec`

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md
