### PR TITLE
Add more useful key bindings for typescript layer

### DIFF
--- a/autoload/SpaceVim/layers/lang/typescript.vim
+++ b/autoload/SpaceVim/layers/lang/typescript.vim
@@ -77,10 +77,18 @@ function! s:on_ft() abort
       call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 't'], 'TSType',
             \ 'view type', 1)
     else
+      call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'c'], 'TsuTypeDefinition',
+            \ 'type definition', 1)
       call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'd'], 'TsuquyomiSignatureHelp',
             \ 'show document', 1)
       call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'e'], 'TsuquyomiRenameSymbol',
             \ 'rename symbol', 1)
+      call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'i'], 'TsuImport',
+            \ 'import', 1)
+      call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'm'], 'TsuImplementation',
+            \ 'interface implementations', 1)
+      call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'r'], 'TsuquyomiReferences',
+            \ 'references', 1)
     endif
   endif
 endfunction


### PR DESCRIPTION
I've been working with typescript lately and I've noticed that only these options are available in my SpaceVim (I'm on vim 8.1) in the language layer:
- [d] show document
- [e] rename symbol

I looked at the code and there are defined more of them but only for nvim. For vim the __tsuquyomi__ plugin is used but it has many more useful features than those two listed.

This PR adds following options:
- [c] type definition
- [i] import
- [m] interface implementations
- [r] references
