### PR TITLE
Prefer local phpmd.xml

### DIFF
--- a/autoload/SpaceVim/layers/lang/php.vim
+++ b/autoload/SpaceVim/layers/lang/php.vim
@@ -58,6 +58,12 @@ function! SpaceVim#layers#lang#php#config() abort
       autocmd!
       autocmd User NeomakeJobInit call <SID>phpBeautify()
       autocmd FocusGained * checktime
+      autocmd Filetype php call <SID>preferLocalPHPMD()
+    augroup END
+  else 
+    augroup SpaceVim_lang_php
+      autocmd!
+      autocmd Filetype php call <SID>preferLocalPHPMD()
     augroup END
   endif
 
@@ -93,5 +99,20 @@ function! s:phpBeautify() abort
       call system(l:command)
       checktime
     endtry
+  endif
+endfunction
+
+function! s:preferLocalPHPMD() abort 
+  let l:dir = expand('%:p:h')
+  while findfile('phpmd.xml', dir) ==# ''
+    let l:next_dir = fnamemodify(dir, ':h')
+    if l:dir == l:next_dir
+      break
+    endif
+    let l:dir = l:next_dir
+  endwhile
+  let l:phpmd_path = dir. '/phpmd.xml'
+  if filereadable(l:phpmd_path)
+    let b:neomake_php_phpmd_args = ['%:p', 'text', l:phpmd_path]
   endif
 endfunction

--- a/autoload/SpaceVim/layers/lang/php.vim
+++ b/autoload/SpaceVim/layers/lang/php.vim
@@ -112,7 +112,7 @@ function! s:preferLocalPHPMD() abort
     let l:dir = l:next_dir
   endwhile
   let l:phpmd_path = dir. '/phpmd.xml'
-  if filereadable(l:phpmd_path)
+  if filereadable(l:phpmd_path) && !exists('b:neomake_php_phpmd_args')
     let b:neomake_php_phpmd_args = ['%:p', 'text', l:phpmd_path]
   endif
 endfunction


### PR DESCRIPTION
This PR improves the neomake config of phpmd.  By default, the neomake use a static config for phpmd, ignoring the potentially existing phpmd config in the working project.  This PR tries to find the local phpmd config, and if it exists, use that local phpmd.xml.