### PR TITLE
Add: custom register language specific mapping function

### DIFF
--- a/autoload/SpaceVim/custom.vim
+++ b/autoload/SpaceVim/custom.vim
@@ -83,6 +83,9 @@ function! SpaceVim#custom#SPCGroupName(keys, name) abort
   call add(g:_spacevim_mappings_space_custom_group_name, [a:keys, a:name])
 endfunction
 
+function! SpaceVim#custom#Reg_langSPC(ft, func) abort
+  call SpaceVim#mapping#space#extend_CustomLSPC({a:ft.'custom' : a:func})
+endfunction
 
 function! SpaceVim#custom#apply(config, type) abort
   " the type can be local or global

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -600,14 +600,24 @@ function! s:windows_layout_toggle() abort
 endfunction
 
 
+function! SpaceVim#mapping#space#extend_CustomLSPC(dict) abort
+  call extend(s:language_specified_mappings, a:dict)
+endfunction
+
+
 let s:language_specified_mappings = {}
 function! SpaceVim#mapping#space#refrashLSPC() abort
   let g:_spacevim_mappings_space.l = {'name' : '+Language Specified'}
-  if !empty(&filetype) && has_key(s:language_specified_mappings, &filetype)
-    call call(s:language_specified_mappings[&filetype], [])
-    let b:spacevim_lang_specified_mappings = g:_spacevim_mappings_space.l
+  if !empty(&filetype)
+    if has_key(s:language_specified_mappings, &filetype)
+      call call(s:language_specified_mappings[&filetype], [])
+      let b:spacevim_lang_specified_mappings = g:_spacevim_mappings_space.l
+    endif
+    if has_key(s:language_specified_mappings, &filetype.'custom')
+      call call(s:language_specified_mappings[&filetype.'custom'], [])
+      call extend(b:spacevim_lang_specified_mappings, g:_spacevim_mappings_space.l)
+    endif
   endif
-
 endfunction
 
 function! SpaceVim#mapping#space#regesit_lang_mappings(ft, func) abort


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?
right now custom can use
```
SpaceVim#mapping#space#def() or SpaceVim#custom#SPC()
```

 to **add new** or **override default** layer mappings, but I found that it is impossible to change a default language specific mapping, if use the above function with 
```
SpaceVim#mapping#space#regesit_lang_mappings()
``` 
 it will override **all default** lang mappings when vim enter into specific filetype buffer.
in this commit add a function
```
SpaceVim#custom#Reg_langSPC()
```
custom can call it in bootstrap#**after** -- **VimEnter** with Custom-defined mappings, it will add new **undefined(i.g. customized mapping that haven`t been defined by SpaceVim)** mappings or override default **same** mappings (when the mapping key has been defined by SpaceVim), e.g.

```
function MySpaceVim#bootstrap#after()
    call SpaceVim#custom#Reg_langSPC('vim', function('s:language_specified_mappings'))

endfunction

function! s:language_specified_mappings() abort
  if g:is_spacevim
    call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 't'],
          \ 'call setline(line("$"), "\" vim:set sw=2 ts=2 sts=2 et tw=78 fmd=marker")',
          \ 'insert Vim file tail', 1)
    call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'a'], 'call call('
          \ . string(s:_function('s:addParam')) . ', [])',
          \ '@ add debug Parameter', 1)
```


[Please explain **in detail** why the changes in this PR are needed.]
