### PR TITLE
Fix hit-enter when using timers

### DIFF
--- a/autoload/SpaceVim/api/cmdlinemenu.vim
+++ b/autoload/SpaceVim/api/cmdlinemenu.vim
@@ -57,8 +57,11 @@ endfunction
 
 function! s:menu(items) abort
   let saved_more = &more
+  let save_cmdheight = &cmdheight
   set nomore
   let items = s:parseItems(a:items)
+  let &cmdheight = len(items) + 1
+  redrawstatus!
   let selected = '1'
   let exit = 0
   let indent = repeat(' ', 7)
@@ -101,6 +104,8 @@ function! s:menu(items) abort
     endif
   endwhile
   let &more = saved_more
+  let &cmdheight = save_cmdheight
+  redraw!
 endfunction
 
 let s:api['menu'] = function('s:menu')


### PR DESCRIPTION
Problem: can not hide hit-enter when using timers.
Solution: change the cmdheight before display info.

# PR Prelude

Thank you for working on SpaceVim! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [ ] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [ ] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [ ] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md
