### PR TITLE
Fix typo in javascript.vim

### DIFF
--- a/autoload/SpaceVim/layers/lang/javascript.vim
+++ b/autoload/SpaceVim/layers/lang/javascript.vim
@@ -21,7 +21,7 @@ function! SpaceVim#layers#lang#javascript#plugins() abort
         \ ]
 
   if s:enable_flow_syntax
-    call add(plugins, ['flowtype/vim-flow.vim', { 'on_ft': 'javascript' }])
+    call add(plugins, ['flowtype/vim-flow', { 'on_ft': 'javascript' }])
     let g:flow#enable = 0
   else
     call add(plugins, ['othree/yajs.vim', { 'on_ft': 'javascript' }])

--- a/autoload/SpaceVim/layers/lang/javascript.vim
+++ b/autoload/SpaceVim/layers/lang/javascript.vim
@@ -42,7 +42,7 @@ let s:enable_flow_syntax = 0
 
 function! SpaceVim#layers#lang#javascript#set_variable(var) abort
   let s:auto_fix = get(a:var, 'auto_fix', 0)
-  let s:enable_flow_syntax = get(a:var, 'flow', 0)
+  let s:enable_flow_syntax = get(a:var, 'enable_flow_syntax', 0)
 endfunction
 
 function! SpaceVim#layers#lang#javascript#config() abort


### PR DESCRIPTION
# PR Prelude

Thank you for working on SpaceVim! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

There was a bug in the last PR that, the flow option is loaded by `flow` rather than `enable_flow_syntax`; This PR fixes the typo.

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md
