### PR TITLE
Fix syntax highlight conflict under flow-typed js

### DIFF
--- a/autoload/SpaceVim/layers/lang/javascript.vim
+++ b/autoload/SpaceVim/layers/lang/javascript.vim
@@ -20,7 +20,10 @@ function! SpaceVim#layers#lang#javascript#plugins() abort
         \ 'on_ft': ['javascript', 'coffee', 'ls', 'typescript'] }],
         \ ]
 
-  if !s:flow
+  if s:enable_flow_syntax
+    call add(plugins, ['flowtype/vim-flow.vim', { 'on_ft': 'javascript' }])
+    let g:flow#enable = 0
+  else
     call add(plugins, ['othree/yajs.vim', { 'on_ft': 'javascript' }])
   endif
 
@@ -35,11 +38,11 @@ function! SpaceVim#layers#lang#javascript#plugins() abort
 endfunction
 
 let s:auto_fix = 0
-let s:flow = 0
+let s:enable_flow_syntax = 0
 
 function! SpaceVim#layers#lang#javascript#set_variable(var) abort
   let s:auto_fix = get(a:var, 'auto_fix', 0)
-  let s:flow = get(a:var, 'flow', 0)
+  let s:enable_flow_syntax = get(a:var, 'flow', 0)
 endfunction
 
 function! SpaceVim#layers#lang#javascript#config() abort

--- a/autoload/SpaceVim/layers/lang/javascript.vim
+++ b/autoload/SpaceVim/layers/lang/javascript.vim
@@ -18,8 +18,11 @@ function! SpaceVim#layers#lang#javascript#plugins() abort
         \ ['othree/es.next.syntax.vim', { 'on_ft': 'javascript' }],
         \ ['othree/javascript-libraries-syntax.vim', {
         \ 'on_ft': ['javascript', 'coffee', 'ls', 'typescript'] }],
-        \ ['othree/yajs.vim', { 'on_ft': 'javascript' }]
         \ ]
+
+  if !s:flow
+    call add(plugins, ['othree/yajs.vim', { 'on_ft': 'javascript' }])
+  endif
 
   if !SpaceVim#layers#lsp#check_filetype('javascript')
     call add(plugins, ['ternjs/tern_for_vim', {
@@ -32,9 +35,11 @@ function! SpaceVim#layers#lang#javascript#plugins() abort
 endfunction
 
 let s:auto_fix = 0
+let s:flow = 0
 
 function! SpaceVim#layers#lang#javascript#set_variable(var) abort
   let s:auto_fix = get(a:var, 'auto_fix', 0)
+  let s:flow = get(a:var, 'flow', 0)
 endfunction
 
 function! SpaceVim#layers#lang#javascript#config() abort

--- a/docs/cn/layers/lang/javascript.md
+++ b/docs/cn/layers/lang/javascript.md
@@ -34,12 +34,23 @@ To use this configuration layer, add `call SpaceVim#layers#load('lang#javascript
 
 ## Layer configuration
 
-`auto_fix`: auto fix problems when save files, disabled by default. if you need this feature, you can load this layer via:
+`auto_fix`: auto fix problems when save files, disabled by default. If you need this feature, you can load this layer via:
 
 ```vim
 call SpaceVim#layers#load('lang#javascript',
             \ {
             \ 'auto_fix' : 1,
+            \ }
+            \ )
+
+```
+
+`enable_flow_syntax`: Enable configuration for [flow](https://flow.org/), disabled by default. If you need this feature, you can load this layer via:
+
+```vim
+call SpaceVim#layers#load('lang#javascript',
+            \ {
+            \ 'enable_flow_syntax' : 1,
             \ }
             \ )
 

--- a/docs/layers/lang/javascript.md
+++ b/docs/layers/lang/javascript.md
@@ -34,12 +34,23 @@ To use this configuration layer, add `call SpaceVim#layers#load('lang#javascript
 
 ## Layer configuration
 
-`auto_fix`: auto fix problems when save files, disabled by default. if you need this feature, you can load this layer via:
+`auto_fix`: auto fix problems when save files, disabled by default. If you need this feature, you can load this layer via:
 
 ```vim
 call SpaceVim#layers#load('lang#javascript',
             \ {
             \ 'auto_fix' : 1,
+            \ }
+            \ )
+
+```
+
+`enable_flow_syntax`: Enable configuration for [flow](https://flow.org/), disabled by default. If you need this feature, you can load this layer via:
+
+```vim
+call SpaceVim#layers#load('lang#javascript',
+            \ {
+            \ 'enable_flow_syntax' : 1,
             \ }
             \ )
 


### PR DESCRIPTION
When js is typed by flow, yajs cannot correctly highlight the js file.

This PR adds an option to disable yajs when flow is enable. 
