### PR TITLE
Fix a potentially misleading example in the doc

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -330,7 +330,7 @@ to install it on your system if you wish to use it.
 To change the default font set the variable `guifont` in your `~/.SpaceVim.d/init.toml` file. By default its value is:
 
 ```toml
-    guifont = 'DejaVu\ Sans\ Mono\ for\ Powerline\ 11'
+    guifont = 'DejaVu Sans Mono for Powerline:h11'
 ```
 
 If the specified font is not found, the fallback one will be used (depends on your system).


### PR DESCRIPTION
# PR Prelude

Thank you for working on SpaceVim! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

The example of the documentation is wrong, since it is in the init.toml, the spaces must not be escaped. I spend 20 minutes to understand this.

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md
