### PR TITLE
Could we add a lang#processing?

### DIFF
--- a/autoload/SpaceVim/layers/lang/processing.vim
+++ b/autoload/SpaceVim/layers/lang/processing.vim
@@ -1,0 +1,49 @@
+"=============================================================================
+" processing.vim --- SpaceVim lang#processing layer
+" Copyright (c) 2016-2017 Wang Shidong & Contributors
+" Author: Russell Bentley < russell.w.bentley at icloud.com >
+" URL: https://spacevim.org
+" License: GPLv3
+"=============================================================================
+
+""
+" @section lang#processing, layer-lang-processing
+" @parentsection layers
+" This layer is for Processing development:
+" https://processing.org
+"
+" This is based on the work from https://github.com/sophacles/vim-processing
+"
+" Requirements:
+"
+"   1. You will need a copy of processing-java. The best way to do this is to get a copy of the Processing IDE from https://processing.org/download/
+"
+"       Once you have it, run it, and then select Tools -> install
+"       "processing-java"
+"
+" @subsection Mappings
+" >
+"   Mode        Key         Function
+"   -----------------------------------------------
+"   normal      SPC l r     execute current sketch 
+" <
+
+function! SpaceVim#layers#lang#processing#plugins() abort
+  let plugins = [
+        \ ['sophacles/vim-processing', { 'on_ft' : 'processing' }],
+        \ ]
+  return plugins
+endfunction
+
+function! SpaceVim#layers#lang#processing#config() abort
+  let runner = 'processing-java --force --output=/tmp/vim-processing --sketch=$(pwd)/$(dirname %s) --run'
+  call SpaceVim#plugins#runner#reg_runner('processing', runner)
+  call SpaceVim#mapping#space#regesit_lang_mappings('processing',
+        \ function('s:language_specified_mappings'))
+endfunction
+
+function! s:language_specified_mappings() abort
+  call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'r'],
+        \ 'call SpaceVim#plugins#runner#open()', 'execute current file', 1)
+endfunction
+

--- a/docs/layers/lang/processing.md
+++ b/docs/layers/lang/processing.md
@@ -1,0 +1,54 @@
+---
+title: "SpaceVim lang#processing layer"
+description: "This layer is for working on Processing sketches. It provides sytnax checking and an app runner"
+---
+
+# [Available Layers](../../) >> lang#processing
+
+<!-- vim-markdown-toc GFM -->
+
+- [Description](#description)
+- [Features](#features)
+- [Install](#install)
+  - [Layer](#layer)
+- [Key bindings](#key-bindings)
+  - [Code runner](#code-runner)
+
+<!-- vim-markdown-toc -->
+
+## Description
+
+This layer is for working on Processing sketches.
+It builds on top of the existing vim plugin [sophacles/vim-processing](https://github.com/sophacles/vim-processing).
+
+## Features
+
+- Syntax highlighting and indent
+- Run sketches asynchonously
+
+## Install
+
+You will need to install the `processing-java` tool.
+This is best done via the Processing IDE which can be obtained from the [processing website](https://processing.org/download/).
+Once you have the IDE, you can select Tools -> install "processing-java".
+
+### Layer
+
+To use this configuration layer, update custom configuration file with:
+
+```toml
+[[layers]]
+  name = "lang#processing"
+```
+
+## Key bindings
+
+| Key bindings    | Descriptions                     |
+| --------------- | -------------------------------- |
+| `SPC l r`       | Run your sketch                  |
+
+### Code runner
+
+You can build and run your sketch with `SPC l r`.
+The sketch to run is decided based on the directory of you current buffer.
+Note that the sketch is run asynchonously, so you are free to continue editing while it is running.


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [X] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why is this change is necessary and useful?

[Processing](https://processing.org) is a creative coding platform. It is useful as an education tool, but also for artists and other folk who want to quickly iterate with graphical and interactive media. I personally use it frequently to prototype tools and workflows.

There is a good vim plugin for processing already, [sophacles/vim-processing](https://github.com/sophacles/vim-processing), and it provided make support, as well syntax highlighting and error reporting.

I made a first pass as adding a language layer for processing. Notably, this imports the existing vim plugin for processing, and adds a runner for processing sketches. It's a work in progress, and I have a couple questions.

1. **How can I improve my runner command?** 
Processing has a rigid set of requirements for a sketch of a give given name. The entry functions must live in a .pde file (processing's file extensions) with the name of the sketch, and all the source files must live in a directory with the name of the sketch. For example consider a sketch called `JNATest`:

```
$ exa --tree JNATest
JNATest
├── JNATest.pde
└── MNode.pde
```

In addition, the command line tool requires absolute path to the sketch directory. With that in mind, the runner command I've been using is:

```
processing-java --force --output=/tmp/vim-processing --sketch=$(pwd)/$(dirname %s) --run
```

Since the runner subs in the bufname: 

```
let cmd = printf(a:runner, get(s:, 'selected_file', bufname('%')))
```

I had to add those other shell commands to get the absolute path to the directory containing the source file being edited. Is there a better way I should do that? Also, it's unclear to me if windows support is a goal or not, so that might change things as well too.

2. **Should I add a NeoMake maker?**

I think I need to add a neomake maker in order to benefit from SpaceVim's built in error highlighting systems. Would it be better for me to do that via the neomake project or this layer? Or is there a way I can hook up the vim-processing's [compiler file](https://github.com/sophacles/vim-processing/blob/master/compiler/processing.vim)?


I appreciate any feedback, and I also understand if this is a not a good fit for SpaceVim. Keep up the great work!