### PR TITLE
Fix typo in TypeScript layer TSDoc command

### DIFF
--- a/autoload/SpaceVim/layers/lang/typescript.vim
+++ b/autoload/SpaceVim/layers/lang/typescript.vim
@@ -60,7 +60,7 @@ function! s:on_ft() abort
     if has('nvim')
       call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'c'], 'TSTypeDef',
             \ 'type definition', 1)
-      call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'd'], 'TsDoc',
+      call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'd'], 'TSDoc',
             \ 'show document', 1)
       call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'e'], 'TSRename',
             \ 'rename symbol', 1)


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Hello. I tried using the `lang#typescript` layer and when I ran the shortcut for the documentation command `SPC l d` I got an error that `TsDoc` is not a command. Trying `:TSDoc` worked so I figured there's a typo with in typescript layer. This is my fix and my first PR to this project, hope I'm on the right track!