### PR TITLE
Fix stausline windows id

### DIFF
--- a/autoload/SpaceVim/api/messletters.vim
+++ b/autoload/SpaceVim/api/messletters.vim
@@ -58,6 +58,8 @@ function! s:circled_num(num, type) abort
     else
       return ''
     endif
+  elseif a:type == 3
+    return a:num
   endif
 endfunction
 


### PR DESCRIPTION
when statusline mode text is enabled, the id of current windows is
0 on the statusline.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [ ] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [ ] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]
