### PR TITLE
Fix typo of methon

### DIFF
--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -601,7 +601,7 @@ function! SpaceVim#layers#core#statusline#config() abort
   call SpaceVim#mapping#space#def('nnoremap', ['t', 'm', 'd'], 'call SpaceVim#layers#core#statusline#toggle_section("date")',
         \ 'toggle the date', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['t', 'm', 'i'], 'call SpaceVim#layers#core#statusline#toggle_section("input method")',
-        \ 'toggle the input methon', 1)
+        \ 'toggle the input method', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['t', 'm', 't'], 'call SpaceVim#layers#core#statusline#toggle_section("time")',
         \ 'toggle the time', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['t', 'm', 'p'], 'call SpaceVim#layers#core#statusline#toggle_section("cursorpos")',

--- a/autoload/SpaceVim/layers/lang/java.vim
+++ b/autoload/SpaceVim/layers/lang/java.vim
@@ -191,7 +191,7 @@ function! s:language_specified_mappings() abort
 
   " execute
   let g:_spacevim_mappings_space.l.r = {'name' : '+Run'}
-  " run main methon
+  " run main method
   call SpaceVim#mapping#space#langSPC('nmap', ['l','r', 'm'], 'JavaUnitTestMain', 'Run main method', 1)
   call SpaceVim#mapping#space#langSPC('nmap', ['l','r', 'c'], 'JavaUnitExec', 'Run current method', 1)
   call SpaceVim#mapping#space#langSPC('nmap', ['l','r', 'a'], 'JavaUnitTestAll', 'Run all test methods', 1)


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]

![image](https://user-images.githubusercontent.com/16032614/54425837-ac4e8800-4759-11e9-9826-e5226645c74c.png)


I saw a **different character** than the one I verified in the document. (**UI Toggles Section.**)

So I was convinced that this was a typo.

I could not miss this part, and I am want to fix that part.

"toggle the input **methon**" is wrong.

"run the main **methon**" is wrong. 

So, I fix them.

Thank you for make SpaceVim
