### PR TITLE
Fix docs/layers/shell.md table

### DIFF
--- a/docs/layers/shell.md
+++ b/docs/layers/shell.md
@@ -70,6 +70,7 @@ in percents with the variable `default_height`. Default value is 30.
 | `Ctrl-l`    | Switch to the windows on the right       |
 
 ### Additional key bindings on Windows
+
 | Key Binding | Description                              |
 | ----------- | ---------------------------------------- |
 | `Ctrl-d`    | Sends `exit <CR>` if at a prompt         |


### PR DESCRIPTION
The original Markdown table didn't generate a proper table on the website: https://spacevim.org/layers/shell/.

Add this additional blank line should fix that

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

The original Markdown table generation on the website is wrong, add an empty line should fix it.
