### PR TITLE
Fixed: extend the patterns.

### DIFF
--- a/autoload/SpaceVim/layers/lang/vim.vim
+++ b/autoload/SpaceVim/layers/lang/vim.vim
@@ -34,7 +34,7 @@ endfunction
 function! SpaceVim#layers#lang#vim#config() abort
   call SpaceVim#mapping#gd#add('vim','lookup#lookup')
   call SpaceVim#mapping#space#regesit_lang_mappings('vim', function('s:language_specified_mappings'))
-  call SpaceVim#plugins#highlight#reg_expr('vim', '^\<fu\%[nction]\>!\?', '^\<endf\%[unction]\>')
+  call SpaceVim#plugins#highlight#reg_expr('vim', '\s*\<fu\%[nction]\>!\?\s*', '\s*\<endf\%[unction]\>\s*')
 endfunction
 
 function! s:language_specified_mappings() abort

--- a/autoload/SpaceVim/layers/lang/vim.vim
+++ b/autoload/SpaceVim/layers/lang/vim.vim
@@ -34,7 +34,7 @@ endfunction
 function! SpaceVim#layers#lang#vim#config() abort
   call SpaceVim#mapping#gd#add('vim','lookup#lookup')
   call SpaceVim#mapping#space#regesit_lang_mappings('vim', function('s:language_specified_mappings'))
-  call SpaceVim#plugins#highlight#reg_expr('vim', '^\s*\(func\|fu\|function\)!\?\s\+', '^\s*\(endfunc\|endf\|endfunction\)')
+  call SpaceVim#plugins#highlight#reg_expr('vim', '^\<fu\%[nction]\>!\?', '^\<endf\%[unction]\>')
 endfunction
 
 function! s:language_specified_mappings() abort


### PR DESCRIPTION
Extend the patterns to match all the right beginning and end of a Vim function defination.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Both of the patterns could only match three beginnings or ends of a Vim function defination. However, all these `fun funct functi functio function endfu endfun endfunct endfuncti endfunctio endfunction` are all OK to Vim.
Furthermore, both the `function` and `endf` are not limited to the begin of a line.
