### PR TITLE
Update php.vim

### DIFF
--- a/autoload/SpaceVim/layers/lang/php.vim
+++ b/autoload/SpaceVim/layers/lang/php.vim
@@ -23,7 +23,7 @@ function! SpaceVim#layers#lang#php#plugins() abort
   if SpaceVim#layers#lsp#check_filetype('php')
     call add(plugins, ['felixfbecker/php-language-server', {'on_ft' : 'php', 'build' : 'composer install && composer run-script parse-stubs'}])
   else
-    call add(plugins, ['shawncplus/phpcomplete.vim', { 'on_ft' : 'php'}])
+    call add(plugins, ['lvht/phpcd.vim', { 'on_ft' : 'php', 'build': 'composer install'}])
   endif
   return plugins
 endfunction


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

I am a regular user of SpaceVim (Created [SpaceBox](https://github.com/VarunBatraIT/spacebox)) and when I updated it, PHP auto-complete stopped working. I was using 1.0.0! Then I removed plugin (disable plugin phpcomplete.vim) and added following and it worked So the change!

```
# custom plugins {{{
[[custom_plugins]]
  name = 'lvht/phpcd.vim'
  build = 'composer install'
  merged = 0
  on_ft = 'php'
# }}}
 ```

Basically https://github.com/lvht/phpcd.vim Works and specified doesn't!