### PR TITLE
Fixed: fix bug of formatting MarkDown table.

### DIFF
--- a/autoload/SpaceVim/layers/lang/markdown.vim
+++ b/autoload/SpaceVim/layers/lang/markdown.vim
@@ -71,7 +71,7 @@ function! s:mappings() abort
     let g:_spacevim_mappings_space = {}
   endif
   let g:_spacevim_mappings_space.l = {'name' : '+Language Specified'}
-  call SpaceVim#mapping#space#langSPC('nmap', ['l','ft'], 'Tabularize /|', 'Format table under cursor', 1)
+  call SpaceVim#mapping#space#langSPC('nmap', ['l','ft'], 'Tabularize /\\\@<!|', 'Format table under cursor', 1)
   call SpaceVim#mapping#space#langSPC('nmap', ['l','p'], 'MarkdownPreview', 'Real-time markdown preview', 1)
   call SpaceVim#mapping#space#langSPC('nmap', ['l','k'], '<plug>(markdown-insert-link)', 'add link url', 0, 1)
   call SpaceVim#mapping#space#langSPC('nmap', ['l', 'r'], 


### PR DESCRIPTION
Fixed: the | that prefixed by a \ should not be treated as a separator of MarkDown table.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]
