### PR TITLE
Add Palenight ColorScheme

### DIFF
--- a/autoload/SpaceVim/layers/colorscheme.vim
+++ b/autoload/SpaceVim/layers/colorscheme.vim
@@ -38,6 +38,7 @@ function! SpaceVim#layers#colorscheme#plugins() abort
         \ ['w0ng/vim-hybrid', { 'merged' : 0 }],
         \ ['SpaceVim/vim-material', { 'merged' : 0}],
         \ ['srcery-colors/srcery-vim', { 'merged' : 0}],
+        \ [ 'drewtempelmeyer/palenight.vim', {'merged': 0 }],
         \ ]
   "
   " TODO:

--- a/autoload/SpaceVim/layers/colorscheme.vim
+++ b/autoload/SpaceVim/layers/colorscheme.vim
@@ -79,6 +79,7 @@ unlet s:n
 
 let s:random_colorscheme = 0
 let s:random_frequency = ''
+let s:bright_statusline = 0
 
 function! SpaceVim#layers#colorscheme#config() abort
   if s:random_colorscheme
@@ -127,6 +128,11 @@ endfunction
 function! SpaceVim#layers#colorscheme#set_variable(var) abort
   let s:random_colorscheme = get(a:var, 'random_theme', get(a:var, 'random-theme', 0))
   let s:random_frequency = get(a:var, 'frequency', 'hourly')
+  let s:bright_statusline = get(a:var, 'bright_statusline', 0)
+endfunction
+
+function! SpaceVim#layers#colorscheme#get_variable() abort
+  return s:
 endfunction
 
 function! SpaceVim#layers#colorscheme#get_options() abort

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -540,8 +540,8 @@ function! SpaceVim#layers#core#statusline#def_colors() abort
   exe 'hi! SpaceVim_statusline_b ctermbg=' . t[1][2] . ' ctermfg=' . t[1][3] . ' guibg=' . t[1][1] . ' guifg=' . t[1][0]
   exe 'hi! SpaceVim_statusline_c ctermbg=' . t[2][2] . ' ctermfg=' . t[2][3] . ' guibg=' . t[2][1] . ' guifg=' . t[2][0]
   if name ==# 'palenight' && t[9] ==# 'bright'
-    " exe 'hi! SpaceVim_statusline_z ctermbg=' . t[3][1] . ' ctermfg=' . t[2][2] . ' guibg=' . t[3][0] . ' guifg=' . t[2][0]
-  " else
+    exe 'hi! SpaceVim_statusline_z ctermbg=' . t[3][1] . ' ctermfg=' . t[2][2] . ' guibg=' . t[3][0] . ' guifg=' . t[2][0]
+  else
     exe 'hi! SpaceVim_statusline_z ctermbg=' . t[3][1] . ' ctermfg=' . t[4][3] . ' guibg=' . t[3][0] . ' guifg=' . t[4][0]
   endif
   hi! SpaceVim_statusline_error ctermbg=003 ctermfg=Black guibg=#504945 guifg=#fb4934 gui=bold

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -539,7 +539,11 @@ function! SpaceVim#layers#core#statusline#def_colors() abort
   exe 'hi! SpaceVim_statusline_ia gui=bold cterm=bold ctermbg=' . t[0][2] . ' ctermfg=' . t[0][3] . ' guibg=' . t[0][1] . ' guifg=' . t[0][0]
   exe 'hi! SpaceVim_statusline_b ctermbg=' . t[1][2] . ' ctermfg=' . t[1][3] . ' guibg=' . t[1][1] . ' guifg=' . t[1][0]
   exe 'hi! SpaceVim_statusline_c ctermbg=' . t[2][2] . ' ctermfg=' . t[2][3] . ' guibg=' . t[2][1] . ' guifg=' . t[2][0]
-  exe 'hi! SpaceVim_statusline_z ctermbg=' . t[3][1] . ' ctermfg=' . t[4][3] . ' guibg=' . t[3][0] . ' guifg=' . t[4][0]
+  if name ==# 'palenight' && t[9] ==# 'bright'
+    " exe 'hi! SpaceVim_statusline_z ctermbg=' . t[3][1] . ' ctermfg=' . t[2][2] . ' guibg=' . t[3][0] . ' guifg=' . t[2][0]
+  " else
+    exe 'hi! SpaceVim_statusline_z ctermbg=' . t[3][1] . ' ctermfg=' . t[4][3] . ' guibg=' . t[3][0] . ' guifg=' . t[4][0]
+  endif
   hi! SpaceVim_statusline_error ctermbg=003 ctermfg=Black guibg=#504945 guifg=#fb4934 gui=bold
   hi! SpaceVim_statusline_warn ctermbg=003 ctermfg=Black guibg=#504945 guifg=#fabd2f gui=bold
   call s:HI.hi_separator('SpaceVim_statusline_a', 'SpaceVim_statusline_b')

--- a/autoload/SpaceVim/layers/core/tabline.vim
+++ b/autoload/SpaceVim/layers/core/tabline.vim
@@ -282,10 +282,18 @@ function! SpaceVim#layers#core#tabline#def_colors() abort
     endtry
   endif
   exe 'hi! SpaceVim_tabline_a ctermbg=' . t[0][2] . ' ctermfg=' . t[0][3] . ' guibg=' . t[0][1] . ' guifg=' . t[0][0]
-  exe 'hi! SpaceVim_tabline_b ctermbg=' . t[1][2] . ' ctermfg=' . t[1][3] . ' guibg=' . t[1][1] . ' guifg=' . t[1][0]
+  if name ==# 'palenight'
+    exe 'hi! SpaceVim_tabline_b ctermbg=' . '236'   . ' ctermfg=' . t[1][3] . ' guibg=' .'#44475a'. ' guifg=' . t[1][0]
+  else
+    exe 'hi! SpaceVim_tabline_b ctermbg=' . t[1][2] . ' ctermfg=' . t[1][3] . ' guibg=' . t[1][1] . ' guifg=' . t[1][0]
+  endif
   " SpaceVim_tabline_c is for modified buffers
   exe 'hi! SpaceVim_tabline_m ctermbg=' . t[4][3] . ' ctermfg=' . t[4][2] . ' guibg=' . t[4][1] . ' guifg=' . t[4][0]
-  exe 'hi! SpaceVim_tabline_m_i ctermbg=' . t[1][2] . ' ctermfg=' . t[4][3] . ' guibg=' . t[1][1] . ' guifg=' . t[4][1]
+  if name ==# 'palenight'
+    exe 'hi! SpaceVim_tabline_m_i ctermbg=' . '236' . ' ctermfg=' . t[4][3] . ' guibg=' . '#44475a' . ' guifg=' . t[4][1]
+  else
+    exe 'hi! SpaceVim_tabline_m_i ctermbg=' . t[1][2] . ' ctermfg=' . t[4][3] . ' guibg=' . t[1][1] . ' guifg=' . t[4][1]
+  endif
   call s:HI.hi_separator('SpaceVim_tabline_a', 'SpaceVim_tabline_b')
   call s:HI.hi_separator('SpaceVim_tabline_m', 'SpaceVim_tabline_b')
   call s:HI.hi_separator('SpaceVim_tabline_m', 'SpaceVim_tabline_a')

--- a/autoload/SpaceVim/mapping/guide/theme/palenight.vim
+++ b/autoload/SpaceVim/mapping/guide/theme/palenight.vim
@@ -48,7 +48,8 @@ let s:guiChangedColor   = '#5f5f5f'
 " group_in: windows id in iedit-normal mode
 
 function! SpaceVim#mapping#guide#theme#palenight#palette() abort
-  if get(g:, 'spacevim_statusline_bright', 0)
+  let is_bright = SpaceVim#layers#colorscheme#get_variable()['bright_statusline']
+  if is_bright
     return [
           \ [ s:guiBlack , s:gui08 , s:ctermBlack , s:cterm08 ],
           \ [ s:guiWhite , s:gui02 , s:ctermWhite , s:cterm02 ],

--- a/autoload/SpaceVim/mapping/guide/theme/palenight.vim
+++ b/autoload/SpaceVim/mapping/guide/theme/palenight.vim
@@ -1,0 +1,78 @@
+" Color Palette {{{
+let s:gui01   = '#44475a'
+let s:gui02   = '#5f6a8e'
+let s:gui03   = '#ffb86c'
+let s:gui04   = '#bd93f9'
+let s:gui05   = '#ff5555'
+let s:gui06   = '#f1fa8c'
+let s:gui07   = '#50fa7b'
+let s:gui08   = '#bd93f9'
+let s:cterm01 = '236'
+let s:cterm02 = '61'
+let s:cterm03 = '215'
+let s:cterm04 = '141'
+let s:cterm05 = '160'
+let s:cterm06 = '228'
+let s:cterm07 = '84'
+let s:cterm08 = '141'
+
+let s:guiWhite   = '#f8f8f2'
+let s:guiBlack   = '#282a36'
+let s:ctermWhite = '15'
+let s:ctermBlack = '16'
+
+let s:ctermChangedColor = '59'
+let s:guiChangedColor   = '#5f5f5f'
+
+" }}}
+
+" the theme colors should be
+" [
+"    \ [ a_guifg,  a_guibg,  a_ctermfg,  a_ctermbg],
+"    \ [ b_guifg,  b_guibg,  b_ctermfg,  b_ctermbg],
+"    \ [ c_guifg,  c_guibg,  c_ctermfg,  c_ctermbg],
+"    \ [ z_guibg,  z_ctermbg],
+"    \ [ i_guifg,  i_guibg,  i_ctermfg,  i_ctermbg],
+"    \ [ v_guifg,  v_guibg,  v_ctermfg,  v_ctermbg],
+"    \ [ r_guifg,  r_guibg,  r_ctermfg,  r_ctermbg],
+"    \ [ ii_guifg, ii_guibg, ii_ctermfg, ii_ctermbg],
+"    \ [ in_guifg, in_guibg, in_ctermfg, in_ctermbg],
+" \ ]
+" group_a: window id
+" group_b/group_c: stausline sections
+" group_z: empty area
+" group_i: window id in insert mode
+" group_v: window id in visual mode
+" group_r: window id in select mode
+" group_ii: window id in iedit-insert mode
+" group_in: windows id in iedit-normal mode
+
+function! SpaceVim#mapping#guide#theme#palenight#palette() abort
+  if get(g:, 'spacevim_statusline_bright', 0)
+    return [
+          \ [ s:guiBlack , s:gui08 , s:ctermBlack , s:cterm08 ],
+          \ [ s:guiWhite , s:gui02 , s:ctermWhite , s:cterm02 ],
+          \ [ s:guiWhite , s:gui02 , s:ctermWhite , s:cterm02 ],
+          \ [ s:gui01    , s:cterm01 ],
+          \ [ s:guiBlack , s:gui07 , s:ctermBlack , s:cterm07 ],
+          \ [ s:guiBlack , s:gui06 , s:ctermBlack , s:cterm06 ],
+          \ [ s:guiBlack , s:gui05 , s:ctermWhite , s:cterm05 ],
+          \ ['#282828', '#689d6a', 235, 72],
+          \ ['#282828', '#8f3f71', 235, 132],
+          \ 'bright'
+          \ ]
+  else
+    return [
+          \ [ s:guiBlack , s:gui08 , s:ctermBlack , s:cterm08 ],
+          \ [ s:guiWhite , s:gui01 , s:ctermWhite , s:cterm01 ],
+          \ [ s:guiWhite , s:gui01 , s:ctermWhite , s:cterm01 ],
+          \ [ s:guiChangedColor, s:ctermChangedColor],
+          \ [ s:guiBlack , s:gui07 , s:ctermBlack , s:cterm07 ],
+          \ [ s:guiBlack , s:gui06 , s:ctermBlack , s:cterm06 ],
+          \ [ s:guiBlack , s:gui05 , s:ctermWhite , s:cterm05 ],
+          \ ['#282828', '#689d6a', 235, 72],
+          \ ['#282828', '#8f3f71', 235, 132],
+          \ 'dark',
+          \ ]
+  endif
+endfunction

--- a/doc/SpaceVim.txt
+++ b/doc/SpaceVim.txt
@@ -1332,18 +1332,24 @@ Requirements:
 >
       rustup component add rust-src
 <
-  2. Install racer:
+  2. Install Rust nightly build
+
 
 >
-      cargo install racer
+      rustup install nightly
 <
-  3. Set the RUST_SRC_PATH variable in your .bashrc:
+  3. Install racer:
+
+>
+      cargo +nightly install racer
+<
+  4. Set the RUST_SRC_PATH variable in your .bashrc:
 
 >
       RUST_SRC_PATH=~/.multirust/toolchains/<change>/lib/rustlib/src/rust/src
       export RUST_SRC_PATH
 <
-  4. Add racer to your path, or set the path with:
+  5. Add racer to your path, or set the path with:
 
 >
       let g:racer_cmd = "/path/to/racer/bin"

--- a/docs/cn/layers/colorscheme.md
+++ b/docs/cn/layers/colorscheme.md
@@ -45,6 +45,7 @@ colorscheme 模块为 SpaceVim 提供了一系列常用的颜色主题，默认�
 | srcery       | yes      | no       | yes      | yes      | yes        |
 | onedark      | yes      | no       | yes      | yes      | yes        |
 | jellybeans   | yes      | no       | yes      | yes      | yes        |
+| palenight    | yes      | no       | yes      | yes      | yes        |
 | one          | yes      | yes      | yes      | yes      | yes        |
 | nord         | yes      | no       | yes      | yes      | yes        |
 | gruvbox      | yes      | yes      | yes      | yes      | yes        |

--- a/docs/layers/colorscheme.md
+++ b/docs/layers/colorscheme.md
@@ -41,17 +41,18 @@ Colorscheme list
 
 | Name         | dark | light | term | gui | statusline |
 | ------------ | ---- | ----- | ---- | --- | ---------- |
-| molokai      | yes  | no    | yes  | yes | yes        |
-| srcery       | yes  | no    | yes  | yes | yes        |
-| onedark      | yes  | no    | yes  | yes | yes        |
-| jellybeans   | yes  | no    | yes  | yes | yes        |
-| one          | yes  | yes   | yes  | yes | yes        |
-| nord         | yes  | no    | yes  | yes | yes        |
-| gruvbox      | yes  | yes   | yes  | yes | yes        |
-| NeoSolarized | yes  | yes   | yes  | yes | yes        |
-| hybrid       | yes  | yes   | yes  | yes | yes        |
-| material     | yes  | yes   | yes  | yes | yes        |
-| SpaceVim     | yes  | yes   | yes  | yes | yes        |
+| molokai      | yes  | no    | yes  | yes |    yes     |
+| srcery       | yes  | no    | yes  | yes |    yes     |
+| onedark      | yes  | no    | yes  | yes |    yes     |
+| jellybeans   | yes  | no    | yes  | yes |    yes     |
+| palenight    | yes  | no    | yes  | yes |    yes     |
+| one          | yes  | yes   | yes  | yes |    yes     |
+| nord         | yes  | no    | yes  | yes |    yes     |
+| gruvbox      | yes  | yes   | yes  | yes |    yes     |
+| NeoSolarized | yes  | yes   | yes  | yes |    yes     |
+| hybrid       | yes  | yes   | yes  | yes |    yes     |
+| material     | yes  | yes   | yes  | yes |    yes     |
+| SpaceVim     | yes  | yes   | yes  | yes |    yes     |
 
 By default this layer only include above colorschemes. If you want to use other colorschemes which
 are available on Github, use the `custom_plugins` section in configuration file. For example:


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?
add new colorscheme **palenight**.

**with** or **without** the below two commits all works. the two commits just add a bright statusline style. 
```
"update palenight colorscheme" && "fix palenight colorscheme"
```
**default statusline** color style is dark one if
```
g:spacevim_statusline_bright == 0  ||  exists(g:spacevim_statusline_bright) == 0
```
I have **not** added the global option   **g:spacevim_statusline_bright**  in  **autoload/SpaceVim.vim**

[Please explain **in detail** why the changes in this PR are needed.]
