### PR TITLE
Fix lsp support for haskell, javascript and typescript.

### DIFF
--- a/autoload/SpaceVim/layers/lang/haskell.vim
+++ b/autoload/SpaceVim/layers/lang/haskell.vim
@@ -31,11 +31,6 @@ function! SpaceVim#layers#lang#haskell#config() abort
   if SpaceVim#layers#lsp#check_filetype('haskell')
     call SpaceVim#mapping#gd#add('haskell',
           \ function('SpaceVim#lsp#go_to_def'))
-    if executable('hie-wrapper')
-      call SpaceVim#lsp#reg_server('haskell', ['hie-wrapper', '--lsp'])
-    else 
-      call SpaceVim#lsp#reg_server('haskell', ['hie', '--lsp'])
-    endif
   endif
 
   augroup SpaceVim_lang_haskell

--- a/autoload/SpaceVim/layers/lang/haskell.vim
+++ b/autoload/SpaceVim/layers/lang/haskell.vim
@@ -31,7 +31,11 @@ function! SpaceVim#layers#lang#haskell#config() abort
   if SpaceVim#layers#lsp#check_filetype('haskell')
     call SpaceVim#mapping#gd#add('haskell',
           \ function('SpaceVim#lsp#go_to_def'))
-    call SpaceVim#lsp#reg_server('haskell', ['hie', '--lsp'])
+    if executable('hie-wrapper')
+      call SpaceVim#lsp#reg_server('haskell', ['hie-wrapper', '--lsp'])
+    else 
+      call SpaceVim#lsp#reg_server('haskell', ['hie', '--lsp'])
+    endif
   endif
 
   augroup SpaceVim_lang_haskell

--- a/autoload/SpaceVim/layers/lsp.vim
+++ b/autoload/SpaceVim/layers/lsp.vim
@@ -81,7 +81,7 @@ let s:enabled_fts = []
 
 let s:lsp_servers = {
       \ 'javascript' : ['typescript-language-server', '--stdio'],
-      \ 'haskell' : ['hie', '--lsp'],
+      \ 'haskell' : ['hie-wrapper', '--lsp'],
       \ 'c' : ['clangd'],
       \ 'cpp' : ['clangd'],
       \ 'objc' : ['clangd'],

--- a/autoload/SpaceVim/layers/lsp.vim
+++ b/autoload/SpaceVim/layers/lsp.vim
@@ -80,7 +80,7 @@ endfunction
 let s:enabled_fts = []
 
 let s:lsp_servers = {
-      \ 'javascript' : ['typescript-language-server', '--stdio'],
+      \ 'typescript' : ['typescript-language-server', '--stdio'],
       \ 'haskell' : ['hie-wrapper', '--lsp'],
       \ 'c' : ['clangd'],
       \ 'cpp' : ['clangd'],
@@ -93,7 +93,7 @@ let s:lsp_servers = {
       \ 'html' : ['html-languageserver', '--stdio'],
       \ 'php' : ['php', g:spacevim_plugin_bundle_dir . 'repos/github.com/felixfbecker/php-language-server/bin/php-language-server.php'],
       \ 'julia' : ['julia', '--startup-file=no', '--history-file=no', '-e', 'using LanguageServer; server = LanguageServer.LanguageServerInstance(STDIN, STDOUT, false); server.runlinter = true; run(server);'],
-      \ 'typescript' : ['javascript-typescript-stdio']
+      \ 'javascript' : ['javascript-typescript-stdio']
       \ }
 
 function! SpaceVim#layers#lsp#set_variable(var) abort


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have updated the [Following-HADE](https://github.com/SpaceVim/SpaceVim/blob/master/wiki/en/Following-HEAD.md) page for this PR.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

1. use lsp.vim as the single truth of lsp config.  Do not config lsp in haskell.vim.  It can prevent the different behavior of loading layers in different order.
2. If there exists multi versions of ghc, and the projects ghc is not the same with the ghc compiling the `haskell-ide-egnine`, then the `hie` will throw an error of ghc version mismatch and stops working.  Therefore, we need to use the `hie-wrapper` with hie to start haskell language server for different versions.
3. fixes typo of `javascript` and `typescript` lsp.