### PR TITLE
In lsp config replace #{cwd} for the current working directory.

### DIFF
--- a/autoload/SpaceVim/layers/lsp.vim
+++ b/autoload/SpaceVim/layers/lsp.vim
@@ -148,7 +148,7 @@ function! SpaceVim#layers#lsp#set_variable(var) abort
         endfor
         let s:lsp_servers[ft] = l:newcmds
       else
-        call SpaceVim#logger#warn('Failed to enable lsp for ' . ft . ', ' . cmd . ' is not executable!')
+        call SpaceVim#logger#warn('Failed to enable lsp for ' . ft . ', ' . l:exec . ' is not executable!')
       endif
     endif
   endfor

--- a/autoload/SpaceVim/layers/lsp.vim
+++ b/autoload/SpaceVim/layers/lsp.vim
@@ -132,13 +132,21 @@ function! SpaceVim#layers#lsp#set_variable(var) abort
   if !empty(override)
     call extend(s:lsp_servers, override, 'force')
   endif
+  let l:cwd = getcwd()
   for ft in get(a:var, 'filetypes', [])
-    let cmd = get(s:lsp_servers, ft, [''])[0]
-    if empty(cmd)
+    let l:cmds = get(s:lsp_servers, ft, [''])
+    let l:exec = l:cmds[0]
+    if empty(l:exec)
       call SpaceVim#logger#warn('Failed to find the lsp server command for ' . ft)
     else
-      if executable(cmd)
+      if executable(l:exec)
         call add(s:enabled_fts, ft)
+        let l:newcmds = []
+        for l:cmd in l:cmds
+          let l:newcmd = substitute(l:cmd, '#{cwd}', l:cwd, 'g')
+          call add(l:newcmds, l:newcmd)
+        endfor
+        let s:lsp_servers[ft] = l:newcmds
       else
         call SpaceVim#logger#warn('Failed to enable lsp for ' . ft . ', ' . cmd . ' is not executable!')
       endif


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Some lsp servers have their workspace be set by cmd config. I've had experience with at least one of them (java jdt-ls) using the same directory as workspace for all projects which cause it to crash when running multiple instances of the server (a couple projects opened in vim at the same time).

By being able to tell it to use a workspace dependent on the project I'm currently working at I avoid having the confict.

Example:
```toml
    [layers.override_cmd]
        java = [
            "java",
            "-Declipse.application=org.eclipse.jdt.ls.core.id1",
            "-Dosgi.bundles.defaultStartLevel=4",
            "-Declipse.product=org.eclipse.jdt.ls.core.product",
            "-Dlog.protocol=true",
            "-Dlog.level=DEBUG",
            "-noverify",
            "-Xmx1G",
            "-jar",
            "~/.config/jdt-ls/plugins/org.eclipse.equinox.launcher_1.5.200.v20180922-1751.jar",
            "-configuration",
            "~/.config/jdt-ls/config_linux",
            "-data",
            "~/.cache/jdt-ls/workspace/#{cwd}"
        ]
```
This is the result:
```
$ tree ~/.cache/jdt-ls
/home/galbar/.cache/jdt-ls
└── workspace
    └── home
        └── galbar
            └── Projects
                ├── java-test-1
                │   └── jdt.ls-java-project
                │       ├── bin
                │       └── src
                └── java-test-2
                     └── jdt.ls-java-project
                        ├── bin
                        └── src
```