### PR TITLE
fix a map bug cscope

### DIFF
--- a/autoload/SpaceVim/layers/cscope.vim
+++ b/autoload/SpaceVim/layers/cscope.vim
@@ -29,7 +29,7 @@ function! SpaceVim#layers#cscope#config() abort
   else
     call SpaceVim#mapping#space#def('nnoremap', ['m', 'c', 'c'], 'call cscope#find("d", expand("<cword>"))', 'find functions called by this function', 1)
     call SpaceVim#mapping#space#def('nnoremap', ['m', 'c', 'C'], 'call cscope#find("c", expand("<cword>"))', 'find functions calling this function', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['m', 'c', 'C'], 'call cscope#find("g", expand("<cword>"))', 'find global definition of a symbol', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['m', 'c', 'd'], 'call cscope#find("g", expand("<cword>"))', 'find global definition of a symbol', 1)
     call SpaceVim#mapping#space#def('nnoremap', ['m', 'c', 'r'], 'call cscope#find("s", expand("<cword>"))', 'find references of a symbol', 1)
     call SpaceVim#mapping#space#def('nnoremap', ['m', 'c', 'f'], 'call cscope#find("f", expand("<cword>"))', 'find files', 1)
     call SpaceVim#mapping#space#def('nnoremap', ['m', 'c', 'F'], 'call cscope#find("i", expand("<cword>"))', 'find files including this file', 1)


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]
The key map for "find function calling this function" is duplicated with "find global definition of a symbol".
This hide the map for the "find global definition of a symbol"