### PR TITLE
[issue#2367]: clear rootDir cache after rooter pattern changed

### DIFF
--- a/autoload/SpaceVim/plugins/projectmanager.vim
+++ b/autoload/SpaceVim/plugins/projectmanager.vim
@@ -16,6 +16,7 @@
 
 
 call add(g:spacevim_project_rooter_patterns, '.SpaceVim.d/')
+let s:spacevim_project_rooter_patterns = copy(g:spacevim_project_rooter_patterns)
 
 let s:project_paths = {}
 
@@ -79,6 +80,12 @@ function! SpaceVim#plugins#projectmanager#reg_callback(func) abort
 endfunction
 
 function! SpaceVim#plugins#projectmanager#current_root() abort
+  " if rooter patterns changed, clear cache.
+  " https://github.com/SpaceVim/SpaceVim/issues/2367
+  if join(g:spacevim_project_rooter_patterns, ':') !=# join(s:spacevim_project_rooter_patterns, ':')
+    call setbufvar('%', 'rootDir', '')
+    let s:spacevim_project_rooter_patterns = copy(g:spacevim_project_rooter_patterns)
+  endif
   let rootdir = getbufvar('%', 'rootDir', '')
   if empty(rootdir)
     let rootdir = s:find_root_directory()

--- a/wiki/en/Following-HEAD.md
+++ b/wiki/en/Following-HEAD.md
@@ -44,6 +44,7 @@ The next release is v1.0.0.
 - Fix FlyGrep syntax to support different outputs ([#2363](https://github.com/SpaceVim/SpaceVim/pull/2363), [`0b26f40`](https://github.com/SpaceVim/SpaceVim/commit/0b26f407d879427505418f5c3b4c1d753f3f4317))
 - Fix `project_rooter_automatically = 0` option to not change directory to project root ([#2363](https://github.com/SpaceVim/SpaceVim/pull/2365))
 - Add log for generate configuration file ([#2369](https://github.com/SpaceVim/SpaceVim/pull/2369))
+- Clear rootDir cache after rooter pattern change([#2370](https://github.com/SpaceVim/SpaceVim/pull/2370))
 
 ### Removed
 


### PR DESCRIPTION
  > SpaceVim will try to find root before loadding custom config,
  > so that is why It can not find your project root. yes, if the
  > project rooter patterns is change the cache should be cleared.

  The fix here is create a shadow copy of
  `g:spacevim_project_rooter_pattern` and if user changed it should
  be different from the shadow version, we clear the cache and sync
  them again.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have updated the [Following-HEAD](https://github.com/SpaceVim/SpaceVim/blob/master/wiki/en/Following-HEAD.md) page for this PR.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]
