### PR TITLE
Fix for https://github.com/SpaceVim/SpaceVim/issues/2301.

### DIFF
--- a/autoload/SpaceVim/layers/github.vim
+++ b/autoload/SpaceVim/layers/github.vim
@@ -47,7 +47,8 @@ function! SpaceVim#layers#github#config() abort
   let g:_spacevim_mappings_space.g.g = { 'name': '+Gist' }
 
   " @todo remove the username
-  call SpaceVim#mapping#space#def('nnoremap', ['g', 'g', 'l'], 'Gista list -u wsdjeg',
+  " autoload to set default username
+  call SpaceVim#mapping#space#def('nnoremap', ['g', 'g', 'l'], 'Gista list',
         \ 'list gist', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['g', 'g', 'p'], 'Gista post',
         \ 'post selection or current file', 1, 1)

--- a/docs/layers/github.md
+++ b/docs/layers/github.md
@@ -10,6 +10,7 @@ description: "This layer provides GitHub integration for SpaceVim"
 - [Description](#description)
 - [Install](#install)
 - [Key bindings](#key-bindings)
+- [Extra configuration for GitHub and Gist](#extra-configuration-for-github-and-gist)
 
 <!-- vim-markdown-toc -->
 
@@ -38,3 +39,20 @@ To use this configuration layer, add following snippet to your custom configurat
 | `SPC g h p` | show PRs in browser          |
 | `SPC g g l` | list all gist                |
 | `SPC g g p` | post gist                    |
+
+## Extra configuration for GitHub and Gist
+
+For avoid repeating input the account name and passwrod, you need to add the belowing contennt for auto .SpaceVim.d/autoload/myspacevim.vim [Bootstrap Functions](https://spacevim.org/documentation/#bootstrap-functions). 
+
+```vim
+func! myspacevim#before() abort
+  "other configs
+  let g:github_dashboard = { 'username': 'yourgithubuser', 'password': $GITHUB_TOKEN }
+  let g:gista#client#default_username = 'monkeyxite'
+endf
+```
+Refer [github dashboar](https://github.com/junegunn/vim-github-dashboard), for security concerns you could create a Personal Access Token, export it as an environment variable and use it as a password.
+```shell
+# in some secure file sourced in your .bashrc, .bash_profile, .zshrc, etc.
+export GITHUB_TOKEN="<your 40 char token>"
+```


### PR DESCRIPTION
Updated for  remove username  in github layer & doc.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [ X] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [ X] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [ X] I have updated the [Following-HEAD](https://github.com/SpaceVim/SpaceVim/blob/master/wiki/en/Following-HEAD.md) page for this PR.
- [ X] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]

There is todo item in github layer since each gist list action would only show specific user "wsdjeg". Therefor a new issue #2301 is created and in the layer vim updated to remove the username and specify how to config the usename and passwd in layer github doc.