### PR TITLE
Update python.md

### DIFF
--- a/docs/layers/lang/python.md
+++ b/docs/layers/lang/python.md
@@ -56,6 +56,12 @@ pip install --user flake8
 
 The default key binding for formatting buffer is `SPC b f`, and you need to install `yapf`. To enable automatic buffer formatting on save, load this layer with setting `format-on-save` to `1`.
 
+```
+[[layers]]
+  name = "lang#python"
+  format-on-save = 1
+```
+
 ```sh
 pip install --user yapf
 ```


### PR DESCRIPTION
Adding the example for automatic buffer formatting enabled on save.  (This doesn't work for me)

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [ ] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [ ] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I have updated the [Following-HEAD](https://github.com/SpaceVim/SpaceVim/blob/master/wiki/en/Following-HEAD.md) page for this PR.
- [ ] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?
It makes an example available so users find it simpler to implement.

[Please explain **in detail** why the changes in this PR are needed.]
The documentation is a little ambigious.