### PR TITLE
Enable test layer configuration

### DIFF
--- a/autoload/SpaceVim/layers/test.vim
+++ b/autoload/SpaceVim/layers/test.vim
@@ -44,7 +44,7 @@ function! SpaceVim#layers#test#set_variable(var) abort
   let l:override = get(a:var, 'override_config', {})
   if !empty(l:override)
     for l:option in keys(l:override)
-      let l:varname = 'test#'.substitute(l:option, '-', '#', 'g')
+      let l:varname = 'test#'.substitute(l:option, '_', '#', 'g')
       execute 'let g:'.l:varname.' = '."'".l:override[l:option]."'"
     endfor
   endif

--- a/autoload/SpaceVim/layers/test.vim
+++ b/autoload/SpaceVim/layers/test.vim
@@ -39,3 +39,13 @@ function! SpaceVim#layers#test#config() abort
   let g:test#custom_strategies = {'spacevim': function('SpaceVim#plugins#runner#open')}
   let g:test#strategy = 'spacevim'
 endfunction
+
+function! SpaceVim#layers#test#set_variable(var) abort
+  let l:override = get(a:var, 'override_config', {})
+  if !empty(l:override)
+    for l:option in keys(l:override)
+      let l:varname = 'test#'.substitute(l:option, '-', '#', 'g')
+      execute 'let g:'.l:varname.' = '."'".l:override[l:option]."'"
+    endfor
+  endif
+endfunction

--- a/docs/layers/test.md
+++ b/docs/layers/test.md
@@ -26,6 +26,27 @@ To use this configuration layer, add following snippet to your custom configurat
   name = "test"
 ```
 
+## Configuration
+
+To set or override any configuration ([see supported settings here](https://github.com/janko/vim-test)) you may use the `override_config`:
+
+```toml
+[[layers]]
+  name = "test"
+  [layers.override_config]
+    java-runner = "gradletest"
+    java-gradletest-executable = "./gradlew test"
+```
+
+In the example above is equivalent to adding the following in viml:
+
+```viml
+let test#java#runner = "gradletest"
+let test#java#gradletest#executable = "./gradlew test"
+```
+
+In essence, it replaces `-` with `#` and prepends `test#` to the keys inside `override_config`.
+
 ## Key bindings
 
 | Key Binding | Description                                                                                                                                                                                                                                                                             |

--- a/docs/layers/test.md
+++ b/docs/layers/test.md
@@ -34,8 +34,8 @@ To set or override any configuration ([see supported settings here](https://gith
 [[layers]]
   name = "test"
   [layers.override_config]
-    java-runner = "gradletest"
-    java-gradletest-executable = "./gradlew test"
+    java_runner = "gradletest"
+    java_gradletest_executable = "./gradlew test"
 ```
 
 In the example above is equivalent to adding the following in viml:
@@ -45,7 +45,7 @@ let test#java#runner = "gradletest"
 let test#java#gradletest#executable = "./gradlew test"
 ```
 
-In essence, it replaces `-` with `#` and prepends `test#` to the keys inside `override_config`.
+In essence, it replaces `_` with `#` and prepends `test#` to the keys inside `override_config`.
 
 ## Key bindings
 


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Enable test layer configuration.

This enables setting any configuration for the vim-test plugin (used behind the test layer).

I wanted to test my java project but we use a custom gradle setup across all our projects. This enables me to use the custom setup. 
