### PR TITLE
Added support for having both custom toml and init files

### DIFF
--- a/autoload/SpaceVim/custom.vim
+++ b/autoload/SpaceVim/custom.vim
@@ -163,7 +163,9 @@ endfunction
 
 function! s:load_glob_conf() abort
   let global_dir = empty($SPACEVIMDIR) ? expand('~/.SpaceVim.d') : $SPACEVIMDIR
+  let local_exists = 0
   if filereadable(global_dir . '/init.toml')
+    let local_exists = 1
     let g:_spacevim_global_config_path = global_dir . '/init.toml'
     let local_conf = global_dir . '/init.toml'
     let local_conf_cache = expand('~/.cache/SpaceVim/conf/init.json')
@@ -176,20 +178,21 @@ function! s:load_glob_conf() abort
       call writefile([s:JSON.json_encode(conf)], local_conf_cache)
       call SpaceVim#custom#apply(conf)
     endif
-  elseif filereadable(global_dir . '/init.vim')
+  endif
+  if filereadable(global_dir . '/init.vim')
+    let local_exists = 1
     let g:_spacevim_global_config_path = global_dir . '/init.vim'
     let custom_glob_conf = global_dir . '/init.vim'
     let &rtp = global_dir . ',' . &rtp
     exe 'source ' . custom_glob_conf
-  else
-    if has('timers')
-      " if there is no custom config auto generate it.
-      let g:spacevim_checkinstall = 0
-      augroup SpaceVimBootstrap
-        au!
-        au VimEnter * call timer_start(2000, function('SpaceVim#custom#autoconfig'))
-      augroup END
-    endif
+  endif
+  if !local_exists && has('timers')
+    " if there is no custom config auto generate it.
+    let g:spacevim_checkinstall = 0
+    augroup SpaceVimBootstrap
+      au!
+      au VimEnter * call timer_start(2000, function('SpaceVim#custom#autoconfig'))
+    augroup END
   endif
 
 endfunction


### PR DESCRIPTION
# PR Prelude

Thank you for working on SpaceVim! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x ] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [ ]x I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [ x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

I want to be able to use both a custom toml file and vim init file. I want to use the toml file for the SpaceVim specific configuration. and the init.vim for user specific configuration that is not supported in the toml file. Nvm, seems like this is possible through the bootstrap functions :)

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md
