### PR TITLE
Website: Typo for "reference"

### DIFF
--- a/docs/layers/lang/javascript.md
+++ b/docs/layers/lang/javascript.md
@@ -37,7 +37,7 @@ name = "lang#javascript"
 - auto-completion
 - syntax checking
 - goto definition
-- refernce finder
+- reference finder
 
 ## Layer configuration
 


### PR DESCRIPTION
Fixed a typo in the word "reference".
