### PR TITLE
Detach syntax file for FlyGrep

### DIFF
--- a/.ci/detach_plugin.sh
+++ b/.ci/detach_plugin.sh
@@ -15,6 +15,7 @@ main () {
         flygrep)
             git clone https://github.com/wsdjeg/FlyGrep.vim.git detach/$1
             cd detach/$1
+            _checkdir syntax/
             _checkdir autoload/SpaceVim/api
             _checkdir autoload/SpaceVim/api/vim
             _checkdir autoload/SpaceVim/api/data
@@ -31,6 +32,7 @@ main () {
             _detect autoload/SpaceVim/api/system.vim
             _detect autoload/SpaceVim/mapping/search.vim
             _detect autoload/SpaceVim/logger.vim
+            _detect syntax/SpaceVimFlyGrep.vim
             _detect LICENSE
             git add .
             git commit -m "Auto Update"

--- a/wiki/en/Following-HEAD.md
+++ b/wiki/en/Following-HEAD.md
@@ -36,6 +36,7 @@ The next release is v1.0.0.
 - Fix comment paragraphs key bindings ([#2340](https://github.com/SpaceVim/SpaceVim/pull/2340))
 - Fix dein-ui error, add syntax ([#2352](https://github.com/SpaceVim/SpaceVim/pull/2352), [`c9e1d4c`](https://github.com/SpaceVim/SpaceVim/commit/c9e1d4c9635c483bb3334c00ed36026d18950070))
 - Fix fullscreen key binding ([#2351](https://github.com/SpaceVim/SpaceVim/pull/2351))
+- Added missed syntax for detached FlyGrep ([#2353](https://github.com/SpaceVim/SpaceVim/pull/2353), [`08d0713`](https://github.com/SpaceVim/SpaceVim/commit/08d0713c4494ca401942a6ca10a48a1ac8484ce1))
 
 ### Removed
 


### PR DESCRIPTION
- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have updated the [Following-HEAD](https://github.com/SpaceVim/SpaceVim/blob/master/wiki/en/Following-HEAD.md) page for this PR.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

To fix syntax highlight for FlyGrep apart from SpaceVim.

Related links:
- https://github.com/SpaceVim/SpaceVim/commit/c9e1d4c9635c483bb3334c00ed36026d18950070
- https://github.com/wsdjeg/dein-ui.vim/issues/4

@wsdjeg I just did exactly what you did for __dein-ui__.