### PR TITLE
Update Go layer to reflect vim-go var name change

### DIFF
--- a/autoload/SpaceVim/layers/lang/go.vim
+++ b/autoload/SpaceVim/layers/lang/go.vim
@@ -39,7 +39,7 @@ endfunction
 
 function! SpaceVim#layers#lang#go#config() abort
   let g:go_highlight_functions = 1
-  let g:go_highlight_methods = 1
+  let g:go_highlight_function_calls = 1
   let g:go_highlight_structs = 1
   let g:go_highlight_operators = 1
   let g:go_highlight_build_constraints = 1


### PR DESCRIPTION

# PR Prelude

Thank you for working on SpaceVim! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

*vim-go* renamed `go_highlight_methods` to `go_highlight_function_calls` recently to address confusion with the way the existing variable names [behaved][rename]. This change will re-enable the higlighting of function and method _invocations_, which is currently broken. Although I've decided to not use spacevim, I thought others would benefit from the fix.

No tests are included as I don't see any existing framework to test the existing layer.

[rename]: https://github.com/fatih/vim-go/pull/1557#issuecomment-357498784
[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md