### PR TITLE
ui.vim: Default │ instead of ┊

### DIFF
--- a/autoload/SpaceVim/layers/ui.vim
+++ b/autoload/SpaceVim/layers/ui.vim
@@ -27,16 +27,19 @@ function! SpaceVim#layers#ui#plugins() abort
 endfunction
 
 function! SpaceVim#layers#ui#config() abort
+  " IndentLine plugin settings
   if g:spacevim_colorscheme_bg ==# 'dark'
     let g:indentLine_color_term = get(g:, 'indentLine_color_term', 239)
     let g:indentLine_color_gui = get(g:, 'indentLine_color_gui', '#504945')
   else
     let g:indentLine_color_gui = get(g:, 'indentLine_color_gui', '#d5c4a1')
   endif
-  let g:indentLine_char = get(g:, 'indentLine_char', '┊')
+  let g:indentLine_char = get(g:, 'indentLine_char', '│')
   let g:indentLine_concealcursor = 'niv'
   let g:indentLine_conceallevel = 2
   let g:indentLine_fileTypeExclude = ['help', 'man', 'startify', 'vimfiler']
+  IndentLinesReset
+
   let g:better_whitespace_filetypes_blacklist = ['diff', 'gitcommit', 'unite',
         \ 'qf', 'help', 'markdown', 'leaderGuide',
         \ 'startify'


### PR DESCRIPTION
I found visually pleasurable to see a continued line, instead of lines with points.

Run `IndentLinesReset` in the end because sometimes it's not applied.

This could be just a personal matter of taste. So, reject the PR is an option.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have updated the [Following-HEAD](https://github.com/SpaceVim/SpaceVim/blob/master/wiki/en/Following-HEAD.md) page for this PR.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]
