### PR TITLE
Add Leader f f to fzf layer

### DIFF
--- a/autoload/SpaceVim/layers/fzf.vim
+++ b/autoload/SpaceVim/layers/fzf.vim
@@ -64,6 +64,17 @@ endfunction
 let s:file = expand('<sfile>:~')
 let s:unite_lnum = expand('<slnum>') + 3
 function! s:defind_fuzzy_finder() abort
+  nnoremap <silent> <Leader>ff
+        \ :<C-u>FzfFiles<CR>
+  let lnum = expand('<slnum>') + s:unite_lnum - 4
+  let g:_spacevim_mappings.f.f = ['FzfFiles',
+        \ 'fuzzy find files',
+        \ [
+        \ '[Leader f f ] is to fuzzy find files in CWD',
+        \ '',
+        \ 'Definition: ' . s:file . ':' . lnum,
+        \ ]
+        \ ]
   nnoremap <silent> <Leader>fe
         \ :<C-u>FzfRegister<CR>
   let lnum = expand('<slnum>') + s:unite_lnum - 4

--- a/docs/layers/fzf.md
+++ b/docs/layers/fzf.md
@@ -33,11 +33,12 @@ name = "fzf"
 | `<Leader> f <Space>` | Fuzzy find menu:CustomKeyMaps |
 | `<Leader> f p`       | Fuzzy find menu:AddedPlugins  |
 | `<Leader> f e`       | Fuzzy find register           |
+| `<Leader> f f`       | Fuzzy find files in CWD       |
 | `<Leader> f h`       | Fuzzy find history/yank       |
 | `<Leader> f j`       | Fuzzy find jump, change       |
 | `<Leader> f l`       | Fuzzy find location list      |
 | `<Leader> f m`       | Fuzzy find output messages    |
 | `<Leader> f o`       | Fuzzy find outline            |
 | `<Leader> f q`       | Fuzzy find quick fix          |
-| `<Leader> f t`       | Fuzzy find global tags          |
+| `<Leader> f t`       | Fuzzy find global tags        |
 | `SPC b b`            | List all buffers              |


### PR DESCRIPTION
### PR Prelude
- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

<kbd>Leader</kbd> <kbd>f</kbd> <kbd>f</kbd> uses FzfFiles to search for files by name in the current
working directory. 

This is as opposed to <kbd>Space</kbd> <kbd>f</kbd> <kbd>f</kbd> which uses FzF to
search in the directory of the currently open file.