### PR TITLE
Specify the exact branch for git rebase

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -103,7 +103,7 @@ git remote add upstream https://github.com/SpaceVim/SpaceVim.git
 
 ```sh
 git fetch upstream
-git rebase upstream master
+git rebase upstream/master master
 ```
 
 #### Ideally for simple PRs (most of them):


### PR DESCRIPTION
# PR Prelude

Thank you for working on SpaceVim! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

The documentation contains a git command that fails with the error `fatal: Needed a single revision
invalid upstream 'upstream'`. This is fixed by specifying the exact branch, rather than just the remote.

No test as this is purely a documentation change.

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md
