### PR TITLE
Fix error `unknown option guifont` in VimR

### DIFF
--- a/config/general.vim
+++ b/config/general.vim
@@ -28,8 +28,6 @@ endif
 if g:spacevim_hiddenfileinfo == 1 && has('patch-7.4.1570')
     set shortmess+=F
 endif
-if has('gui_running')
-  if !empty(g:spacevim_guifont)
-      let &guifont = g:spacevim_guifont
-  endif
+if has('gui_running') && !empty(g:spacevim_guifont)
+  let &guifont = g:spacevim_guifont
 endif

--- a/config/general.vim
+++ b/config/general.vim
@@ -28,6 +28,8 @@ endif
 if g:spacevim_hiddenfileinfo == 1 && has('patch-7.4.1570')
     set shortmess+=F
 endif
-if !empty(g:spacevim_guifont)
-    let &guifont = g:spacevim_guifont
+if has('gui_running')
+  if !empty(g:spacevim_guifont)
+      let &guifont = g:spacevim_guifont
+  endif
 endif


### PR DESCRIPTION
For neovim gui front-ends, the neovim is started without gui and they set gui in their own ways.  For example, starting neovim in VimR+SpaceVim throws an error that:

<img width="837" alt="screen shot 2018-04-22 at 5 30 04 pm" src="https://user-images.githubusercontent.com/746159/39100133-043848c0-4653-11e8-9613-dd85a3642dde.png">

This PR checks about if has('gui_running') before set guifont