### PR TITLE
Fixed missing endif at ruby config layer

### DIFF
--- a/autoload/SpaceVim/layers/lang/ruby.vim
+++ b/autoload/SpaceVim/layers/lang/ruby.vim
@@ -21,6 +21,7 @@ function! SpaceVim#layers#lang#ruby#config() abort
       call SpaceVim#plugins#repl#reg('ruby',s:ruby_repl_command)
   else
       call SpaceVim#plugins#repl#reg('ruby', 'irb')
+  endif
 endfunction
 
 function! SpaceVim#layers#lang#ruby#set_variable(var) abort


### PR DESCRIPTION
This PR intends to fix the missing `endif` keyword at ruby layer introduced in the latest version