### PR TITLE
On Windows, send CTRL+r if '+' register is not given

### DIFF
--- a/autoload/SpaceVim/layers/shell.vim
+++ b/autoload/SpaceVim/layers/shell.vim
@@ -93,6 +93,7 @@ func! SpaceVim#layers#shell#ctrl_r() abort
   if reg == 43
     return @+
   endif
+  return "\<C-r>"
 endfunction
 
 func! SpaceVim#layers#shell#ctrl_w() abort


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [ x ] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [ x ] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [ x ] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

It is not expected behavior to output 0 like it currently does if '+' isn't given. (The other alternative would be allowing any register to be specified. I'll let someone else implement that.)
