### PR TITLE
Add: coc.nvim integration enhacements

### DIFF
--- a/autoload/SpaceVim/layers/lsp.vim
+++ b/autoload/SpaceVim/layers/lsp.vim
@@ -9,7 +9,9 @@
 function! SpaceVim#layers#lsp#plugins() abort
   let plugins = []
 
-  if has('nvim')
+  if SpaceVim#layers#isLoaded("autocomplete") && get(g:, "spacevim_autocomplete_method") ==# 'coc'
+    " nop
+  elseif has('nvim')
     call add(plugins, ['autozimu/LanguageClient-neovim',
           \ { 'merged': 0, 'if': has('python3'), 'build' : 'bash install.sh' }])
   else

--- a/autoload/SpaceVim/lsp.vim
+++ b/autoload/SpaceVim/lsp.vim
@@ -8,7 +8,69 @@
 
 scriptencoding utf-8
 
-if has('nvim')
+
+if SpaceVim#layers#isLoaded("autocomplete") && get(g:, "spacevim_autocomplete_method") ==# 'coc'
+  " use coc.nvim
+  let s:coc_language_servers = {}
+  let s:coc_language_servers_key_id_map = {}
+  function! SpaceVim#lsp#reg_server(ft, cmds) abort
+    " coc.nvim doesn't support key values containing dots
+    " See https://github.com/neoclide/coc.nvim/issues/323
+    " Since a:cmds[0], i.e. the language server command can be a full path,
+    " which can potentially contain dots, we just take it's last part, if any
+    " dots are present.
+    " 
+    " Clearly, with this implementation, an edge case could be the following
+    "
+    " [layers.override_cmd]
+    "   c = ['/home/user/.local/.bin/ccls', '--log-file=/tmp/ccls.log']
+    "   cpp = ['/home/user/local/.bin/ccls', '--log-file=/tmp/ccls.log']
+    "
+    " the last part `bin/ccls` is the same, whereas the commands are not
+    " actually the same.
+    " We need to keep an id to distinguish among conflicting keys.
+    
+    if stridx(a:cmds[0], ".") >= 0 
+      let l:key = split(a:cmds[0], "\\.")[-1]
+    else
+      let l:key = a:cmds[0]
+    endif
+
+    for id in range(get(s:coc_language_servers_key_id_map, l:key, 0))
+      if has_key(s:coc_language_servers, l:key . id) && s:coc_language_servers[l:key . id].command ==# a:cmds[0]
+        call add(s:coc_language_servers[l:key . id].filetypes, a:ft)
+        return
+      endif
+    endfor
+
+    let s:coc_language_servers_key_id_map[l:key] = get(s:coc_language_servers_key_id_map, l:key, 0)
+    let s:coc_language_servers[l:key . s:coc_language_servers_key_id_map[l:key]] = {
+          \'command': a:cmds[0],
+          \'args': a:cmds[1:],
+          \'filetypes': [a:ft]
+          \}
+
+    let s:coc_language_servers_key_id_map[l:key] = s:coc_language_servers_key_id_map[l:key] + 1
+
+    autocmd! User CocNvimInit :call coc#config("languageserver", s:coc_language_servers)
+  endfunction
+
+  function! SpaceVim#lsp#show_doc() abort
+    call CocActionAsync("doHover")
+  endfunction
+
+  function! SpaceVim#lsp#go_to_def() abort
+    call CocActionAsync("jumpDefinition")
+  endfunction
+
+  function! SpaceVim#lsp#rename() abort
+    call CocActionAsync("rename")
+  endfunction
+
+  function! SpaceVim#lsp#references() abort
+    call CocActionAsync("jumpReferences")
+  endfunction
+elseif has('nvim')
   " use LanguageClient-neovim
   function! SpaceVim#lsp#reg_server(ft, cmds) abort
     let g:LanguageClient_serverCommands[a:ft] = copy(a:cmds)

--- a/docs/layers/autocomplete.md
+++ b/docs/layers/autocomplete.md
@@ -10,6 +10,7 @@ description: "Autocomplete code within SpaceVim, fuzzy find the candidates from 
 - [Description](#description)
 - [Install](#install)
 - [Configuration](#configuration)
+  - [Choose which completion engine to be used](#choose-which-completion-engine-to-be-used)
   - [Key bindings](#key-bindings)
   - [Snippets directories](#snippets-directories)
   - [Show snippets in auto-completion popup](#show-snippets-in-auto-completion-popup)
@@ -29,7 +30,10 @@ The following completion engines are supported:
 - [neocomplete](https://github.com/Shougo/neocomplete.vim) - vim with `+lua`
 - [neocomplcache](https://github.com/Shougo/neocomplcache.vim) - vim without `+lua`
 - [deoplete](https://github.com/Shougo/deoplete.nvim) - neovim with `+python3`
+- [coc](https://github.com/neoclide/coc.nvim) - vim >= 8.1 or neovim >= 0.3.1
 - [YouCompleteMe](https://github.com/Valloric/YouCompleteMe) - disabled by default, to enable ycm, see `:h g:spacevim_enable_ycm`
+- [Completor](https://github.com/maralla/completor.vim) - vim8 with `+python` or `+python3`
+- [asyncomplete](https://github.com/prabirshrestha/asyncomplete.vim) - vim8 or neovim with `timers`
 
 Snippets are supported via [neosnippet](https://github.com/Shougo/neosnippet.vim).
 
@@ -43,6 +47,20 @@ To use this configuration layer, add following snippet to your custom configurat
 ```
 
 ## Configuration
+
+### Choose which completion engine to be used
+
+You can choose the completion engine (among the supported ones) to be used
+with the following variable:
+
+- `g:spacevim_autocomplete_method`: the possible values are:
+    - `ycm`: for YouCompleteMe
+    - `neocomplcache`
+    - `coc`: **Note** that coc.nvim is also a language server protocol client. 
+See [lsp layer](language-server-protocol.md) for more information.
+    - `deoplete`
+    - `asyncomplete`
+    - `completor`
 
 ### Key bindings
 

--- a/docs/layers/language-server-protocol.md
+++ b/docs/layers/language-server-protocol.md
@@ -22,9 +22,12 @@ This layers adds extensive support for [language-server-protocol](https://micros
 This layer is a heavy wallpaper of [LanguageClient-neovim](https://github.com/SpaceVim/LanguageClient-neovim) (an old fork),
 The upstream is rewritten by rust.
 
-we also include [vim-lsp](https://github.com/prabirshrestha/vim-lsp), which is wrote in pure vim script.
+We also include [vim-lsp](https://github.com/prabirshrestha/vim-lsp), which is wrote in pure vim script.
 
-the neovim team is going to implement the build-in LSP support, the
+Note that if `coc` is used as autocomplete method in the `autocomplete` layer,
+it will be used as lsp client.
+
+The neovim team is going to implement the build-in LSP support, the
 PR is [neovim#6856](https://github.com/neovim/neovim/pull/6856). and the author of this PR
 create another plugin [tjdevries/nvim-langserver-shim](https://github.com/tjdevries/nvim-langserver-shim)
 
@@ -33,6 +36,8 @@ SpaceVim should works well in different version of vim/neovim, so in the feature
 ```vim
 if has('nvim')
   " use neovim build-in lsp
+if SpaceVim#layers#isLoaded("autocomplete") && get(g:, "spacevim_autocomplete_method") ==# 'coc'
+  " use coc.nvim
 elseif has('python3')
   " use LanguageClient-neovim
 else


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]
Currently, if we use `coc.nvim` as autocomplete method and enable the lsp layer, we have two Language  server clients enabled. This is quite undesirable.
Users are told to disable the lsp layer if they use coc.nvim, but this is not mentioned in the documentation.
Therefore, the lsp layer should use coc.nvim as client if it's used as autocomplete method and the lsp layer's configuration should be passed to coc.nvim through the `coc#config()` function. This way we have a single interface for managing language servers, the user no more needs to add lsp configuration to the `coc-settings.json`, which BTW has to be placed in the `~/.vim` directory and since `~/.vim` for SpaceVim users is just a link to `~/.SpaceVim`, it's relatively tricky to add `coc-settings.json` to their, let's say, dotfiles repository without polluting the SpaceVim repository.

**NOTE**
In order for this pull request to work, we have to wait neoclide/coc.nvim#316 to be merged.
Without the `CocSetup` autocmd, when `SpaceVim#lsp#reg_server` is called `coc.nvim` is not loaded yet, therefore calls to `coc#config` are invalid.

As pointed out by @chemzqm we could leverage the plugin managers' hook. I know that `vim-plug` fires an `doautocmd User <plugin>` when it loads a plugin, whereas `dein` requires the user to explicitly define this hook among the parameters passed for the plugin.

From documentation of dein
```vim
	call dein#add('Shougo/deoplete.nvim', {
	\ 'hook_source':
	\  'execute "doautocmd <nomodeline> User" "dein#source#".
	\   g:dein#plugin.name'
	\ })

```

BTW, from what I've seen, currently additional parameters for a plugin (like lazy load events or commands) are directly forwarded to the plugin manager being used. 
https://github.com/SpaceVim/SpaceVim/blob/b7be390f57c1d714483f09b238f33c24100faee7/autoload/zvim/plug.vim#L158-L192
Clearly, each one expects different keys, but I didn't find any adapter layer/function that converts the options for the various supported plugin manager. It seems that the passed options are recognized only by `dein`.
Do we really support other plugin manager?