### PR TITLE
Add: Dockerfile build for Neovim and SpaceVim

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Please complete these steps and check these boxes before filing your PR:
 
 - [ ] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
 - [ ] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
-- [ ] I have updated the [Following-HADE](https://github.com/SpaceVim/SpaceVim/blob/master/wiki/en/Following-HEAD.md) page for this PR.
+- [ ] I have updated the [Following-HEAD](https://github.com/SpaceVim/SpaceVim/blob/master/wiki/en/Following-HEAD.md) page for this PR.
 - [ ] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.
 
 ### Why this change is necessary and useful?

--- a/docker/Dockerfile.nvim-python3
+++ b/docker/Dockerfile.nvim-python3
@@ -1,0 +1,54 @@
+FROM python:3.6.5-stretch
+
+ENV DEBIAN_URL "http://ftp.us.debian.org/debian"
+
+RUN echo "deb $DEBIAN_URL testing main contrib non-free" >> /etc/apt/sources.list \
+  && apt-get update                                             \
+  && apt-get install -y                                         \
+    autoconf                                                    \
+    automake                                                    \
+    cmake                                                       \
+    fish                                                        \
+    g++                                                         \
+    gettext                                                     \
+    git                                                         \
+    libtool                                                     \
+    libtool-bin                                                 \
+    lua5.3                                                      \
+    ninja-build                                                 \
+    pkg-config                                                  \
+    unzip                                                       \
+    xclip                                                       \
+    xfonts-utils                                                \
+  && apt-get clean all
+
+RUN cd /usr/src                                                 \
+  && git clone https://github.com/neovim/neovim.git             \
+  && cd neovim                                                  \
+  && make CMAKE_BUILD_TYPE=RelWithDebInfo                       \
+          CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=/usr/local" \
+  && make install                                               \
+  && rm -r /usr/src/neovim
+
+ENV HOME /home/spacevim
+
+RUN groupdel users                                              \
+  && groupadd -r spacevim                                       \
+  && useradd --create-home --home-dir $HOME                     \
+             -r -g spacevim                                     \
+             spacevim
+
+USER spacevim
+
+WORKDIR $HOME
+ENV PATH "$HOME/.local/bin:${PATH}"
+
+RUN mkdir -p $HOME/.config $HOME/.SpaceVim.d
+
+RUN pip install --user neovim pipenv
+
+RUN curl -sLf https://spacevim.org/install.sh | bash
+
+RUN nvim --headless +'call dein#install()' +qall
+
+ENTRYPOINT /usr/local/bin/nvim

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,2 @@
+build:
+		docker build -t nvim -f Dockerfile.nvim-python3 .

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,37 @@
+## SpaceVim and Neovim in Docker
+This Dockerfile builds neovim `HEAD` and installs the latest available version of SpaceVim. You might want to use this for several reasons:
+
+* Have a consistent version of Neovim and SpaceVim as long as the machine supports Docker.
+* Try SpaceVim without modifying your current Vim/Neovim configuration.
+* Try the latest Neovim with SpaceVim.
+* Try SpaceVim with a newer version of Python.
+* Debug SpaceVim configurations. e.g. when posting a bug report if you can reproduce it in this container then there's a higher chance that it is a true bug and not just an issue with your machine.
+
+### FAQ
+Isn't Docker stateless? Won't I have to reinstall all plugins each time I launch the container?
+* During the build we call `dein#install()` so all plugins are installed and frozen. Your custom configurations can be added as an additional build step using the Docker `COPY` command.
+
+### Build
+You can build using the supplied `Makefile`:
+```
+make build
+```
+or call the command manually using:
+```
+docker build -t nvim -f Dockerfile.nvim-python3 .
+```
+
+### Run
+You can run the container using:
+```
+docker run -it nvim
+```
+but that isn't terribly useful since changes made inside the container won't be visible outside. More useful is mounting the current working directory inside the container:
+```
+docker run -it -v $(pwd):/home/spacevim/src nvim
+```
+
+Even better is an alias `dnvim` which will do this automatically:
+```
+alias dnvim="docker run -it -v $(pwd):/home/spacevim/src nvim"
+```

--- a/wiki/en/Following-HEAD.md
+++ b/wiki/en/Following-HEAD.md
@@ -13,6 +13,7 @@ The next release is v0.9.0.
 - Add lsp support for julia ([#1850](https://github.com/SpaceVim/SpaceVim/pull/1850))
 - Add lsp support for typescript ([#1870](https://github.com/SpaceVim/SpaceVim/pull/1870))
 - Add option for disabling parentheses autocompletion ([#1920](https://github.com/SpaceVim/SpaceVim/pull/1920))
+- Add Docker build of Neovim and SpaceVim ([#1923](https://github.com/SpaceVim/SpaceVim/pull/1923))
 
 ### Improvement
 


### PR DESCRIPTION
This commit introduces a self contained Neovim build which runs
SpaceVim. This has multiple uses:

* Easy debugging environment. Quickly check if the problem is your
machine or really a bug in SpaceVim.
* Portability across machines as long as the destination has Docker
support.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have updated the [Following-HADE](https://github.com/SpaceVim/SpaceVim/blob/master/wiki/en/Following-HEAD.md) page for this PR.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]
