### PR TITLE
Website: Add git-plugin documentation to git layer

### DIFF
--- a/docs/layers/git.md
+++ b/docs/layers/git.md
@@ -9,6 +9,7 @@ description: "This layers adds extensive support for git"
 
 - [Description](#description)
 - [Install](#install)
+- [Layer options](#layer-options)
 - [Key bindings](#key-bindings)
 
 <!-- vim-markdown-toc -->
@@ -25,6 +26,10 @@ To use this configuration layer, add following snippet to your custom configurat
 [[layers]]
   name = "git"
 ```
+
+## Layer options
+
+- `git-plugin`: default value is `gina` (or `gita` on older vim versions), available values include: `gina`, `fugitive`, `gita`
 
 ## Key bindings
 


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

The `git-plugin` option added in https://github.com/SpaceVim/SpaceVim/pull/2583 seems to be undocumented