### PR TITLE
Fixed: ChineseLinter.vim should not be loaded for all file types.

### DIFF
--- a/autoload/SpaceVim/layers/chinese.vim
+++ b/autoload/SpaceVim/layers/chinese.vim
@@ -10,8 +10,8 @@
 function! SpaceVim#layers#chinese#plugins() abort
   let plugins = [
         \ ['yianwillis/vimcdoc'          , {'merged' : 0}],
-        \ ['ianva/vim-youdao-translater' , {'on_cmd' : ['Ydv' , 'Ydc', 'Yde']}],
-        \ ['wsdjeg/ChineseLinter.vim'    , {'merged' : 0, 'on_cmd' : ['CheckChinese']}],
+        \ ['ianva/vim-youdao-translater' , {'merged' : 0, 'on_cmd' : ['Ydv' , 'Ydc', 'Yde']}],
+        \ ['wsdjeg/ChineseLinter.vim'    , {'merged' : 0, 'on_cmd' : 'CheckChinese', 'on_ft' : ['markdown', 'text']}],
         \ ]
   if SpaceVim#layers#isLoaded('ctrlp')
     call add(plugins, ['vimcn/ctrlp.cnx', {'merged' : 0}])


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

ChineseLinter.vim should only be load for a limit number  of filetypes, such as markdown, text."