### PR TITLE
Fix: Typo in highlight project search

### DIFF
--- a/autoload/SpaceVim/plugins/highlight.vim
+++ b/autoload/SpaceVim/plugins/highlight.vim
@@ -279,7 +279,7 @@ endfunction
 
 " key binding: / search_project {{{
 function! s:search_project() abort
-  call spacevim#plugins#flygrep#open({'input' : s:current_match}) 
+  call SpaceVim#plugins#flygrep#open({'input' : s:current_match}) 
 endfunction
 " }}}
 

--- a/wiki/en/Following-HEAD.md
+++ b/wiki/en/Following-HEAD.md
@@ -86,6 +86,7 @@ The next release is v0.9.0.
 - Fix unkown v:progpath ([#2169](https://github.com/SpaceVim/SpaceVim/pull/2169))
 - Fix builtin statusline theme ([#2170](https://github.com/SpaceVim/SpaceVim/pull/2170))
 - Fix toggle cursorline highlighting ([#2171](https://github.com/SpaceVim/SpaceVim/pull/2171))
+- Fix searching for the cursor word in the project w/ FlyGrep ([#2183](https://github.com/SpaceVim/SpaceVim/pull/2183))
 
 ### Removed
 


### PR DESCRIPTION
Fix typo in the invocation of FlyGrep for searching the
highlighted word in the project dir so that the command functions
correctly.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have updated the [Following-HEAD](https://github.com/SpaceVim/SpaceVim/blob/master/wiki/en/Following-HEAD.md) page for this PR.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Before this change, searching the project for the highlighted word in FlyGrep was broken, this change fixes the issue so that Project searching of the highlighted word works again.