### PR TITLE
Fixed: fix a bug in markdown_insert_url.

### DIFF
--- a/autoload/SpaceVim/layers/lang/markdown.vim
+++ b/autoload/SpaceVim/layers/lang/markdown.vim
@@ -103,18 +103,22 @@ endfunction
 function! s:markdown_insert_url(visual) abort
   if !empty(@+)
     let l:save_register_unnamed = @"
-    if a:visual
-      normal! gvx
-    else
-      normal! diw
+    let l:save_edge_left = getpos("'<")
+    let l:save_edge_right = getpos("'>")
+    if !a:visual
+      execute "normal! viw\<esc>"
     endif
+    let l:paste = (col("'>") == col("$") - 1 ? 'p' : 'P')
+    normal! gvx
     let @" = '[' . @" . '](' . @+ . ')'
-    if col('.') == col('$') - 1
-      normal! p
-    else
-      normal! P
-    endif
+    execute 'normal! ' . l:paste
     let @" = l:save_register_unnamed
+    if a:visual
+      let l:save_edge_left[2] += 1
+      let l:save_edge_right[2] += 1
+    endif
+    call setpos("'<", l:save_edge_left)
+    call setpos("'>", l:save_edge_right)
   endif
 endfunction
 

--- a/autoload/SpaceVim/layers/lang/markdown.vim
+++ b/autoload/SpaceVim/layers/lang/markdown.vim
@@ -115,7 +115,9 @@ function! s:markdown_insert_url(visual) abort
     let @" = l:save_register_unnamed
     if a:visual
       let l:save_edge_left[2] += 1
-      let l:save_edge_right[2] += 1
+      if l:save_edge_left[1] == l:save_edge_right[1]
+        let l:save_edge_right[2] += 1
+      endif
     endif
     call setpos("'<", l:save_edge_left)
     call setpos("'>", l:save_edge_right)


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

1. Fix a bug that if the left character of the word under the cursor(normal) or the last character of selection(visual) is located just before the last character in a line, the markdown link object will be located incorrectly. Usually, the last character of a line is a punctuation, especial for a text, markdown, tex or rst file ,etc.
2. Restore [and modify] these two postion `'<` and `'>` to make this function work better.
