### PR TITLE
Use stdin instead when format java file.

### DIFF
--- a/autoload/SpaceVim/layers/lang/java.vim
+++ b/autoload/SpaceVim/layers/lang/java.vim
@@ -104,10 +104,8 @@ function! SpaceVim#layers#lang#java#config() abort
   let g:neoformat_enabled_java = ['googlefmt']
   let g:neoformat_java_googlefmt = {
         \ 'exe': 'java',
-        \ 'args': ['-jar', get(g:,'spacevim_layer_lang_java_formatter', '')],
-        \ 'replace': 0,
-        \ 'stdin': 0,
-        \ 'no_append': 0,
+        \ 'args': ['-jar', get(g:,'spacevim_layer_lang_java_formatter', ''), '-'],
+        \ 'stdin': 1,
         \ }
   try
     let g:neoformat_enabled_java += neoformat#formatters#java#enabled()


### PR DESCRIPTION
Fix #1633