### PR TITLE
Improve Ruby language layer to accept a custom REPL

### DIFF
--- a/autoload/SpaceVim/layers/lang/ruby.vim
+++ b/autoload/SpaceVim/layers/lang/ruby.vim
@@ -12,10 +12,19 @@ function! SpaceVim#layers#lang#ruby#plugins() abort
         \ ]
 endfunction
 
+let s:ruby_repl_command = ''
+
 function! SpaceVim#layers#lang#ruby#config() abort
   call SpaceVim#plugins#runner#reg_runner('ruby', 'ruby %s')
   call SpaceVim#mapping#space#regesit_lang_mappings('ruby', function('s:language_specified_mappings'))
-  call SpaceVim#plugins#repl#reg('ruby', 'irb')
+  if !empty(s:ruby_repl_command)
+      call SpaceVim#plugins#repl#reg('ruby',s:ruby_repl_command)
+  else
+      call SpaceVim#plugins#repl#reg('ruby', 'irb')
+endfunction
+
+function! SpaceVim#layers#lang#ruby#set_variable(var) abort
+  let s:ruby_repl_command = get(a:var, 'repl_command', '') 
 endfunction
 
 function! s:language_specified_mappings() abort

--- a/docs/layers/lang/ruby.md
+++ b/docs/layers/lang/ruby.md
@@ -46,8 +46,21 @@ gem install rubocop
 
 ### Inferior REPL process
 
-Start a `irb` inferior REPL process with `SPC l s i`. 
+Start a `irb` inferior REPL process with `SPC l s i`. You may change the REPL command by layer option `repl_command`. For example, if you want to use `pry`, load this layer via:
 
+```toml
+[[layers]]
+    name = "lang#ruby"
+    repl_command = "pry"
+```
+
+however, if the executable is not on your $PATH, then you need to specify a complete file path.
+
+```toml
+[[layers]]
+    name = "lang#ruby"
+    repl_command = "/NOT/IN/YOUR/PATH/rubocop"
+```
 Send code to inferior process commands:
 
 | Key Binding | Description                                      |

--- a/wiki/en/Following-HEAD.md
+++ b/wiki/en/Following-HEAD.md
@@ -54,6 +54,7 @@ The next release is v0.9.0.
 - Improve compatibility with old vim ([#2130](https://github.com/SpaceVim/SpaceVim/pull/2130))
 - Improve vimcompatible mode ([#2174](https://github.com/SpaceVim/SpaceVim/pull/2174))
 - Add mapping for NERDCommenterSexy ([#2180](https://github.com/SpaceVim/SpaceVim/pull/2180))
+- Improve Ruby language layer to accept a custom REPL ([#2185] (https://github.com/SpaceVim/SpaceVim/pull/2185))
 
 ### Changed
 


### PR DESCRIPTION
Taking a cue from the Lua language layer, update the Ruby language layer
to support specify a custom REPL. This command expects a valid path to
an executable, so a file path would be required if the executable is not
on your $PATH.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have updated the [Following-HEAD](https://github.com/SpaceVim/SpaceVim/blob/master/wiki/en/Following-HEAD.md) page for this PR.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?
This change is useful because it will allow Ruby developers who have a nicely configured Pry console to work with that instead of the default irb.  Simple customization that yields a nice benefit.

[Please explain **in detail** why the changes in this PR are needed.]
