### PR TITLE
rewrite hitory match results, supporting continous open search result…

### DIFF
--- a/autoload/SpaceVim/api/prompt.vim
+++ b/autoload/SpaceVim/api/prompt.vim
@@ -44,13 +44,14 @@ let s:self._quit = 1
 let s:self._handle_fly = ''
 let s:self._onclose = ''
 let s:self._oninputpro = ''
-
+let s:last_search_str  = ''
 
 
 func! s:self.open() abort
   let self._quit = 0
   let save_redraw = &lazyredraw
   set nolazyredraw
+  let  self._prompt.begin = s:last_search_str 
   call self._build_prompt()
   if !empty(self._prompt.begin)
     call self._handle_input(self._prompt.begin)
@@ -121,11 +122,13 @@ func! s:self._handle_input(...) abort
     elseif char ==# "\<bs>"
       let self._prompt.begin = substitute(self._prompt.begin,'.$','','g')
       call self._build_prompt()
-    elseif char == self._keys.close
+    elseif((char == self._keys.close) || (char ==# "\<C-l>" ))
       call self.close()
       break
     elseif char ==# "\<FocusLost>" || char ==# "\<FocusGained>" || char2nr(char) == 128
       continue
+    elseif char ==# "\<C-d>"
+      call self._clear_prompt()
     else
       let self._prompt.begin .= char
       call self._build_prompt()
@@ -153,6 +156,7 @@ func! s:self._build_prompt() abort
 endf
 
 function! s:self._clear_prompt() abort
+  let s:last_search_str = self._prompt.begin
   let self._prompt = {
         \ 'mpt' : self._prompt.mpt,
         \ 'begin' : '',
@@ -168,6 +172,7 @@ function! s:self.close() abort
   call self._clear_prompt()
   normal! :
   let self._quit = 1
+  let g:flygrep_status = 'exit' 
 endfunction
 
 function! SpaceVim#api#prompt#get() abort

--- a/autoload/SpaceVim/api/prompt.vim
+++ b/autoload/SpaceVim/api/prompt.vim
@@ -45,13 +45,19 @@ let s:self._handle_fly = ''
 let s:self._onclose = ''
 let s:self._oninputpro = ''
 let s:last_search_str  = ''
-
+let s:self.last_search = {
+      \ 'begin' : '',
+      \ 'cursor' : '',
+      \ 'end' : '',
+      \ }
 
 func! s:self.open() abort
   let self._quit = 0
   let save_redraw = &lazyredraw
   set nolazyredraw
-  let  self._prompt.begin = s:last_search_str 
+  let self._prompt.begin = s:self.last_search.begin
+  let self._prompt.cursor = s:self.last_search.cursor
+  let self._prompt.end = s:self.last_search.end
   call self._build_prompt()
   if !empty(self._prompt.begin)
     call self._handle_input(self._prompt.begin)
@@ -77,6 +83,7 @@ func! s:self._handle_input(...) abort
     endif
     call self._build_prompt()
   endif
+
   while self._quit == 0
     let char = self._getchar()
     if has_key(self._function_key, char)
@@ -145,6 +152,7 @@ endf
 func! s:self._build_prompt() abort
   let ident = repeat(' ', self.__cmp.win_screenpos(0)[1] - 1)
   redraw
+
   echohl Comment | echon ident . self._prompt.mpt
   echohl None | echon self._prompt.begin
   echohl Wildmenu | echon self._prompt.cursor
@@ -152,11 +160,14 @@ func! s:self._build_prompt() abort
   if empty(self._prompt.cursor) && !has('nvim')
     echohl Comment | echon '_' | echohl None
   endif
+  redraw
   " FIXME: Macvim need extra redraw, 
 endf
 
 function! s:self._clear_prompt() abort
-  let s:last_search_str = self._prompt.begin
+  let s:self.last_search.begin = self._prompt.begin 
+  let s:self.last_search.cursor = self._prompt.cursor
+  let s:self.last_search.end = self._prompt.end 
   let self._prompt = {
         \ 'mpt' : self._prompt.mpt,
         \ 'begin' : '',
@@ -172,7 +183,6 @@ function! s:self.close() abort
   call self._clear_prompt()
   normal! :
   let self._quit = 1
-  let g:flygrep_status = 'exit' 
 endfunction
 
 function! SpaceVim#api#prompt#get() abort

--- a/autoload/SpaceVim/plugins/flygrep.vim
+++ b/autoload/SpaceVim/plugins/flygrep.vim
@@ -6,6 +6,11 @@
 " License: GPLv3
 "=============================================================================
 
+"search result chose line indent
+let s:line_indent = 0 
+"running status for flygrep
+let g:flygrep_status = ''
+
 " Loadding SpaceVim api {{{
 scriptencoding utf-8
 let s:MPT = SpaceVim#api#import('prompt')
@@ -30,7 +35,7 @@ let [
 let s:grep_timer_id = -1
 let s:preview_timer_id = -1
 let s:grepid = 0
-let s:grep_history = []
+let s:grep_history = ['','','','','','','','','','','','','','','','','','','','','','','','','','','','','','']
 let s:complete_input_history_num = [0,0]
 " }}}
 
@@ -148,6 +153,13 @@ function! s:flygrep(expr) abort
   endtr
   hi def link FlyGrepPattern MoreMsg
   let s:hi_id = s:matchadd('FlyGrepPattern', s:expr_to_pattern(a:expr), 2)
+  "if no restart , line_indent show be reset
+  if g:flygrep_status !=# 'restart'
+    let s:line_indent = 0 
+  else
+    let g:flygrep_status = 'run'
+  endif
+  
   let s:grep_expr = a:expr
   call timer_stop(s:grep_timer_id)
   let s:grep_timer_id = timer_start(200, function('s:grep_timer'), {'repeat' : 1})
@@ -294,6 +306,12 @@ function! s:grep_stderr(id, data, event) abort
 endfunction
 
 function! s:grep_exit(id, data, event) abort
+  "in restart case, line show back to line_indent
+  if s:line_indent != 0
+    exe "normal! " . s:line_indent . "j"
+  endif
+  redraw
+
   redrawstatus
   let s:grepid = 0
 endfunction
@@ -306,8 +324,10 @@ endfunction
 function! s:next_item() abort
   if line('.') == line('$')
     normal! gg
+    let s:line_indent = 0 
   else
     normal! j
+    let s:line_indent = s:line_indent + 1
   endif
   if s:preview_able == 1
     call s:preview()
@@ -360,8 +380,10 @@ endfunction
 function! s:previous_item() abort
   if line('.') == 1
     normal! G
+    let s:line_indent = line('$') -1
   else
     normal! k
+    let s:line_indent = s:line_indent - 1
   endif
   if s:preview_able == 1
     call s:preview()
@@ -371,27 +393,46 @@ function! s:previous_item() abort
   redrawstatus
 endfunction
 
+let s:grep_history_max = 30
+let s:grep_history_head = 0
+let s:grep_history_front = 0
+let s:grep_history_current = 0 
+let s:grep_history_old_front = 0 
+
+function! s:add_history(grep_expr) abort
+
+  if ( (a:grep_expr !=# '') && (a:grep_expr !=# s:grep_history[ s:grep_history_old_front ]))
+    let s:grep_history_old_front = s:grep_history_front
+    let s:grep_history_front = (s:grep_history_front + 1) % s:grep_history_max
+    if( s:grep_history_front == s:grep_history_head )
+      let s:grep_history_head = (s:grep_history_head + 1) % s:grep_history_max
+    endif
+    let  s:grep_history[ s:grep_history_old_front ] = a:grep_expr
+    let s:grep_history_current = s:grep_history_old_front 
+  endif
+
+endfunction
+
 function! s:open_item() abort
-  call add(s:grep_history, s:grep_expr)
-  let s:MPT._handle_fly = function('s:flygrep')
-  if getline('.') !=# ''
-    if s:grepid != 0
-      call s:JOB.stop(s:grepid)
-    endif
-    call s:MPT._clear_prompt()
-    let s:MPT._quit = 1
-    let line = getline('.')
-    let filename = fnameescape(split(line, ':\d\+:')[0])
-    let linenr = matchstr(line, ':\d\+:')[1:-2]
-    let colum = matchstr(line, '\(:\d\+\)\@<=:\d\+:')[1:-2]
-    if s:preview_able == 1
-      pclose
-    endif
-    let s:preview_able = 0
-    noautocmd q
-    exe 'e ' . filename
-    call cursor(linenr, colum)
-    noautocmd normal! :
+   call s:add_history(s:grep_expr)
+   let s:MPT._handle_fly = function('s:flygrep')
+   if getline('.') !=# ''
+     
+     if s:grepid != 0
+       call s:JOB.stop(s:grepid)
+     endif
+     
+     let line = getline('.')
+     let filename = fnameescape(split(line, ':\d\+:')[0])
+     let linenr = matchstr(line, ':\d\+:')[1:-2]
+     let colum = matchstr(line, '\(:\d\+\)\@<=:\d\+:')[1:-2]
+     exe "normal! \<c-w>p"
+     exe 'e ' . filename
+     call cursor(linenr, colum)
+     exe "normal! \<c-w>p"
+     redraw
+     call s:MPT._build_prompt()
+     redrawstatus
   endif
 endfunction
 
@@ -484,44 +525,23 @@ endfunction
 
 let s:complete_input_history_base = ''
 function! s:previous_match_history() abort
-  if s:complete_input_history_num == [0,0]
-    let s:complete_input_history_base = s:MPT._prompt.begin
-    let s:MPT._prompt.cursor = ''
-    let s:MPT._prompt.end = ''
-  else
-    let s:MPT._prompt.begin = s:complete_input_history_base
+  if( s:grep_history_current != s:grep_history_head )
+    let s:grep_history_current = (s:grep_history_current + s:grep_history_max -1 ) % s:grep_history_max
+    let s:MPT._prompt.begin = s:grep_history[s:grep_history_current] 
+    normal! "_ggdG
+    call s:MPT._handle_fly(s:MPT._prompt.begin . s:MPT._prompt.cursor .s:MPT._prompt.end)
   endif
-  let s:complete_input_history_num[0] += 1
-  let s:MPT._prompt.begin = s:complete_input_history(s:complete_input_history_base, s:complete_input_history_num)
-  normal! "_ggdG
-  call s:MPT._handle_fly(s:MPT._prompt.begin . s:MPT._prompt.cursor .s:MPT._prompt.end)
 endfunction
 
 function! s:next_match_history() abort
-
-  if s:complete_input_history_num == [0,0]
-    let s:complete_input_history_base = s:MPT._prompt.begin
-    let s:MPT._prompt.cursor = ''
-    let s:MPT._prompt.end = ''
-  else
-    let s:MPT._prompt.begin = s:complete_input_history_base
-  endif
-  let s:complete_input_history_num[1] += 1
-  let s:MPT._prompt.begin = s:complete_input_history(s:complete_input_history_base, s:complete_input_history_num)
-  normal! "_ggdG
-  call s:MPT._handle_fly(s:MPT._prompt.begin . s:MPT._prompt.cursor .s:MPT._prompt.end)
-endfunction
-
-function! s:complete_input_history(str,num) abort
-  let results = filter(copy(s:grep_history), "v:val =~# '^' . a:str")
-  if len(results) > 0
-    call add(results, a:str)
-    let index = ((len(results) - 1) - a:num[0] + a:num[1]) % len(results)
-    return results[index]
-  else
-    return a:str
+  if(s:grep_history_current != s:grep_history_old_front)
+    let s:grep_history_current = (s:grep_history_current + 1 ) % s:grep_history_max
+    let s:MPT._prompt.begin = s:grep_history[s:grep_history_current] 
+    normal! "_ggdG
+    call s:MPT._handle_fly(s:MPT._prompt.begin . s:MPT._prompt.cursor .s:MPT._prompt.end)
   endif
 endfunction
+
 let s:MPT._function_key = {
       \ "\<Tab>" : function('s:next_item'),
       \ "\<C-j>" : function('s:next_item'),
@@ -566,69 +586,72 @@ endif
 " files: files for grep, @buffers means listed buffer.
 " dir: specific a directory for grep
 function! SpaceVim#plugins#flygrep#open(agrv) abort
-  if empty(s:grep_default_exe)
-    call SpaceVim#logger#warn(' [flygrep] make sure you have one search tool in your PATH', 1)
-    return
-  endif
-  let s:mode = ''
-  " set default handle func: s:flygrep
-  let s:MPT._handle_fly = function('s:flygrep')
-  noautocmd rightbelow split __flygrep__
-  let s:flygrep_buffer_id = bufnr('%')
-  setlocal buftype=nofile bufhidden=wipe nobuflisted nolist noswapfile nowrap cursorline nospell nonu norelativenumber
-  let save_tve = &t_ve
-  setlocal t_ve=
-  if has('gui_running')
-    let cursor_hi = s:HI.group2dict('Cursor')
-    let g:wsd = cursor_hi
-    call s:HI.hide_in_normal('Cursor')
-  endif
-  " setlocal nomodifiable
-  setf SpaceVimFlyGrep
-  call s:matchadd('FileName', '[^:]*:\d\+:\d\+:', 3)
-  let s:MPT._prompt.begin = get(a:agrv, 'input', '')
-  let fs = get(a:agrv, 'files', '')
-  if fs ==# '@buffers'
-    let s:grep_files = map(s:BUFFER.listed_buffers(), 'bufname(v:val)')
-  elseif !empty(fs)
-    let s:grep_files = fs
-  else
-    let s:grep_files = ''
-  endif
-  let dir = expand(get(a:agrv, 'dir', ''))
-  if !empty(dir) && isdirectory(dir)
-    let s:grep_dir = dir
-  else
-    let s:grep_dir = ''
-  endif
-  let s:grep_exe = get(a:agrv, 'cmd', s:grep_default_exe)
-  if empty(s:grep_dir) && empty(s:grep_files) && s:grep_exe == 'findstr'
-    let s:grep_files = '*.*'
-  elseif s:grep_exe == 'findstr' && !empty(s:grep_dir)
-    let s:grep_dir = '/D:' . s:grep_dir
-  endif
-  let s:grep_opt = get(a:agrv, 'opt', s:grep_default_opt)
-  let s:grep_ropt = get(a:agrv, 'ropt', s:grep_default_ropt)
-  let s:grep_ignore_case = get(a:agrv, 'ignore_case', s:grep_default_ignore_case)
-  let s:grep_smart_case  = get(a:agrv, 'smart_case', s:grep_default_smart_case)
-  let s:grep_expr_opt  = get(a:agrv, 'expr_opt', s:grep_default_expr_opt)
-  call SpaceVim#logger#info('FlyGrep startting ===========================')
-  call SpaceVim#logger#info('   executable    : ' . s:grep_exe)
-  call SpaceVim#logger#info('   option        : ' . string(s:grep_opt))
-  call SpaceVim#logger#info('   r_option      : ' . string(s:grep_ropt))
-  call SpaceVim#logger#info('   files         : ' . string(s:grep_files))
-  call SpaceVim#logger#info('   dir           : ' . string(s:grep_dir))
-  call SpaceVim#logger#info('   ignore_case   : ' . string(s:grep_ignore_case))
-  call SpaceVim#logger#info('   smart_case    : ' . string(s:grep_smart_case))
-  call SpaceVim#logger#info('   expr opt      : ' . string(s:grep_expr_opt))
-  " sometimes user can not see the flygrep windows, redraw only once.
-  redraw
-  call s:MPT.open()
-  call SpaceVim#logger#info('FlyGrep ending    ===========================')
-  let &t_ve = save_tve
-  if has('gui_running')
-    call s:HI.hi(cursor_hi)
-  endif
+  let g:flygrep_status = 'restart'
+  while g:flygrep_status !=# 'exit' 
+    if empty(s:grep_default_exe)
+      call SpaceVim#logger#warn(' [flygrep] make sure you have one search tool in your PATH', 1)
+      return
+    endif
+    let s:mode = ''
+    " set default handle func: s:flygrep
+    let s:MPT._handle_fly = function('s:flygrep')
+    noautocmd rightbelow split __flygrep__
+    let s:flygrep_buffer_id = bufnr('%')
+    setlocal buftype=nofile bufhidden=wipe  nolist noswapfile nowrap cursorline nospell  norelativenumber
+    let save_tve = &t_ve
+    setlocal t_ve=
+    if has('gui_running')
+      let cursor_hi = s:HI.group2dict('Cursor')
+      let g:wsd = cursor_hi
+      call s:HI.hide_in_normal('Cursor')
+    endif
+    " setlocal nomodifiable
+    setf SpaceVimFlyGrep
+    call s:matchadd('FileName', '[^:]*:\d\+:\d\+:', 3)
+    let s:MPT._prompt.begin = get(a:agrv, 'input', '')
+    let fs = get(a:agrv, 'files', '')
+    if fs ==# '@buffers'
+      let s:grep_files = map(s:BUFFER.listed_buffers(), 'bufname(v:val)')
+    elseif !empty(fs)
+      let s:grep_files = fs
+    else
+      let s:grep_files = ''
+    endif
+    let dir = expand(get(a:agrv, 'dir', ''))
+    if !empty(dir) && isdirectory(dir)
+      let s:grep_dir = dir
+    else
+      let s:grep_dir = ''
+    endif
+    let s:grep_exe = get(a:agrv, 'cmd', s:grep_default_exe)
+    if empty(s:grep_dir) && empty(s:grep_files) && s:grep_exe == 'findstr'
+      let s:grep_files = '*.*'
+    elseif s:grep_exe == 'findstr' && !empty(s:grep_dir)
+      let s:grep_dir = '/D:' . s:grep_dir
+    endif
+    let s:grep_opt = get(a:agrv, 'opt', s:grep_default_opt)
+    let s:grep_ropt = get(a:agrv, 'ropt', s:grep_default_ropt)
+    let s:grep_ignore_case = get(a:agrv, 'ignore_case', s:grep_default_ignore_case)
+    let s:grep_smart_case  = get(a:agrv, 'smart_case', s:grep_default_smart_case)
+    let s:grep_expr_opt  = get(a:agrv, 'expr_opt', s:grep_default_expr_opt)
+    call SpaceVim#logger#info('FlyGrep startting ===========================')
+    call SpaceVim#logger#info('   executable    : ' . s:grep_exe)
+    call SpaceVim#logger#info('   option        : ' . string(s:grep_opt))
+    call SpaceVim#logger#info('   r_option      : ' . string(s:grep_ropt))
+    call SpaceVim#logger#info('   files         : ' . string(s:grep_files))
+    call SpaceVim#logger#info('   dir           : ' . string(s:grep_dir))
+    call SpaceVim#logger#info('   ignore_case   : ' . string(s:grep_ignore_case))
+    call SpaceVim#logger#info('   smart_case    : ' . string(s:grep_smart_case))
+    call SpaceVim#logger#info('   expr opt      : ' . string(s:grep_expr_opt))
+    " sometimes user can not see the flygrep windows, redraw only once.
+    redraw
+    call s:MPT.open()
+    call SpaceVim#logger#info('FlyGrep ending    ===========================')
+    let &t_ve = save_tve
+    if has('gui_running')
+      call s:HI.hi(cursor_hi)
+    endif
+  endwhile
 endfunction
 " }}}
 

--- a/autoload/SpaceVim/plugins/flygrep.vim
+++ b/autoload/SpaceVim/plugins/flygrep.vim
@@ -9,7 +9,7 @@
 "search result chose line indent
 let s:line_indent = 0 
 "running status for flygrep
-let g:flygrep_status = ''
+let s:flygrep_status = 'run'
 
 " Loadding SpaceVim api {{{
 scriptencoding utf-8
@@ -154,10 +154,10 @@ function! s:flygrep(expr) abort
   hi def link FlyGrepPattern MoreMsg
   let s:hi_id = s:matchadd('FlyGrepPattern', s:expr_to_pattern(a:expr), 2)
   "if no restart , line_indent show be reset
-  if g:flygrep_status !=# 'restart'
+  if s:flygrep_status !=# 'restart'
     let s:line_indent = 0 
   else
-    let g:flygrep_status = 'run'
+    let s:flygrep_status = 'run'
   endif
   
   let s:grep_expr = a:expr
@@ -586,7 +586,6 @@ endif
 " files: files for grep, @buffers means listed buffer.
 " dir: specific a directory for grep
 
-let g:flygrep_status = 'run'
 function! SpaceVim#plugins#flygrep#open(agrv) abort
     if empty(s:grep_default_exe)
       call SpaceVim#logger#warn(' [flygrep] make sure you have one search tool in your PATH', 1)

--- a/autoload/SpaceVim/plugins/flygrep.vim
+++ b/autoload/SpaceVim/plugins/flygrep.vim
@@ -408,7 +408,7 @@ function! s:add_history(grep_expr) abort
       let s:grep_history_head = (s:grep_history_head + 1) % s:grep_history_max
     endif
     let  s:grep_history[ s:grep_history_old_front ] = a:grep_expr
-    let s:grep_history_current = s:grep_history_old_front 
+    let s:grep_history_current = s:grep_history_front 
   endif
 
 endfunction
@@ -534,12 +534,12 @@ function! s:previous_match_history() abort
 endfunction
 
 function! s:next_match_history() abort
-  if(s:grep_history_current != s:grep_history_old_front)
+  if(s:grep_history_current != s:grep_history_front)
     let s:grep_history_current = (s:grep_history_current + 1 ) % s:grep_history_max
-    let s:MPT._prompt.begin = s:grep_history[s:grep_history_current] 
-    normal! "_ggdG
-    call s:MPT._handle_fly(s:MPT._prompt.begin . s:MPT._prompt.cursor .s:MPT._prompt.end)
   endif
+  let s:MPT._prompt.begin = s:grep_history[s:grep_history_current] 
+  normal! "_ggdG
+  call s:MPT._handle_fly(s:MPT._prompt.begin . s:MPT._prompt.cursor .s:MPT._prompt.end)
 endfunction
 
 let s:MPT._function_key = {
@@ -586,6 +586,7 @@ endif
 " files: files for grep, @buffers means listed buffer.
 " dir: specific a directory for grep
 
+let s:flygrep_status = 'run'
 function! SpaceVim#plugins#flygrep#open(agrv) abort
     if empty(s:grep_default_exe)
       call SpaceVim#logger#warn(' [flygrep] make sure you have one search tool in your PATH', 1)

--- a/autoload/SpaceVim/plugins/flygrep.vim
+++ b/autoload/SpaceVim/plugins/flygrep.vim
@@ -585,9 +585,9 @@ endif
 " keys:
 " files: files for grep, @buffers means listed buffer.
 " dir: specific a directory for grep
+
+let g:flygrep_status = 'run'
 function! SpaceVim#plugins#flygrep#open(agrv) abort
-  let g:flygrep_status = 'restart'
-  while g:flygrep_status !=# 'exit' 
     if empty(s:grep_default_exe)
       call SpaceVim#logger#warn(' [flygrep] make sure you have one search tool in your PATH', 1)
       return
@@ -651,7 +651,7 @@ function! SpaceVim#plugins#flygrep#open(agrv) abort
     if has('gui_running')
       call s:HI.hi(cursor_hi)
     endif
-  endwhile
+    let s:flygrep_status = 'restart'
 endfunction
 " }}}
 


### PR DESCRIPTION
…, open last searching result when restart

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [√] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [√] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [√] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

### 1
First, people use 'FlyGrep' to search a specify symbol in  the whole project  , they always need to continually open multiple searching result items to get more detail information for judging  is that item they want, to make sure the item is they want , they have to view the code near symbol， there are a  function PREVIEW in 'FlyGrep' now , it works good for simple cases,  however ,it is not enough,  since preview buffer window is too small to display engough information when referred to some long and complicated code patches, and the preview window cannot be easily edited ( like scroll up or down) which prevent one from previewing enough releated code nearby. maybe you will question why not  open that item, it really need, but 'FlyGrep' will close searching result after open it, that's what want to say next.

Second, people tends to open multiple searching items(to see different references of that symbol), however, 'FlyGrep' will close searching result window after open an item , it means to you have to open 'FlyGrep' again and input that symbol again( or use the 'previous match history' to turn to last search symbol ) and using some extra  'Tab' and check for moving over items which have been opened  before moving to a new another item. 

considering all about that , I  make some changes on 'FlyGrep ' , referring to VSCode symbol searching tool,
- 1. searching reuslt window will not be closed after open a result, people still can choose and open other items
- 2. when people use <ESC>  to quit, they can start to view or edit items they opened, and when they using 'FlyGrep' again, 'FlyGrep'  will be reverted to the state before quit (including recover searching  symbol, searching result, and the choosing line position ), it looks like 'FlyGrep' never be shutdown but just hidden
 
### 2
there are some issues with the function of turning to previous/next searching symbol,  it usually does't work as expect , I use a  loop array to rewrite it , it works good and avoids an potential memory exceed problem

thanks