### PR TITLE
Update installation step in lang#go

### DIFF
--- a/docs/layers/lang/go.md
+++ b/docs/layers/lang/go.md
@@ -27,6 +27,8 @@ To use this configuration layer, update custom configuration file with:
   name = "lang#go"
 ```
 
+After the installation, run `:GoInstallBinaries` inside vim.
+
 ## Features
 
 - auto-completion


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

It will help users setup `lang#go` layer more easily. I ran into the problem that I do not have all the plugins that `vim-go` needed and got error  `vim-go: go#util#Exec() called with empty a:cmd `. This is because I don't know that I should run `:GoInstallBinaries` to download necessary dependencies for `vim-go`. I found the solution in the issue https://github.com/SpaceVim/SpaceVim/issues/1494 and think it would be helpful to include this in the documentation.
