### PR TITLE
modify Racer installation docs to fit what I had to do

### DIFF
--- a/autoload/SpaceVim/layers/lang/rust.vim
+++ b/autoload/SpaceVim/layers/lang/rust.vim
@@ -19,16 +19,21 @@
 " >
 "       rustup component add rust-src 
 " <
-"   2. Install racer:
+"   2. Install Rust nightly build
+"       
 " >
-"       cargo install racer
+"       rustup install nightly
 " <
-"   3. Set the RUST_SRC_PATH variable in your .bashrc:
+"   3. Install racer:
+" >
+"       cargo +nightly install racer
+" <
+"   4. Set the RUST_SRC_PATH variable in your .bashrc:
 " >
 "       RUST_SRC_PATH=~/.multirust/toolchains/<change>/lib/rustlib/src/rust/src
 "       export RUST_SRC_PATH
 " <
-"   4. Add racer to your path, or set the path with:
+"   5. Add racer to your path, or set the path with:
 " >
 "       let g:racer_cmd = "/path/to/racer/bin"
 " <


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [👊 ] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [👊 ] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [👊 ] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?
This updates the docs contained in `rust.vim` to reflect what I needed to do in order to install Racer ([See](https://github.com/racer-rust/racer#requirements)).

In summary, you need a nightly build of Rust because Racer, or racer's dependencies calls features that haven't made it into the stable build of Rust.

**Note, I have no idea if `rust-src` is still required**
