### PR TITLE
Introduce lang#nix layer

### DIFF
--- a/autoload/SpaceVim/layers/lang/nix.vim
+++ b/autoload/SpaceVim/layers/lang/nix.vim
@@ -1,0 +1,24 @@
+"=============================================================================
+" nix.vim --- nix language support for SpaceVim
+" Copyright (c) 2016-2019 Wang Shidong & Contributors
+" Author: Ben Gamari <ben@smart-cactus.org>
+" URL: https://spacevim.org
+" License: GPLv3
+"=============================================================================
+
+""
+" @section lang#nix, layer-lang-nix
+" @parentsection layers
+" @subsection Intro
+" The lang#nix layer provides syntax highlighting for the Nix
+" expression language.
+
+function! SpaceVim#layers#lang#nix#plugins() abort
+  let plugins = []
+  call add(plugins, ['LnL7/vim-nix', {'on_ft' : ['nix']}])
+  return plugins
+endfunction
+
+function! SpaceVim#layers#lang#nix#config() abort
+endfunction
+

--- a/docs/layers/lang/nix.md
+++ b/docs/layers/lang/nix.md
@@ -1,0 +1,33 @@
+---
+title: "SpaceVim lang#nix layer"
+description: "This layer adds Nix language support to SpaceVim."
+---
+
+# [Available Layers](../../) >> lang#nix
+
+<!-- vim-markdown-toc GFM -->
+
+- [Description](#description)
+- [Features](#features)
+- [Install](#install)
+- [Key bindings](#key-bindings)
+
+<!-- vim-markdown-toc -->
+
+## Description
+
+This layer adds [Nix](https://nixos.org/nix/manual/) language support to SpaceVim.
+
+## Features
+
+- syntax highlighting
+
+## Install
+
+To use this configuration layer, update custom configuration file with:
+
+```toml
+[[layers]]
+  name = "lang#nix"
+```
+


### PR DESCRIPTION
### Why this change is necessary and useful?

[Nix](https://nixos.org/nix/) is a simple expression language used by the Nix package manager. This layer introduces basic syntax highlighting via https://github.com/LnL7/vim-nix.