### PR TITLE
Fixed: Proper pug support for lang#extra layer

### DIFF
--- a/autoload/SpaceVim/layers/lang/extra.vim
+++ b/autoload/SpaceVim/layers/lang/extra.vim
@@ -9,7 +9,7 @@
 
  function! SpaceVim#layers#lang#extra#plugins() abort
     let plugins = [
-                \ ['digitaltoad/vim-jade',                   { 'on_ft' : ['jade']}],
+                \ ['digitaltoad/vim-pug',                    { 'on_ft' : ['pug', 'jade']}],
                 \ ['juvenn/mustache.vim',                    { 'on_ft' : ['mustache']}],
                 \ ['kchmck/vim-coffee-script',               { 'on_ft' : ['coffee']}],
                 \ ['PotatoesMaster/i3-vim-syntax',           { 'on_ft' : 'i3'}],


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Enabling lang#extra layer doesn't highlight any *.pug files/syntax.
Also after some research, I've found that `digitaltoad/vim-jade` plugin was renamed to `digitaltoad/vim-pug` (old one still works by GitHub redirecting feature). So this change is not necessary, but will reduce future problems and misunderstanding.
Tested on my local machine.

Thanks for your awesome work!
