### PR TITLE
fix undefined variable for g:_spacevim_config_path

### DIFF
--- a/autoload/SpaceVim/commands.vim
+++ b/autoload/SpaceVim/commands.vim
@@ -87,7 +87,8 @@ function! SpaceVim#commands#config(...) abort
       exe 'tabnew' g:_spacevim_config_path
     endif
   else
-    if g:spacevim_force_global_config
+    if g:spacevim_force_global_config ||
+          \ get(g:, '_spacevim_config_path', '0') ==# '0'
       exe 'tabnew' g:_spacevim_global_config_path
     else
       exe 'tabnew' g:_spacevim_config_path


### PR DESCRIPTION
# PR Prelude

Thank you for working on SpaceVim! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md

We need to check wether g:_spacevim_config_path exists, if not, we should load configration from g:_space_global_config_path instead of undefined variable error.