### PR TITLE
Add auto fix feature to typescript

### DIFF
--- a/autoload/SpaceVim/layers/lang/javascript.vim
+++ b/autoload/SpaceVim/layers/lang/javascript.vim
@@ -64,9 +64,9 @@ function! SpaceVim#layers#lang#javascript#config() abort
   if s:auto_fix
     augroup SpaceVim_lang_javascript
       autocmd!
-      autocmd User NeomakeFinished call <SID>checktime_if_javascript()
+      autocmd User NeomakeFinished checktime
       autocmd FileType javascript setlocal omnifunc=javascriptcomplete#CompleteJS
-      autocmd FocusGained * call <SID>checktime_if_javascript()
+      autocmd FocusGained * checktime
     augroup END
   endif
 endfunction
@@ -122,12 +122,6 @@ endfunction
 function! s:tern_go_to_def() abort
   if exists(':TernDef')
     TernDef
-  endif
-endfunction
-
-function! s:checktime_if_javascript() abort
-  if (&filetype =~# '^javascript')
-    checktime
   endif
 endfunction
 

--- a/autoload/SpaceVim/layers/lang/typescript.vim
+++ b/autoload/SpaceVim/layers/lang/typescript.vim
@@ -8,33 +8,51 @@
 
 
 function! SpaceVim#layers#lang#typescript#plugins() abort
-    let plugins = []
-    call add(plugins, ['leafgarland/typescript-vim'])
-    if has('nvim')
-        call add(plugins, ['mhartington/nvim-typescript'])
-    else
-        call add(plugins, ['Quramy/tsuquyomi'])
+  let plugins = []
+  call add(plugins, ['leafgarland/typescript-vim'])
+  if has('nvim')
+    call add(plugins, ['mhartington/nvim-typescript'])
+  else
+    call add(plugins, ['Quramy/tsuquyomi'])
+  endif
+  return plugins
+endfunction
+
+let s:auto_fix = 0
+
+function! SpaceVim#layers#lang#typescript#set_variable(var) abort
+  if has('nvim')
+    let  g:nvim_typescript#server_path =
+          \ get(a:var, 'typescript_server_path',
+          \ './node_modules/.bin/tsserver')
+  else
+    let tsserver_path = get(a:var, 'typescript_server_path', '')
+    if !empty(tsserver_path)
+      let g:tsuquyomi_use_dev_node_module = 2
+      let g:tsuquyomi_tsserver_path = tsserver_path
     endif
-    return plugins
+  endif
+  let s:auto_fix = get(a:var, 'auto_fix', 0)
 endfunction
 
 
 function! SpaceVim#layers#lang#typescript#config() abort
-    if !has('nvim')
-        autocmd FileType typescript setlocal omnifunc=tsuquyomi#complete
-    endif
-endfunction
+  if s:auto_fix
+    let g:neomake_typescript_tslint_args = ['--fix']
+    augroup SpaceVim_lang_typescript
+      autocmd!
+      autocmd User NeomakeFinished checktime
+      autocmd FocusGained * checktime
+    augroup END
+  else 
+    augroup SpaceVim_lang_typescript
+      autocmd!
+    augroup END
+  endif
 
-function! SpaceVim#layers#lang#typescript#set_variable(var) abort
-    if has('nvim')
-        let  g:nvim_typescript#server_path =
-                    \ get(a:var, 'typescript_server_path',
-                    \ './node_modules/.bin/tsserver')
-    else
-        let tsserver_path = get(a:var, 'typescript_server_path', '')
-        if !empty(tsserver_path)
-            let g:tsuquyomi_use_dev_node_module = 2
-            let g:tsuquyomi_tsserver_path = tsserver_path
-        endif
-    endif
+  if !has('nvim')
+    augroup SpaceVim_lang_typescript
+      autocmd FileType typescript setlocal omnifunc=tsuquyomi#complete
+    augroup END
+  endif
 endfunction


### PR DESCRIPTION
1. Add --fix feature to typescript.vim
2. Because the `autocmd User NeomakeFinished` are conflicting between javascript.vim and typescript.vim, I remove the filetype check to ensure auto fix can work on both ts and js files
3. fix indent and some other styling inconsistence