### PR TITLE
Add [SPC]bb map to list all buffers in fzf layer

### DIFF
--- a/autoload/SpaceVim/layers/fzf.vim
+++ b/autoload/SpaceVim/layers/fzf.vim
@@ -22,6 +22,7 @@ let s:filename = expand('<sfile>:~')
 let s:lnum = expand('<slnum>') + 2
 function! SpaceVim#layers#fzf#config() abort
   let lnum = expand('<slnum>') + s:lnum - 1
+  call SpaceVim#mapping#space#def('nnoremap', ['b', 'b'], 'Fzfbuffers', 'List all buffers', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['p', 'f'],
         \ 'FzfFiles',
         \ ['find files in current project',
@@ -331,6 +332,23 @@ function! s:register() abort
   call fzf#run({
         \   'source':  reverse(<sid>registers_list()),
         \   'sink':    function('s:yankregister'),
+        \   'options': '+m',
+        \   'down': '40%'
+        \ })
+endfunction
+
+command! Fzfbuffers call <SID>buffers()
+function! s:open_buffer(e) abort
+  execute 'buffer' matchstr(a:e, '^[ 0-9]*')
+endfunction
+function! s:buffers() abort
+  let s:source = 'buffers'
+  function! s:buffer_list() abort
+    return split(s:CMP.execute('buffers'), '\n')
+  endfunction
+  call fzf#run({
+        \   'source':  reverse(<sid>buffer_list()),
+        \   'sink':    function('s:open_buffer'),
         \   'options': '+m',
         \   'down': '40%'
         \ })

--- a/docs/layers/fzf.md
+++ b/docs/layers/fzf.md
@@ -23,3 +23,4 @@ This layer is a heavily customized wrapper for fzf.
 | `<Leader> f o`       | Fuzzy find outline            |
 | `<Leader> f q`       | Fuzzy find quick fix          |
 | `<Leader> f r`       | Resumes Unite window          |
+| `<Leader> b b`       | List all buffers              |


### PR DESCRIPTION
fzf layer works better than denite and unite layers. This commit add
`[SPC]bb` map in fzf layer.

denite layer used to enable `[SPC]bb` to navigate in all buffers.
This change add same functionality but in fzf layer.

I didn't write tests for this change. Don't know how to do it. I would have created this map in my init.vim file, but an issue in how to use [SPC].  

# PR Prelude

Thank you for working on SpaceVim! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [X] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md
