### PR TITLE
feat(dash.vim): add devdocs support with (devdocs.vim)

### DIFF
--- a/autoload/SpaceVim/layers/tools/dash.vim
+++ b/autoload/SpaceVim/layers/tools/dash.vim
@@ -16,6 +16,9 @@ function! SpaceVim#layers#tools#dash#plugins() abort
         \ ['rizzatti/dash.vim', {
         \ 'on_map': { 'n': ['<Plug>DashSearch', '<Plug>DashGlobalSearch'] }
         \ }],
+        \ ['rhysd/devdocs.vim', {
+        \ 'on_map': { 'n': ['<Plug>(devdocs-under-cursor)'] }
+        \ }],
         \ ]
 endfunction
 
@@ -28,6 +31,8 @@ function! SpaceVim#layers#tools#dash#config() abort
   "" }}}
 
   let g:_spacevim_mappings_space.D = { 'name' : '+Dash' }
+  call SpaceVim#mapping#space#def('nmap', ['D', 'b'],
+        \ '<Plug>(devdocs-under-cursor)', 'search word on devdocs.io', 0)
   call SpaceVim#mapping#space#def('nmap', ['D', 'd'],
         \ '<Plug>DashSearch', 'search word under cursor', 0)
   call SpaceVim#mapping#space#def('nmap', ['D', 'D'],


### PR DESCRIPTION
keybinding: (SPC D b) search word on devdocs.io
[rhysd/devdocs.vim](https://github.com/rhysd/devdocs.vim)

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Add a new way to search dev docs with [devdocs.io](https://devdocs.io/). 
Especially for people who do not have *Dash* installed.