### PR TITLE
Add additional bindings from coc.nvim for c layer

### DIFF
--- a/autoload/SpaceVim/layers/lang/c.vim
+++ b/autoload/SpaceVim/layers/lang/c.vim
@@ -191,6 +191,19 @@ function! s:language_specified_mappings() abort
           \ 'call SpaceVim#lsp#rename()', 'rename symbol', 1)
     call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'f'],
           \ 'call SpaceVim#lsp#references()', 'references', 1)
+
+    " these work for now with coc.nvim only
+
+    call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'i'],
+          \ 'call SpaceVim#lsp#go_to_impl()', 'implementation', 1)
+    call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 't'],
+          \ 'call SpaceVim#lsp#go_to_typedef()', 'type definition', 1)
+    call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'R'],
+          \ 'call SpaceVim#lsp#refactor()', 'refactor', 1)
+    " TODO this should be gD
+    call SpaceVim#mapping#space#langSPC('nnoremap', ['l', 'D'],
+          \ 'call SpaceVim#lsp#go_to_declaration()', 'declaration', 1)
+
   endif
   let g:_spacevim_mappings_space.l.s = {'name' : '+Send'}
   call SpaceVim#mapping#space#langSPC('nmap', ['l','s', 'i'],

--- a/autoload/SpaceVim/lsp.vim
+++ b/autoload/SpaceVim/lsp.vim
@@ -63,7 +63,23 @@ if SpaceVim#layers#isLoaded('autocomplete') && get(g:, 'spacevim_autocomplete_me
   endfunction
 
   function! SpaceVim#lsp#go_to_def() abort
-    call CocActionAsync('jumpDefinition')
+    call CocAction('jumpDefinition')
+  endfunction
+
+  function! SpaceVim#lsp#go_to_declaration() abort
+    call CocAction('jumpDeclaration')
+  endfunction
+
+  function! SpaceVim#lsp#go_to_typedef() abort
+    call CocAction('jumpTypeDefinition')
+  endfunction
+
+  function! SpaceVim#lsp#go_to_impl() abort
+    call CocAction('jumpImplementation')
+  endfunction
+
+  function! SpaceVim#lsp#refactor() abort
+    call CocActionAsync('refactor')
   endfunction
 
   function! SpaceVim#lsp#rename() abort
@@ -71,7 +87,7 @@ if SpaceVim#layers#isLoaded('autocomplete') && get(g:, 'spacevim_autocomplete_me
   endfunction
 
   function! SpaceVim#lsp#references() abort
-    call CocActionAsync('jumpReferences')
+    call CocAction('jumpReferences')
   endfunction
 elseif has('nvim')
   " use LanguageClient-neovim


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

This pr adds additional bindings to layers/lang/c.vim to use coc.nvim's
CocAction('jumpDeclaration') <kbd>[SPC] l D</kbd>
CocAction('jumpTypeDefinition')  <kbd>[SPC] l t</kbd>
CocAction('jumpImplementation')  <kbd>[SPC] l i</kbd>
CocActionAsync('refactor')  <kbd>[SPC] l R</kbd>
