### PR TITLE
Fix layer activation command and typo in Python layer docs

### DIFF
--- a/docs/layers/lang/python.md
+++ b/docs/layers/lang/python.md
@@ -29,14 +29,14 @@ This layer is for Python development.
 
 ## Features
 
-- Aoto-completion using [deoplete-jedi](https://github.com/zchee/deoplete-jedi) or [jedi-vim](https://github.com/davidhalter/jedi-vim)
+- Auto-completion using [deoplete-jedi](https://github.com/zchee/deoplete-jedi) or [jedi-vim](https://github.com/davidhalter/jedi-vim)
 - Documentation Lookup using [jedi-vim](https://github.com/davidhalter/jedi-vim)
 
 ## Install
 
 ### Layer
 
-To use this configuration layer, add `SPLayer 'lang#python'` to your custom configuration file.
+To use this configuration layer, add `call SpaceVim#layers#load('lang#python')` to your custom configuration file.
 
 ### Syntax Checking
 


### PR DESCRIPTION
# PR Prelude
- [ x ] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [ x ] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [ x ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [ x ] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This PR simple fix some typo in documentation of python layer.

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md
