### PR TITLE
Fix: typo in sql.vim

### DIFF
--- a/autoload/SpaceVim/layers/lang/sql.vim
+++ b/autoload/SpaceVim/layers/lang/sql.vim
@@ -6,7 +6,7 @@
 " License: GPLv3
 "=============================================================================
 
-function! SpaceVim#layers#autoload#lang#sql#plugins() abort
+function! SpaceVim#layers#lang#sql#plugins() abort
   let plugins = []
   call add(plugins, ['tpope/vim-dadbod', {'merged' : 0}])
   return plugins


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?
* Fix typo on function name.
* The sql layer caused vim crashed.

[Please explain **in detail** why the changes in this PR are needed.]
