### PR TITLE
add julia 0.6 support by lsp

### DIFF
--- a/autoload/SpaceVim/layers/lang/julia.vim
+++ b/autoload/SpaceVim/layers/lang/julia.vim
@@ -19,7 +19,7 @@ function! SpaceVim#layers#lang#julia#plugins() abort
   let plugins = []
   call add(plugins, ['JuliaEditorSupport/julia-vim' ])
   if (has('nvim'))
-    call add(plugins, ['JuliaEditorSupport/deoplete-julia', {'on_ft' : 'julia'}])
+    call add(plugins, ['roxma/nvim-completion-manager'])
   endif
   call add(plugins, ['zyedidia/julialint.vim', {'on_ft' : 'julia'}])
   return plugins
@@ -30,4 +30,14 @@ function! SpaceVim#layers#lang#julia#config() abort
   let g:latex_to_unicode_tab = 0
   au! BufNewFile,BufRead *.jl setf julia
   au! BufNewFile,BufRead *.julia setf julia
+  
+  " julia
+  let g:default_julia_version = '0.6'
+
+  " language server
+  let g:LanguageClient_autoStart = 1
+  
+  nnoremap <silent> K :call LanguageClient_textDocument_hover()<CR>
+  nnoremap <silent> gd :call LanguageClient_textDocument_definition()<CR>
+  nnoremap <silent> <F2> :call LanguageClient_textDocument_rename()<CR>
 endfunction

--- a/autoload/SpaceVim/layers/lang/julia.vim
+++ b/autoload/SpaceVim/layers/lang/julia.vim
@@ -18,9 +18,6 @@
 function! SpaceVim#layers#lang#julia#plugins() abort
   let plugins = []
   call add(plugins, ['JuliaEditorSupport/julia-vim' ])
-  if (has('nvim'))
-    call add(plugins, ['roxma/nvim-completion-manager'])
-  endif
   call add(plugins, ['zyedidia/julialint.vim', {'on_ft' : 'julia'}])
   return plugins
 endfunction

--- a/autoload/SpaceVim/layers/lsp.vim
+++ b/autoload/SpaceVim/layers/lsp.vim
@@ -91,7 +91,8 @@ let s:lsp_servers = {
       \ 'rust' : ['rustup', 'run', 'nightly', 'rls'],
       \ 'python' : ['pyls'],
       \ 'html' : ['html-languageserver', '--stdio'],
-      \ 'php' : ['php', g:spacevim_plugin_bundle_dir . 'repos/github.com/felixfbecker/php-language-server/bin/php-language-server.php']
+      \ 'php' : ['php', g:spacevim_plugin_bundle_dir . 'repos/github.com/felixfbecker/php-language-server/bin/php-language-server.php'],
+      \ 'julia' : ['julia', '--startup-file=no', '--history-file=no', '-e', 'using LanguageServer; server = LanguageServer.LanguageServerInstance(STDIN, STDOUT, false); server.runlinter = true; run(server);']
       \ }
 
 function! SpaceVim#layers#lsp#set_variable(var) abort


### PR DESCRIPTION
# PR Prelude

Thank you for working on SpaceVim! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [ ] I have read and understood SpaceVim's [CONTRIBUTING][cont] document.
- [ ] I have read and understood SpaceVim's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful
currently, SpaceVim only support Julia 0.5 which is outdated. This will upgrade it to support Julia 0.6, which is widely used nowadays by using the lsp.
I am not familiar with vim programming, so could have errors I did not found.  
this PR is for fixing an issue: https://github.com/SpaceVim/SpaceVim/issues/1846

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md
[code]: https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md
