### PR TITLE
Fix: map VBG*SelectedText actions in correct mode

### DIFF
--- a/autoload/SpaceVim/layers/debug.vim
+++ b/autoload/SpaceVim/layers/debug.vim
@@ -25,9 +25,9 @@ function! SpaceVim#layers#debug#config() abort
   call SpaceVim#mapping#space#def('nnoremap', ['d', 'O'], 'VBGstepOut', 'step out of current function', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['d', 'k'], 'VBGkill', 'Terminates the debugger', 1)
   let g:_spacevim_mappings_space.d.e = {'name' : '+Evaluate/Execute'}
-  call SpaceVim#mapping#space#def('nnoremap', ['d', 'e', 's'], 'VBGevalSelectedText', 'Evaluate and print the selected text', 1)
+  call SpaceVim#mapping#space#def('vnoremap', ['d', 'e', 's'], 'VBGevalSelectedText', 'Evaluate and print the selected text', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['d', 'e', 'e'], 'VBGevalWordUnderCursor', 'Evaluate the <cword> under the cursor', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['d', 'e', 'S'], 'VBGexecuteSelectedText', 'Execute the selected text', 1)
+  call SpaceVim#mapping#space#def('vnoremap', ['d', 'e', 'S'], 'VBGexecuteSelectedText', 'Execute the selected text', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['d', '.'], 'call call('
         \ . string(s:_function('s:debug_transient_state')) . ', [])',
         \ 'debug transient state', 1)

--- a/autoload/SpaceVim/layers/debug.vim
+++ b/autoload/SpaceVim/layers/debug.vim
@@ -5,6 +5,7 @@
 " URL: https://spacevim.org
 " License: GPLv3
 "=============================================================================
+scriptencoding utf-8
 
 function! SpaceVim#layers#debug#plugins() abort
   let plugins = []


### PR DESCRIPTION


### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

:bug: : maping for VBG*SelectedText are done in the wrong mode I think. These actions suppose that the user has previously selected a text. Therefore, they won't be in normal mode when using these mappings.

This PR maps them in visual mode.
