### PR TITLE
Fix installation error when there are no '.config' at '$HOME' directory.

### DIFF
--- a/docs/install.sh
+++ b/docs/install.sh
@@ -189,6 +189,7 @@ install_neovim () {
       success "Installed SpaceVim for neovim"
     fi
   else
+    mkdir -p "$HOME/.config"
     ln -s "$HOME/.SpaceVim" "$HOME/.config/nvim"
     success "Installed SpaceVim for neovim"
   fi


### PR DESCRIPTION
# PR Prelude

Thank you for working on SpaceVim! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Configuration for neovim won't take effect after installing when there are no '.config' at '$HOME' directory.

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md
