### PR TITLE
Fixed: fix the bug in function s:set_justification_to.

### DIFF
--- a/autoload/SpaceVim/layers/edit.vim
+++ b/autoload/SpaceVim/layers/edit.vim
@@ -388,7 +388,7 @@ function! s:set_justification_to(align) abort
     let l:lineList = map(getline(l:startlinenr, l:endlinenr), 'trim(v:val)')
     let l:maxlength = 0
     for l:line in l:lineList
-        let l:length = strlen(l:line)
+        let l:length = strdisplaywidth(l:line)
         if l:length > l:maxlength
             let l:maxlength = l:length
         endif


### PR DESCRIPTION
Fixed: fix the bug that the result is incorrect when both Chinese and English charactors are in a same paragraph.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

When both Chinese and English charactors are in a same paragraph, the result may be incorrect. Because `strlen(‘汉’)` return 3, `strlen('E')` return 2. To fix this bug I replace `strlen` with `strdisplaywidth`.

Sorry to give this bug in my lasy PR.
