### PR TITLE
Fix keys highlights, add missed

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -119,11 +119,11 @@ Community-driven configuration provides curated packages tuned by power users an
 ## Highlighted features
 
 - **Great documentation:** access documentation in Vim with
-    <kbd>:h SpaceVim</kbd>.
+    `:h SpaceVim`.
 - **Minimalistic and nice graphical UI:** you'll love the awesome UI and its useful features.
 - **Keep your fingers on the home row:** for quicker editing with support for QWERTY and BEPO layouts.
 - **Mnemonic key bindings:** commands have mnemonic prefixes like
-    <kbd>[Window]</kbd> for all the window and buffer commands or <kbd>[Unite]</kbd> for the
+    `[Window]` for all the window and buffer commands or `[Unite]` for the
     unite work flow commands.
 - **Fast boot time:** Lazy-load 90% of plugins with [dein.vim]
 - **Lower the risk of RSI:** by heavily using the space bar instead of modifiers.
@@ -182,7 +182,7 @@ To update manually close Vim and update the git repository:
 
 ### Update plugins
 
-Use `:SPUpdate` command will update all the plugins and SpaceVim itself. after `:SPUpdate`, you can assign plugins need to be updated. Use <kbd>Tab</kbd> to complete plugin names after `:SPUpdate`.
+Use `:SPUpdate` command will update all the plugins and SpaceVim itself. after `:SPUpdate`, you can assign plugins need to be updated. Use `Tab` to complete plugin names after `:SPUpdate`.
 
 ### Get SpaceVim log
 
@@ -198,7 +198,7 @@ The very first time SpaceVim starts up, it will ask you several questions and th
 
 User configuration can be stored in your `~/.SpaceVim.d` directory.
 
-`~/.SpaceVim.d/` will be added to `&runtimepath` of vim. read <kbd>:h rtp</kbd>.
+`~/.SpaceVim.d/` will be added to `&runtimepath` of vim. read `:h rtp`.
 
 It is also possible to override the location of `~/.SpaceVim.d/` using the environment
 variable `SPACEVIMDIR`. Of course you can also use symlinks to change the location of
@@ -232,7 +232,7 @@ here is an example config file for SpaceVim:
 
 This is a list of available options for SpaceVim:
 
-Comprehensive documentation is available for each layer by <kbd>:h SpaceVim</kbd>.
+Comprehensive documentation is available for each layer by `:h SpaceVim`.
 
 if you want to add custom `SPC` prefix key bindings, you can add this to SpaceVim configuration file, **be sure** the key bindings is not used in SpaceVim.
 
@@ -301,7 +301,7 @@ SpaceVim has a minimalistic and distraction free UI:
 
 ### Colorschemes
 
-The default colorscheme of SpaceVim is [gruvbox](https://github.com/morhetz/gruvbox). There are two variants of this colorscheme, a dark one and a light one. Some aspects of these colorscheme can be customized in the custom configuration file, read <kbd>:h gruvbox</kbd>.
+The default colorscheme of SpaceVim is [gruvbox](https://github.com/morhetz/gruvbox). There are two variants of this colorscheme, a dark one and a light one. Some aspects of these colorscheme can be customized in the custom configuration file, read `:h gruvbox`.
 
 It is possible to define your default themes in your `~/.SpaceVim.d/init.vim` with the variable colorschemes. For instance, to specify [vim-one with dark colorscheme](https://github.com/rakr/vim-one):
 
@@ -312,8 +312,8 @@ let g:spacevim_colorscheme_bg = 'dark'
 
 | Mappings           | Description                                                    |
 | ------------------ | -------------------------------------------------------------- |
-| <kbd>SPC T n</kbd> | switch to next random colorscheme listed in colorscheme layer. |
-| <kbd>SPC T s</kbd> | select a theme using a unite buffer.                           |
+| `SPC T n` | switch to next random colorscheme listed in colorscheme layer. |
+| `SPC T s` | select a theme using a unite buffer.                           |
 
 all the included colorscheme can be found in [colorscheme layer](http://spacevim.org/layers/colorscheme/).
 
@@ -339,21 +339,21 @@ Some UI indicators can be toggled on and off (toggles start with t and T):
 
 | Key Binding | Description                                                       |
 | ----------- | ----------------------------------------------------------------- |
-| SPC t 8     | highlight any character past the 80th column                      |
-| SPC t f     | display the fill column (by default the fill column is set to 80) |
-| SPC t h h   | toggle highlight of the current line                              |
-| SPC t h i   | toggle highlight indentation levels (TODO)                        |
-| SPC t h c   | toggle highlight indentation current column                       |
-| SPC t h s   | toggle syntax highlighting                                        |
-| SPC t i     | toggle indentation guide at point                                 |
-| SPC t n     | toggle line numbers                                               |
-| SPC t b     | toggle background                                                 |
-| SPC t t     | open tabs manager                                                 |
-| SPC T ~     | display ~ in the fringe on empty lines                            |
-| SPC T F     | toggle frame fullscreen                                           |
-| SPC T f     | toggle display of the fringe                                      |
-| SPC T m     | toggle menu bar                                                   |
-| SPC T t     | toggle tool bar                                                   |
+| `SPC t 8`   | highlight any character past the 80th column                      |
+| `SPC t f`   | display the fill column (by default the fill column is set to 80) |
+| `SPC t h h` | toggle highlight of the current line                              |
+| `SPC t h i` | toggle highlight indentation levels (TODO)                        |
+| `SPC t h c` | toggle highlight indentation current column                       |
+| `SPC t h s` | toggle syntax highlighting                                        |
+| `SPC t i`   | toggle indentation guide at point                                 |
+| `SPC t n`   | toggle line numbers                                               |
+| `SPC t b`   | toggle background                                                 |
+| `SPC t t`   | open tabs manager                                                 |
+| `SPC T ~`   | display ~ in the fringe on empty lines                            |
+| `SPC T F`   | toggle frame fullscreen                                           |
+| `SPC T f`   | toggle display of the fringe                                      |
+| `SPC T m`   | toggle menu bar                                                   |
+| `SPC T t`   | toggle tool bar                                                   |
 
 ### Statusline
 
@@ -581,8 +581,8 @@ can change it via `g:spacevim_windows_leader`
 | `<leader>`+`sv` | Split with previous buffer                                                                                                                                                                                                     |
 | `<leader>`+`sg` | Vertically split with previous buffer                                                                                                                                                                                          |
 
-SpaceVim has mapped normal <kbd>q</kbd> as smart buffer close, the normal func of <kbd>q</kbd>
-can be get by <kbd><leader> q r</kbd>
+SpaceVim has mapped normal `q` as smart buffer close, the normal func of `q`
+can be get by `<leader> q r`
 
 | Key                   |      Mode     | Action                                                                         |
 | --------------------- | :-----------: | ------------------------------------------------------------------------------ |
@@ -787,18 +787,18 @@ then use `<Tab>` or `<Up>` and `<Down>` to select the mapping, press `<Enter>` w
 
 Denite/Unite is powerful tool to  unite all interfaces. it was meant to be like [Helm](https://github.com/emacs-helm/helm) for Vim. These mappings is for getting help info about functions, variables etc:
 
-| Mappings  | Description                                                      |
-| --------- | ---------------------------------------------------------------- |
-| SPC h SPC | discover SpaceVim documentation, layers and packages using unite |
-| SPC h i   | get help with the symbol at point                                |
-| SPC h k   | show top-level bindings with which-key                           |
-| SPC h m   | search available man pages                                       |
+| Mappings    | Description                                                      |
+| ---------   | ---------------------------------------------------------------- |
+| `SPC h SPC` | discover SpaceVim documentation, layers and packages using unite |
+| `SPC h i`   | get help with the symbol at point                                |
+| `SPC h k`   | show top-level bindings with which-key                           |
+| `SPC h m`   | search available man pages                                       |
 
 Reporting an issue:
 
 | Mappings | Description                                                 |
 | -------- | ----------------------------------------------------------- |
-| SPC h I  | Open SpaceVim GitHub issue page with pre-filled information |
+| `SPC h I`| Open SpaceVim GitHub issue page with pre-filled information |
 
 #### Available layers
 


### PR DESCRIPTION
# PR Prelude
- [ x ] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [ x ] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [ x ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [ x ] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This PR fixes key-mapping highlights in general documentation:
1) `<kbd>` tags replaced, because elements like `<leader>` disappear inside that tag, and for more uniformity
2) added some missing keys highlights

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md
