### PR TITLE
make tmux navigator modifier configuarable

### DIFF
--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -325,6 +325,8 @@ let g:spacevim_enable_cursorline       = 1
 let g:spacevim_statusline_separator = 'arrow'
 let g:spacevim_statusline_inactive_separator = 'arrow'
 
+let g:spacevim_tmux_navigator_modifier = 'ctrl'
+
 ""
 " Define the left section of statusline in active windows. By default:
 " >

--- a/autoload/SpaceVim/layers/tmux.vim
+++ b/autoload/SpaceVim/layers/tmux.vim
@@ -47,10 +47,18 @@ function! SpaceVim#layers#tmux#config() abort
     autocmd FocusLost * set nocursorline | redraw!
   augroup END
 
-  nnoremap <silent> <C-h> :TmuxNavigateLeft<CR>
-  nnoremap <silent> <C-j> :TmuxNavigateDown<CR>
-  nnoremap <silent> <C-k> :TmuxNavigateUp<CR>
-  nnoremap <silent> <C-l> :TmuxNavigateRight<CR>
+  if s:tmux_navigator_modifier ==# 'alt'
+    nnoremap <silent> <M-h> :TmuxNavigateLeft<CR>
+    nnoremap <silent> <M-j> :TmuxNavigateDown<CR>
+    nnoremap <silent> <M-k> :TmuxNavigateUp<CR>
+    nnoremap <silent> <M-l> :TmuxNavigateRight<CR>
+  else
+  " elseif s:tmux_navigator_modifier ==# 'ctrl'
+    nnoremap <silent> <C-h> :TmuxNavigateLeft<CR>
+    nnoremap <silent> <C-j> :TmuxNavigateDown<CR>
+    nnoremap <silent> <C-k> :TmuxNavigateUp<CR>
+    nnoremap <silent> <C-l> :TmuxNavigateRight<CR>
+  endif
   let g:neomake_tmux_enabled_makers = ['tmux']
   let g:neomake_tmux_tmux_maker = {
         \ 'exe': 'tmux',
@@ -123,11 +131,15 @@ function! SpaceVim#layers#tmux#set_variable(var) abort
         \ 'tmuxline_separators_alt',
         \ g:spacevim_statusline_inactive_separator)
 
+  let s:tmux_navigator_modifier = get(a:var,
+        \ 'tmux_navigator_modifier',
+        \ g:spacevim_tmux_navigator_modifier)
+
 endfunction
 
 
 function! SpaceVim#layers#tmux#get_options() abort
 
-  return ['tmuxline_separators', 'tmuxline_separators_alt']
+  return ['tmuxline_separators', 'tmuxline_separators_alt', 'tmux_navigator_modifier']
 
 endfunction


### PR DESCRIPTION
[options]
tmux_navigator_modifier = 'alt'

currently only 'alt' and the default 'ctrl' is possible

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have updated the [Following-HEAD](https://github.com/SpaceVim/SpaceVim/blob/master/wiki/en/Following-HEAD.md) page for this PR.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

The modifier for tmux navigator should be configurable 
This PR allows the option tmux_navigator_modifier = 'alt' in init.toml
The default remains 'ctrl'
This might be extended to other options
