### PR TITLE
add mapping for NERDCommenterSexy

### DIFF
--- a/autoload/SpaceVim/layers/core.vim
+++ b/autoload/SpaceVim/layers/core.vim
@@ -229,6 +229,7 @@ function! SpaceVim#layers#core#config() abort
   call SpaceVim#mapping#space#def('nmap', ['c', 'v'], '<Plug>NERDCommenterInvertgv', 'comment or uncomment lines and keep visual', 0, 1)
   call SpaceVim#mapping#space#def('nmap', ['c', 'p'], 'vip<Plug>NERDCommenterComment', 'comment paragraphs', 0, 1)
   call SpaceVim#mapping#space#def('nmap', ['c', 'P'], 'vip<Plug>NERDCommenterInvert', 'toggle comment paragraphs', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', 's'], '<Plug>NERDCommenterSexy', 'comment with sexy/pretty layout', 0, 1)
 
   nnoremap <silent> <Plug>CommentToLine :call <SID>comment_to_line(0)<Cr>
   nnoremap <silent> <Plug>CommentToLineInvert :call <SID>comment_to_line(1)<Cr>

--- a/wiki/en/Following-HEAD.md
+++ b/wiki/en/Following-HEAD.md
@@ -52,6 +52,7 @@ The next release is v0.9.0.
 - Improve statusline for mundo buffer ([#2118](https://github.com/SpaceVim/SpaceVim/pull/2118))
 - Improve compatibility with old vim ([#2130](https://github.com/SpaceVim/SpaceVim/pull/2130))
 - Improve vimcompatible mode ([#2174](https://github.com/SpaceVim/SpaceVim/pull/2174))
+- Add mapping for NERDCommenterSexy ([#2180](https://github.com/SpaceVim/SpaceVim/pull/2180))
 
 ### Changed
 


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have updated the [Following-HEAD](https://github.com/SpaceVim/SpaceVim/blob/master/wiki/en/Following-HEAD.md) page for this PR.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

This allows us to make pretty comment which NERDCommenter labels as sexy comment. Their suggested default keymap is also `<leader>cs` so I also decided to basically use that here. I think its pretty useful than the others in nested blocks of code to get pretty formatted commenting