### PR TITLE
Added references and more lsp features for rust

### DIFF
--- a/autoload/SpaceVim/layers/lang/rust.vim
+++ b/autoload/SpaceVim/layers/lang/rust.vim
@@ -58,17 +58,38 @@ function! SpaceVim#layers#lang#rust#config() abort
   let g:racer_experimental_completer = 1
   let g:racer_cmd = $HOME . '/.cargo/bin/racer'
 
-  call SpaceVim#mapping#gd#add('rust', function('s:gotodef'))
-  call SpaceVim#plugins#runner#reg_runner('rust', ['rustc %s -o #TEMP#', '#TEMP#'])
-  call SpaceVim#mapping#space#regesit_lang_mappings('rust', function('s:language_specified_mappings'))
+  if SpaceVim#layers#lsp#check_filetype('rust')
+    call SpaceVim#mapping#gd#add('rust',
+          \ function('SpaceVim#lsp#go_to_def'))
+  else
+    call SpaceVim#mapping#gd#add('rust', function('s:gotodef'))
+  endif
+
+  call SpaceVim#plugins#runner#reg_runner('rust',
+        \ ['rustc %s -o #TEMP#', '#TEMP#'])
+  call SpaceVim#mapping#space#regesit_lang_mappings('rust',
+        \ function('s:language_specified_mappings'))
 endfunction
 
 function! s:language_specified_mappings() abort
   nmap <buffer> gs <Plug>(rust-def-split)
   nmap <buffer> gx <Plug>(rust-def-vertical)
 
-  call SpaceVim#mapping#space#langSPC('nmap', ['l', 'd'], '<Plug>(rust-doc)', 'show documentation', 0)
-  call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'r'], 'call SpaceVim#plugins#runner#open()', 'execute current file', 1)
+  if SpaceVim#layers#lsp#check_filetype('rust')
+    nnoremap <silent><buffer> K :call SpaceVim#lsp#show_doc()<CR>
+    call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'd'],
+          \ 'call SpaceVim#lsp#show_doc()', 'show documentation', 1)
+    call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'e'],
+          \ 'call SpaceVim#lsp#rename()', 'rename symbol', 1)
+    call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'c'],
+          \ 'call SpaceVim#lsp#references()', 'show references', 1)
+  else
+    call SpaceVim#mapping#space#langSPC('nmap', ['l', 'd'],
+          \ '<Plug>(rust-doc)', 'show documentation', 1)
+  endif
+
+  call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'r'],
+        \ 'call SpaceVim#plugins#runner#open()', 'execute current file', 1)
 endfunction
 
 function! s:gotodef() abort

--- a/autoload/SpaceVim/lsp.vim
+++ b/autoload/SpaceVim/lsp.vim
@@ -25,15 +25,19 @@ if has('nvim')
   function! SpaceVim#lsp#rename() abort
     call LanguageClient_textDocument_rename()
   endfunction
+
+  function! SpaceVim#lsp#references() abort
+    call LanguageClient_textDocument_references()
+  endfunction
 else
   " use vim-lsp
   function! SpaceVim#lsp#reg_server(ft, cmds) abort
-   exe "au User lsp_setup call lsp#register_server({"
+    exe "au User lsp_setup call lsp#register_server({"
           \ . "'name': 'LSP',"
           \ . "'cmd': {server_info -> " . string(a:cmds) . "},"
           \ . "'whitelist': ['" .  a:ft . "' ],"
           \ . "})"
-   exe 'autocmd FileType ' . a:ft . ' setlocal omnifunc=lsp#complete'
+    exe 'autocmd FileType ' . a:ft . ' setlocal omnifunc=lsp#complete'
   endfunction
 
   function! SpaceVim#lsp#show_doc() abort
@@ -48,6 +52,9 @@ else
     LspRename
   endfunction
 
+  function! SpaceVim#lsp#references() abort
+    LspReferences
+  endfunction
 endif
 
 " vi: et sw=2 cc=80


### PR DESCRIPTION
# PR Prelude
Added references and more lsp support for rust. Using l c mapping since l r mapping was occupied. 

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x ] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [ x] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [ x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful
I want to use more lsp features with rust. Only tested with LanguageClient-neovim next branch.

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md
