### PR TITLE
fix alias in Docker Hub README.md

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -38,4 +38,4 @@ but that isn't terribly useful since changes made inside the container won't be 
 
 Even better is an alias `dnvim` which will do this automatically:
 
-    alias dnvim="docker run -it -v $(pwd):/home/spacevim/src nvim"
+    alias dnvim='docker run -it -v $(pwd):/home/spacevim/src nvim'


### PR DESCRIPTION
Changed double to single quotes in the alias example so shells will interpret `$(pwd)` at alias runtime rather than load time.

For background on shell double vs. single quotes, see:
https://stackoverflow.com/a/5573447/749924
https://unix.stackexchange.com/a/355637/36204

Bonus Thank You's:
1. SpaceVim is awesome and I tell everyone about it.
2. The SpaceVim image is my new favorite way to test issues I'm having on host SpaceVim, and it's always my host config's fault :P

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]
