### PR TITLE
fix defx mapping l and c

### DIFF
--- a/config/plugins/defx.vim
+++ b/config/plugins/defx.vim
@@ -95,7 +95,7 @@ function! s:defx_init()
   nnoremap <silent><buffer><expr> <Left> defx#do_action('call', 'DefxSmartH')
   nnoremap <silent><buffer><expr> l
         \ defx#is_directory() ?
-        \ defx#do_action('open_tree') . 'j' : defx#do_action('open')
+        \ defx#do_action('open_tree') . 'j' : defx#do_action('drop')
   nnoremap <silent><buffer><expr> <Right>
         \ defx#is_directory() ?
         \ defx#do_action('open_tree') . 'j' : defx#do_action('open')

--- a/config/plugins/defx.vim
+++ b/config/plugins/defx.vim
@@ -83,7 +83,7 @@ function! s:defx_init()
   " Define mappings
   nnoremap <silent><buffer><expr> gx
         \ defx#do_action('execute_system')
-  nnoremap <silent><buffer><expr> yy
+  nnoremap <silent><buffer><expr> c
         \ defx#do_action('copy')
   nnoremap <silent><buffer><expr> q
         \ defx#do_action('quit')


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?
1, defx#do_action('open') will open the file in existing defx file tree buffer, 'drop' will open in another buffer.
2, you have define two same key binding yy. (action copy and yank path) no wonder I ask Shougo for feature to copy file to another dir like vimfiler does..

