### PR TITLE
Fix: Issue #2948 function call update from deoplete#mappings#smart_close_p…

### DIFF
--- a/config/plugins/deoplete.vim
+++ b/config/plugins/deoplete.vim
@@ -117,8 +117,8 @@ call deoplete#custom#var('omni', 'input_patterns', {
 call deoplete#custom#source('_', 'matchers', ['matcher_full_fuzzy'])
 call deoplete#custom#source('file/include', 'matchers', ['matcher_head'])
 
-inoremap <expr><C-h> deoplete#mappings#smart_close_popup()."\<C-h>"
-inoremap <expr><BS> deoplete#mappings#smart_close_popup()."\<C-h>"
+inoremap <expr><C-h> deoplete#smart_close_popup()."\<C-h>"
+inoremap <expr><BS> deoplete#smart_close_popup()."\<C-h>"
 set isfname-==
 
 " vim:set et sw=2:


### PR DESCRIPTION
…opup to deoplete#smart_close_popup

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]
Issue #2948 affects the 'Backspace' key behavior because of an outdated call to the function deoplete#mappings#smart_close_popup inside 'config/plugins/deoplete.vim' calling the function as deoplete#smart_close_popup as pointed [here](https://github.com/SpaceVim/SpaceVim/issues/2948#issuecomment-512217636) solves the problem.