### PR TITLE
Remove: remove two useless key bindings

### DIFF
--- a/autoload/SpaceVim/layers/core.vim
+++ b/autoload/SpaceVim/layers/core.vim
@@ -107,12 +107,6 @@ function! SpaceVim#layers#core#config() abort
   call SpaceVim#mapping#space#def('nmap', ['j', 'q'], '<Plug>(easymotion-overwin-line)', 'jump to a line', 0)
   call SpaceVim#mapping#space#def('nnoremap', ['j', 'n'], "i\<cr>\<esc>", 'sp-newline', 0)
   call SpaceVim#mapping#space#def('nnoremap', ['j', 'o'], "i\<cr>\<esc>k$", 'open-line', 0)
-  call SpaceVim#mapping#space#def('nnoremap', ['j', 's'], 'call call('
-        \ . string(s:_function('s:split_string')) . ', [0])',
-        \ 'split sexp', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['j', 'S'], 'call call('
-        \ . string(s:_function('s:split_string')) . ', [1])',
-        \ 'split-and-add-newline', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['w', 'r'], 'call call('
         \ . string(s:_function('s:next_window')) . ', [])',
         \ 'rotate windows forward', 1)
@@ -363,37 +357,6 @@ function! s:previous_window() abort
   catch
     exe winnr('$') . 'wincmd w'
   endtry
-endfunction
-
-function! s:split_string(newline) abort
-  let syn_name = synIDattr(synID(line('.'), col('.'), 1), 'name')
-  if syn_name == &filetype . 'String'
-    let c = col('.')
-    let sep = ''
-    while c > 0
-      if s:is_string(line('.'), c)
-        let c = c - 1
-      else
-        let sep = getline('.')[c]
-        break
-      endif
-    endwhile
-    if a:newline
-      let save_register_m = @m
-      let @m = sep . "\n" . sep
-      normal! "mp
-      let @m = save_register_m
-    else
-      let save_register_m = @m
-      let @m = sep . sep
-      normal! "mp
-      let @m = save_register_m
-    endif
-  endif
-endfunction
-
-function! s:is_string(l,c) abort
-  return synIDattr(synID(a:l, a:c, 1), 'name') == &filetype . 'String'
 endfunction
 
 " function() wrapper


### PR DESCRIPTION
Remove: remove two useless key bindings and the two corresponding functions for them.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

```Python
spacevim = 'SpaceVim'
spacevim = "SpaceVim"
spacevim = """SpaceVim is a very
good Vim distribution."""
```
1. Please copy the code above, then paste it in a *.py file.
2. Set the cursor on the words - 3 Spacevim and Vim in turn then press `SPC j s` or `SPC j S`.
3. Then you will find the problems: these 2 key bindings works not properly for Python string.
4. These 2 key bindings works well for Vim string at least. So I guess it's a bug of Vim. 
5. In my opinion, they have a limited effect and are diffcult to implement, so I remove these two useless key bindings and the two corresponding functions for them.
