### PR TITLE
Add mapping to toggle conceal level

### DIFF
--- a/autoload/SpaceVim/layers/ui.vim
+++ b/autoload/SpaceVim/layers/ui.vim
@@ -55,6 +55,8 @@ function! SpaceVim#layers#ui#config() abort
         \ 'highlight-long-lines', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['t', 'b'], 'call ToggleBG()',
         \ 'toggle background', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['t', 'c'], 'call ToggleConceal()',
+        \ 'toggle conceal', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['t', 't'], 'call SpaceVim#plugins#tabmanager#open()',
         \ 'Open tabs manager', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['t', 'f'], 'call call('

--- a/config/functions.vim
+++ b/config/functions.vim
@@ -43,6 +43,13 @@ function! ToggleBG()
         set background=dark
     endif
 endfunction
+function! ToggleConceal()
+    if &conceallevel == 0 
+        setlocal conceallevel=2
+    else
+        setlocal conceallevel=0
+    endif
+endfunction
 function! BracketsFunc()
     let line = getline('.')
     let col = col('.')

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -421,6 +421,7 @@ Some UI indicators can be toggled on and off (toggles start with t and T):
 | `SPC t i`   | toggle indentation guide at point                        |
 | `SPC t n`   | toggle line numbers                                      |
 | `SPC t b`   | toggle background                                        |
+| `SPC t c`   | toggle conceal                                           |
 | `SPC t t`   | open tabs manager                                        |
 | `SPC T ~`   | display ~ in the fringe on empty lines                   |
 | `SPC T F`   | toggle frame fullscreen                                  |


### PR DESCRIPTION
[SPC] t c
toggles between conceallevel=0 and 2

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have updated the [Following-HEAD](https://github.com/SpaceVim/SpaceVim/blob/master/wiki/en/Following-HEAD.md) page for this PR.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

I personally toggle conceallevel frequently when editing latex or markdown/pandoc files.
conceallevel is a general function and may be usefull for others.

It's similar to tpope/vim-unimpaired#105
Might also be usefull for #2095
