### PR TITLE
Add Ctrl-a to the vim compatibility list in the documentation

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -228,6 +228,8 @@ the option is `g:spacevim_enable_language_specific_leader`, default value is 1.
 
 the option is `g:spacevim_windows_smartclose`, default value is `q`. If you still prefer the origin function of `q`, you can use an empty string to disable this feature.
 
+- The `Ctrl + a` binding on the command line auto-completes variable names, but in SpaceVim it moves to the cursor to the beginning of the command.
+
 [Send a PR](http://spacevim.org/development/) to add the differences you found in this section.
 
 If you still want to use this origin function, you can enable vimcompatible mode, via `vimcompatible = 1` in `[options]` section.


### PR DESCRIPTION
# PR Prelude

Thank you for working on SpaceVim! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

No test required as simple documentation update.

`Ctrl-a` is very useful in vim command mode to auto-complete variable names. (e.g. Type `:let spacevim` followed by `Ctrl-a` and it will complete all spacevim variables). Spacevim changes this binding to match emacs/bash, so it moves the cursor to the beginning of the command instead.

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md
