### PR TITLE
Add: add function 'set_justification_to' with it's 3 key bindings.

### DIFF
--- a/autoload/SpaceVim/layers/edit.vim
+++ b/autoload/SpaceVim/layers/edit.vim
@@ -109,6 +109,17 @@ function! SpaceVim#layers#edit#config() abort
         \ . string(s:_function('s:kebab_case')) . ', [])',
         \ 'change symbol style to kebab-case', 1)
 
+  " justification
+  let g:_spacevim_mappings_space.x.j = {'name' : 'justification'}
+  call SpaceVim#mapping#space#def('nnoremap', ['x', 'j', 'l'], 'silent call call('
+        \ . string(s:_function('s:set_justification_to')) . ', ["left"])',
+        \ 'set-the-justification-to-left', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['x', 'j', 'c'], 'silent call call('
+        \ . string(s:_function('s:set_justification_to')) . ', ["center"])',
+        \ 'set-the-justification-to-center', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['x', 'j', 'r'], 'silent call call('
+        \ . string(s:_function('s:set_justification_to')) . ', ["right"])',
+        \ 'set-the-justification-to-right', 1)
 
   let g:_spacevim_mappings_space.i = {'name' : '+Insertion'}
   let g:_spacevim_mappings_space.i.l = {'name' : '+Lorem-ipsum'}
@@ -360,10 +371,43 @@ endfunction
 function! s:delete_extra_space() abort
   if !empty(getline('.'))
     if getline('.')[col('.')-1] ==# ' '
-      exe "normal! viw\"_di\<Space>\<Esc>"
+      execute "normal! \"_ciwi\<Space>\<Esc>"
     endif
   endif
 endfunction
+
+function! s:set_justification_to(align) abort
+    let l:startlinenr = line("'{")
+    let l:endlinenr = line("'}")
+    if getline(l:startlinenr) ==# ''
+        let l:startlinenr += 1
+    endif
+    if getline(l:endlinenr) ==# ''
+        let l:endlinenr -= 1
+    endif
+    let l:lineList = map(getline(l:startlinenr, l:endlinenr), 'trim(v:val)')
+    let l:maxlength = 0
+    for l:line in l:lineList
+        let l:length = strlen(l:line)
+        if l:length > l:maxlength
+            let l:maxlength = l:length
+        endif
+    endfor
+
+    if a:align ==# 'left'
+        execute l:startlinenr . "," . l:endlinenr . ":left\<cr>"
+    elseif a:align ==# 'center'
+        execute l:startlinenr . "," . l:endlinenr . ":center " . l:maxlength . "\<cr>"
+    elseif a:align ==# 'right'
+        execute l:startlinenr . "," . l:endlinenr . ":right  " . l:maxlength . "\<cr>"
+    endif
+
+    unlet l:startlinenr
+    unlet l:endlinenr
+    unlet l:lineList
+    unlet l:maxlength
+endfunction
+
 let s:local_lorem_ipsum = [
       \ 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit.',
       \ 'Donec hendrerit tempor tellus.',

--- a/autoload/SpaceVim/layers/edit.vim
+++ b/autoload/SpaceVim/layers/edit.vim
@@ -371,7 +371,7 @@ endfunction
 function! s:delete_extra_space() abort
   if !empty(getline('.'))
     if getline('.')[col('.')-1] ==# ' '
-      execute "normal! \"_ciwi\<Space>\<Esc>"
+      execute "normal! \"_ciw\<Space>\<Esc>"
     endif
   endif
 endfunction

--- a/docs/cn/documentation.md
+++ b/docs/cn/documentation.md
@@ -1555,11 +1555,11 @@ In highlight symbol transient state:
 | `SPC x i _`   | change symbol style to `under_score`                                 |
 | `SPC x i u`   | change symbol style to `under_score`                                 |
 | `SPC x i U`   | change symbol style to `UP_CASE`                                     |
-| `SPC x j c`   | set the justification to center (TODO)                               |
+| `SPC x j c`   | 居中对齐当前段落                                                     |
 | `SPC x j f`   | set the justification to full (TODO)                                 |
-| `SPC x j l`   | set the justification to left (TODO)                                 |
+| `SPC x j l`   | 左对齐当前段落                                                       |
 | `SPC x j n`   | set the justification to none (TODO)                                 |
-| `SPC x j r`   | set the justification to right (TODO)                                |
+| `SPC x j r`   | 右对齐当前段落                                                       |
 | `SPC x J`     | move down a line of text (enter transient state)                     |
 | `SPC x K`     | move up a line of text (enter transient state)                       |
 | `SPC x l d`   | duplicate line or region (TODO)                                      |

--- a/docs/cn/layers/edit.md
+++ b/docs/cn/layers/edit.md
@@ -25,6 +25,7 @@ lang: cn
 - 重复编辑
 - 多光标支持
 - 对齐文档内容
+- 设置文档段落对齐方式
 - 高亮行为符号
 - 自动载入 editorconfig 配置，需要 `+python` 或者 `+python3` 支持
 - 默认已启用
@@ -55,3 +56,10 @@ lang: cn
 - `}`: 对齐 `}`
 - `)`: 对齐 `)`
 
+| 快捷键       | 功能描述                             |
+| ------------ | ------------------------------------ |
+| `SPC x j c`  | 居中对齐当前段落                     |
+| `SPC x j f`  | set the justification to full (TODO) |
+| `SPC x j l`  | 左对齐当前段落                       |
+| `SPC x j n`  | set the justification to none (TODO) |
+| `SPC x j r`  | 右对齐当前段落                       |

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1568,7 +1568,7 @@ Text related commands (start with `x`):
 | `SPC x a ;`   | align region at ;                                                    |
 | `SPC x a =`   | align region at =                                                    |
 | `SPC x a ¦`   | align region at ¦                                                    |
-| `SPC x a |`   | align region at                                                      |
+| `SPC x a |`   | align region at |                                                    |
 | `SPC x a a`   | align region (or guessed section) using default rules (TODO)         |
 | `SPC x a c`   | align current indentation region using default rules (TODO)          |
 | `SPC x a l`   | left-align with evil-lion (TODO)                                     |
@@ -1589,11 +1589,11 @@ Text related commands (start with `x`):
 | `SPC x i _`   | change symbol style to `under_score`                                 |
 | `SPC x i u`   | change symbol style to `under_score`                                 |
 | `SPC x i U`   | change symbol style to `UP_CASE`                                     |
-| `SPC x j c`   | set the justification to center (TODO)                               |
+| `SPC x j c`   | set the justification to center                                      |
 | `SPC x j f`   | set the justification to full (TODO)                                 |
-| `SPC x j l`   | set the justification to left (TODO)                                 |
+| `SPC x j l`   | set the justification to left                                        |
 | `SPC x j n`   | set the justification to none (TODO)                                 |
-| `SPC x j r`   | set the justification to right (TODO)                                |
+| `SPC x j r`   | set the justification to right                                       |
 | `SPC x J`     | move down a line of text (enter transient state)                     |
 | `SPC x K`     | move up a line of text (enter transient state)                       |
 | `SPC x l d`   | duplicate line or region (TODO)                                      |

--- a/docs/layers/edit.md
+++ b/docs/layers/edit.md
@@ -24,7 +24,8 @@ This layer provides many edit key bindings for SpaceVim, and also provides more 
 - repeat latest action via vim-repeat
 - multiple cursor
 - align
-- highlight whitespace at the end of a line
+- set justification for paragraph
+- highlight whitespaces at the end of a line
 - load ditorconfig config, need `+python` or `+python3`
 
 ## Options
@@ -33,9 +34,9 @@ This layer provides many edit key bindings for SpaceVim, and also provides more 
 
 ## Key bindings
 
-Key binding           | desc
----                  | ---
-`SPC x a {delimiter}` | align content based on delimiter
+| Key bindings          | Descraptions                     |
+| --------------------  | -------------------------------  |
+| `SPC x a {delimiter}` | align content based on delimiter |
 
 **default delimiters**
 
@@ -53,3 +54,8 @@ Key binding           | desc
 - `}`: align `}`
 - `)`: align `)`
 
+| Key bindings | Descraptions                    |
+| ------------ | ------------------------------- |
+| `SPC x j c`  | set the justification to center |
+| `SPC x j l`  | set the justification to left   |
+| `SPC x j r`  | set the justification to right  |


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Add: add function 'set_justification_to' with it's 3 key bindings, and update the corresponding documentations and lay documentations, both en and cn.
Replace `exe "normal! viw\"_di\<Space>\<Esc>"` by `execute "normal! \"_ciw\<Space>\<Esc>"`. The new one is shorter and more readable, and performs better.