### PR TITLE
Fixed regex in SpaceVimFlyGrep syntax file

### DIFF
--- a/syntax/SpaceVimFlyGrep.vim
+++ b/syntax/SpaceVimFlyGrep.vim
@@ -4,5 +4,5 @@ endif
 let b:current_syntax = 'SpaceVimFlyGrep'
 syntax case ignore
 
-syn match FileName /[^:]*:\d\+:\d\+:/
+syn match FileName /[^:]*:\d\+:\(\d\+:\)\?/
 hi def link FileName Comment

--- a/wiki/en/Following-HEAD.md
+++ b/wiki/en/Following-HEAD.md
@@ -39,6 +39,7 @@ The next release is v1.0.0.
 - Fix dein-ui error, add syntax ([#2352](https://github.com/SpaceVim/SpaceVim/pull/2352), [`c9e1d4c`](https://github.com/SpaceVim/SpaceVim/commit/c9e1d4c9635c483bb3334c00ed36026d18950070))
 - Fix fullscreen key binding ([#2351](https://github.com/SpaceVim/SpaceVim/pull/2351))
 - Added missed syntax for detached FlyGrep ([#2353](https://github.com/SpaceVim/SpaceVim/pull/2353), [`08d0713`](https://github.com/SpaceVim/SpaceVim/commit/08d0713c4494ca401942a6ca10a48a1ac8484ce1))
+- Fix FlyGrep syntax to support different outputs ([#2363](https://github.com/SpaceVim/SpaceVim/pull/2363), [`0b26f40`](https://github.com/SpaceVim/SpaceVim/commit/0b26f407d879427505418f5c3b4c1d753f3f4317))
 
 ### Removed
 


### PR DESCRIPTION
- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have updated the [Following-HEAD](https://github.com/SpaceVim/SpaceVim/blob/master/wiki/en/Following-HEAD.md) page for this PR.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Second number (column?) may not be presented in the FlyGrep output.

In my own case: 
![screenshot from 2018-12-19 01-55-01](https://user-images.githubusercontent.com/799353/50188955-77868c80-0334-11e9-998c-fcd01f2e0bd0.png)
