### PR TITLE
disable the indent force for python

### DIFF
--- a/autoload/SpaceVim/layers/lang/python.vim
+++ b/autoload/SpaceVim/layers/lang/python.vim
@@ -30,8 +30,6 @@ function! SpaceVim#layers#lang#python#plugins() abort
   endif
   call add(plugins, ['heavenshell/vim-pydocstring',
         \ { 'on_cmd' : 'Pydocstring'}])
-  call add(plugins, ['Vimjas/vim-python-pep8-indent', 
-        \ { 'on_ft' : 'python'}])
   return plugins
 endfunction
 


### PR DESCRIPTION


### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]
right now, we can not use 2 space indentation in python because of this plugin.
google style used 2 space indentation, so this is actually pretty popular.

This plugin should be an optional choice.