### PR TITLE
Fixed: add a reminder that 'start REPL via SPC l s i first'.

### DIFF
--- a/autoload/SpaceVim/plugins/repl.vim
+++ b/autoload/SpaceVim/plugins/repl.vim
@@ -36,21 +36,24 @@ endfunction
 " selection: send selection text to REPL process
 
 function! SpaceVim#plugins#repl#send(type) abort
-  if a:type ==# 'line'
-    call s:JOB.send(s:job_id, [getline('.'), ''])
-  elseif a:type ==# 'buffer'
-    call s:JOB.send(s:job_id, getline(1, '$') + [''])
-  elseif a:type ==# 'selection'
-    let begin = getpos("'<")
-    let end = getpos("'>")
-    if begin[1] != 0 && end[1] != 0
-      call s:JOB.send(s:job_id, getline(begin[1], end[1]) + [''])
-    else
-      echohl WarningMsg
-      echo 'no selection text'
-      echohl None
-    endif
+  if !exists('s:job_id')
+    echom('Please start REPL via the key binding "SPC l s i" first.')
   else
+    if a:type ==# 'line'
+      call s:JOB.send(s:job_id, [getline('.'), ''])
+    elseif a:type ==# 'buffer'
+      call s:JOB.send(s:job_id, getline(1, '$') + [''])
+    elseif a:type ==# 'selection'
+      let begin = getpos("'<")
+      let end = getpos("'>")
+      if begin[1] != 0 && end[1] != 0
+        call s:JOB.send(s:job_id, getline(begin[1], end[1]) + [''])
+      else
+        echohl WarningMsg
+        echo 'no selection text'
+        echohl None
+      endif
+    endif
   endif
 endfunction
 


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]

Fixed: add a reminder that "Please start REPL via the key binding `SPC l s i` first" when users want to send some code to REPL via the key binding `SPC l s b`, `SPC l s l` or `SPC l s s`.