### PR TITLE
Update javascipt layer documentation to show toml config examples

### DIFF
--- a/docs/layers/lang/javascript.md
+++ b/docs/layers/lang/javascript.md
@@ -27,7 +27,7 @@ To use this configuration layer, update custom configuration file with:
 
 ```toml
 [[layers]]
-  name = "lang#javascript"
+name = "lang#javascript"
 ```
 
 ## Features
@@ -39,26 +39,16 @@ To use this configuration layer, update custom configuration file with:
 
 ## Layer configuration
 
-`auto_fix`: auto fix problems when save files, disabled by default. If you need this feature, you can load this layer via:
+`auto_fix`: auto fix problems when saving files, disabled by default.
 
-```vim
-call SpaceVim#layers#load('lang#javascript',
-            \ {
-            \ 'auto_fix' : 1,
-            \ }
-            \ )
+`enable_flow_syntax`: Enable configuration for [flow](https://flow.org/), disabled by default.
 
-```
-
-`enable_flow_syntax`: Enable configuration for [flow](https://flow.org/), disabled by default. If you need this feature, you can load this layer via:
-
-```vim
-call SpaceVim#layers#load('lang#javascript',
-            \ {
-            \ 'enable_flow_syntax' : 1,
-            \ }
-            \ )
-
+If you need these features, you can enable them in the layer config:
+```toml
+[[layers]]
+name = "lang#javascript"
+auto_fix = true
+enable_flow_syntax = true
 ```
 
 ## Key bindings


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I have updated the [Following-HADE](https://github.com/SpaceVim/SpaceVim/blob/master/wiki/en/Following-HEAD.md) page for this PR.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

While browsing through the layer docs, I found out that the javascript layer still uses vimscript for configuration. I updated it to include toml configs, because that is what all the other layer docs do.