### PR TITLE
Remove vim-javascript due to conflicts in flow-type and in jsx

### DIFF
--- a/autoload/SpaceVim/layers/lang/javascript.vim
+++ b/autoload/SpaceVim/layers/lang/javascript.vim
@@ -18,8 +18,7 @@ function! SpaceVim#layers#lang#javascript#plugins() abort
         \ ['othree/es.next.syntax.vim', { 'on_ft': 'javascript' }],
         \ ['othree/javascript-libraries-syntax.vim', {
         \ 'on_ft': ['javascript', 'coffee', 'ls', 'typescript'] }],
-        \ ['othree/yajs.vim', { 'on_ft': 'javascript' }],
-        \ ['pangloss/vim-javascript', { 'on_ft': 'javascript' }],
+        \ ['othree/yajs.vim', { 'on_ft': 'javascript' }]
         \ ]
 
   if !SpaceVim#layers#lsp#check_filetype('javascript')


### PR DESCRIPTION
## Problem:
Syntax highlighting is not working well when with jsx or flow-typed js/jsx.  The reason is due to vim-javascript.

There is a not in vim-improved-jsx that: https://github.com/neoclide/vim-jsx-improve
> Note: you need to disable vim-javascript plugin if have installed, I have to change some highlight group to make it works with jsx.



## Fix: 
disable vim-javascript