### PR TITLE
fix shortcuts/docs about marking spelling

### DIFF
--- a/autoload/SpaceVim/mapping/z.vim
+++ b/autoload/SpaceVim/mapping/z.vim
@@ -32,7 +32,7 @@ function! SpaceVim#mapping#z#init() abort "{{{
     nnoremap zE zE
     let g:_spacevim_mappings_z['F'] = ['call feedkeys("zF", "n")', 'create a fold for N lines']
     nnoremap zF zF
-    let g:_spacevim_mappings_z['G'] = ['call feedkeys("zG", "n")', 'mark good spelled(update internal-wordlist)']
+    let g:_spacevim_mappings_z['G'] = ['call feedkeys("zG", "n")', 'mark good spelled (update internal wordlist)']
     nnoremap zG zG
     let g:_spacevim_mappings_z['H'] = ['call feedkeys("zH", "n")', 'scroll half a screenwidth to the right']
     nnoremap zH zH
@@ -46,7 +46,7 @@ function! SpaceVim#mapping#z#init() abort "{{{
     nnoremap zO zO
     let g:_spacevim_mappings_z['R'] = ['call feedkeys("zR", "n")', 'set `foldlevel` to deepest fold']
     nnoremap zR zR
-    let g:_spacevim_mappings_z['W'] = ['call feedkeys("zW", "n")', 'mark wrong spelled']
+    let g:_spacevim_mappings_z['W'] = ['call feedkeys("zW", "n")', 'mark wrong spelled (update internal wordlist)']
     nnoremap zW zW
     let g:_spacevim_mappings_z['X'] = ['call feedkeys("zX", "n")', 're-apply `foldleve`']
     nnoremap zX zX
@@ -96,6 +96,8 @@ function! SpaceVim#mapping#z#init() abort "{{{
     nnoremap zt zt
     let g:_spacevim_mappings_z['v'] = ['call feedkeys("zv", "n")', 'open enough folds to view cursor line']
     nnoremap zv zv
+    let g:_spacevim_mappings_z['w'] = ['call feedkeys("zw", "n")', 'mark wrong spelled']
+    nnoremap zw zw
     let g:_spacevim_mappings_z['x'] = ['call feedkeys("zx", "n")', 're-apply foldlevel and do "zV"']
     nnoremap zx zx
     " smart scroll

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1287,14 +1287,14 @@ which will tell you the functional of all mappings starting with `z`.
 | `z D`        | delete folds recursively                     |
 | `z E`        | eliminate all folds                          |
 | `z F`        | create a fold for N lines                    |
-| `z G`        | mark good spelled(update internal-wordlist)  |
+| `z G`        | mark good spelled (update internal wordlist) |
 | `z H`        | scroll half a screenwidth to the right       |
 | `z L`        | scroll half a screenwidth to the left        |
 | `z M`        | set `foldlevel` to zero                      |
 | `z N`        | set `foldenable`                             |
 | `z O`        | open folds recursively                       |
 | `z R`        | set `foldlevel` to deepest fold              |
-| `z W`        | mark wrong spelled                           |
+| `z W`        | mark wrong spelled (update internal wordlist)|
 | `z X`        | re-apply `foldlevel`                         |
 | `z ^`        | cursor to screen bottom line N               |
 | `z a`        | toggle a fold                                |
@@ -1316,6 +1316,7 @@ which will tell you the functional of all mappings starting with `z`.
 | `z s`        | left scroll horizontally to cursor position  |
 | `z t`        | cursor line at top of window                 |
 | `z v`        | open enough folds to view cursor line        |
+| `z w`        | mark wrong spelled                           |
 | `z x`        | re-apply foldlevel and do "zV"               |
 | `z z`        | smart scroll                                 |
 | `z <Left>`   | scroll screen N characters to right          |


### PR DESCRIPTION
### PR Prelude

Please complete these steps and check these boxes before filing your PR:

- [X] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [X] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

- The "zw" shortcut to mark wrong spelling (global list) was missing (in both the code and docs)
- The documentation for "zW" was wrong: zW marks wrong spelling in the internal list, not in the global one (from the docs, it seemed like it was marked in the global one).

This PR adds the new "zw" shortcut and updates the docs.