### PR TITLE
Naming rules

### DIFF
--- a/autoload/SpaceVim/layers/core.vim
+++ b/autoload/SpaceVim/layers/core.vim
@@ -137,7 +137,7 @@ function! SpaceVim#layers#core#config() abort
   call SpaceVim#mapping#space#def('nnoremap', ['j', 'u'], 'call call('
         \ . string(s:_function('s:jump_to_url')) . ', [])',
         \ 'jump to url', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['<Tab>'], 'try | b# | catch | endtry', 'last buffer', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['<Tab>'], 'try | b# | catch | endtry', 'last-buffer', 1)
   let lnum = expand('<slnum>') + s:lnum - 1
   call SpaceVim#mapping#space#def('nnoremap', ['b', '.'], 'call call('
         \ . string(s:_function('s:buffer_transient_state')) . ', [])',
@@ -288,7 +288,7 @@ function! SpaceVim#layers#core#config() abort
   call SpaceVim#mapping#space#def('nmap', ['c', 'P'], '<Plug>CommentParagraphs', 'comment paragraphs', 0, 1)
 
   nnoremap <silent> <Plug>CommentOperator :set opfunc=<SID>commentOperator<Cr>g@
-  let g:_spacevim_mappings_space[';'] = ['call feedkeys("\<Plug>CommentOperator")', 'comment operator']
+  let g:_spacevim_mappings_space[';'] = ['call feedkeys("\<Plug>CommentOperator")', 'comment-operator']
   nmap <silent> [SPC]; <Plug>CommentOperator
 endfunction
 

--- a/autoload/SpaceVim/layers/core.vim
+++ b/autoload/SpaceVim/layers/core.vim
@@ -219,7 +219,7 @@ function! SpaceVim#layers#core#config() abort
     call SpaceVim#mapping#space#def('nnoremap', ['b', 't'], 'Defx -no-toggle', 'show-file-tree-at-buffer-dir', 1)
   endif
   call SpaceVim#mapping#space#def('nnoremap', ['f', 'y'], 'call SpaceVim#util#CopyToClipboard()', 'show-and-copy-buffer-filename', 1)
-  let g:_spacevim_mappings_space.f.v = {'name' : '+Vim(SpaceVim)'}
+  let g:_spacevim_mappings_space.f.v = {'name' : '+Vim/SpaceVim'}
   call SpaceVim#mapping#space#def('nnoremap', ['f', 'v', 'v'], 'let @+=g:spacevim_version | echo g:spacevim_version', 'display-and-copy-version', 1)
   let lnum = expand('<slnum>') + s:lnum - 1
   call SpaceVim#mapping#space#def('nnoremap', ['f', 'v', 'd'], 'SPConfig',
@@ -279,22 +279,22 @@ function! SpaceVim#layers#core#config() abort
   "
   " Toggles the comment state of the selected line(s). If the topmost selected
   " line is commented, all selected lines are uncommented and vice versa.
-  call SpaceVim#mapping#space#def('nmap', ['c', 'l'], '<Plug>NERDCommenterInvert', 'toggle comment lines', 0, 1)
-  call SpaceVim#mapping#space#def('nmap', ['c', 'L'], '<Plug>NERDCommenterComment', 'comment lines', 0, 1)
-  call SpaceVim#mapping#space#def('nmap', ['c', 'u'], '<Plug>NERDCommenterUncomment', 'uncomment lines', 0, 1)
-  call SpaceVim#mapping#space#def('nmap', ['c', 'v'], '<Plug>NERDCommenterInvertgv', 'toggle comment lines and keep visual', 0, 1)
-  call SpaceVim#mapping#space#def('nmap', ['c', 's'], '<Plug>NERDCommenterSexy', 'comment with sexy/pretty layout', 0, 1)
-  call SpaceVim#mapping#space#def('nmap', ['c', 'Y'], '<Plug>NERDCommenterYank', 'yank and comment', 0, 1)
-  call SpaceVim#mapping#space#def('nmap', ['c', '$'], '<Plug>NERDCommenterToEOL', 'comment current line from cursor to the end of the line', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', 'l'], '<Plug>NERDCommenterInvert', 'toggle-comment-lines', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', 'L'], '<Plug>NERDCommenterComment', 'comment-lines', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', 'u'], '<Plug>NERDCommenterUncomment', 'uncomment-lines', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', 'v'], '<Plug>NERDCommenterInvertgv', 'toggle-visual-comment-lines', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', 's'], '<Plug>NERDCommenterSexy', 'comment-with-sexy-layout', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', 'Y'], '<Plug>NERDCommenterYank', 'yank-and-comment', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', '$'], '<Plug>NERDCommenterToEOL', 'comment-from-cursor-to-end-of-line', 0, 1)
 
   nnoremap <silent> <Plug>CommentToLine :call <SID>comment_to_line(0)<Cr>
   nnoremap <silent> <Plug>CommentToLineInvert :call <SID>comment_to_line(1)<Cr>
   nnoremap <silent> <Plug>CommentParagraphs :call <SID>comment_paragraphs(0)<Cr>
   nnoremap <silent> <Plug>CommentParagraphsInvert :call <SID>comment_paragraphs(1)<Cr>
-  call SpaceVim#mapping#space#def('nmap', ['c', 't'], '<Plug>CommentToLineInvert', 'toggle comment until the line', 0, 1)
-  call SpaceVim#mapping#space#def('nmap', ['c', 'T'], '<Plug>CommentToLine', 'comment until the line', 0, 1)
-  call SpaceVim#mapping#space#def('nmap', ['c', 'p'], '<Plug>CommentParagraphsInvert', 'toggle comment paragraphs', 0, 1)
-  call SpaceVim#mapping#space#def('nmap', ['c', 'P'], '<Plug>CommentParagraphs', 'comment paragraphs', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', 't'], '<Plug>CommentToLineInvert', 'toggle-comment-until-line', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', 'T'], '<Plug>CommentToLine', 'comment-until-the-line', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', 'p'], '<Plug>CommentParagraphsInvert', 'toggle-comment-paragraphs', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['c', 'P'], '<Plug>CommentParagraphs', 'comment-paragraphs', 0, 1)
 
   nnoremap <silent> <Plug>CommentOperator :set opfunc=<SID>commentOperator<Cr>g@
   let g:_spacevim_mappings_space[';'] = ['call feedkeys("\<Plug>CommentOperator")', 'comment-operator']

--- a/autoload/SpaceVim/layers/core.vim
+++ b/autoload/SpaceVim/layers/core.vim
@@ -141,7 +141,7 @@ function! SpaceVim#layers#core#config() abort
   let lnum = expand('<slnum>') + s:lnum - 1
   call SpaceVim#mapping#space#def('nnoremap', ['b', '.'], 'call call('
         \ . string(s:_function('s:buffer_transient_state')) . ', [])',
-        \ ['buffer transient state',
+        \ ['buffer-transient-state',
         \ [
         \ '[SPC b .] is to open the buffer transient state',
         \ '',
@@ -154,11 +154,11 @@ function! SpaceVim#layers#core#config() abort
         \ 'call SpaceVim#mapping#kill_visible_buffer_choosewin()',
         \ 'kill the buffer by selecting', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['b', '<C-d>'], 'call SpaceVim#mapping#clearBuffers()', 'kill-other-buffers', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['b', 'c'], 'call SpaceVim#mapping#clear_saved_buffers()', 'clear all saved buffers', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['b', 'c'], 'call SpaceVim#mapping#clear_saved_buffers()', 'clear-all-saved-buffers', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['b', 'e'], 'call call('
         \ . string(s:_function('s:safe_erase_buffer')) . ', [])',
         \ 'safe-erase-buffer', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['b', 'h'], 'Startify', 'home', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['b', 'h'], 'Startify', 'open-welcome-screen', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['b', 'm'], 'call call('
         \ . string(s:_function('s:open_message_buffer')) . ', [])',
         \ 'open-message-buffer', 1)
@@ -193,10 +193,10 @@ function! SpaceVim#layers#core#config() abort
 
   " file tree key bindings
   if g:spacevim_filemanager ==# 'vimfiler'
-    call SpaceVim#mapping#space#def('nnoremap', ['f', 't'], 'VimFiler | doautocmd WinEnter', 'toggle_file_tree', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['f', 'T'], 'VimFiler -no-toggle | doautocmd WinEnter', 'show_file_tree', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['f', 'o'], 'VimFiler -find', 'open_file_tree', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['b', 't'], 'VimFilerBufferDir -no-toggle', 'show_file_tree_at_buffer_dir', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['f', 't'], 'VimFiler | doautocmd WinEnter', 'toggle-file-tree', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['f', 'T'], 'VimFiler -no-toggle | doautocmd WinEnter', 'open-file-tree', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['f', 'o'], 'VimFiler -find', 'find-file-in-file-tree', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['b', 't'], 'VimFilerBufferDir -no-toggle', 'open-filetree-in-buffer-dir', 1)
   elseif g:spacevim_filemanager ==# 'nerdtree'
     call SpaceVim#mapping#space#def('nnoremap', ['f', 't'], 'NERDTreeToggle', 'toggle_file_tree', 1)
     call SpaceVim#mapping#space#def('nnoremap', ['f', 'T'], 'NERDTree', 'show_file_tree', 1)

--- a/autoload/SpaceVim/layers/core.vim
+++ b/autoload/SpaceVim/layers/core.vim
@@ -103,49 +103,49 @@ function! SpaceVim#layers#core#config() abort
   " @todo move this key binding to fuzzy layer
   call SpaceVim#mapping#space#def('nnoremap', ['h', 'm'], 'Unite manpage', 'search available man pages', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['h', 'k'], 'LeaderGuide "[KEYs]"', 'show-top-level-bindings', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['j', '0'], 'm`^', 'push-mark-and-goto-beginning-of-line', 0)
-  call SpaceVim#mapping#space#def('nnoremap', ['j', '$'], 'm`g_', 'push-mark-and-goto-end-of-line', 0)
+  call SpaceVim#mapping#space#def('nnoremap', ['j', '0'], 'm`^', 'jump-to-beginning-of-line', 0)
+  call SpaceVim#mapping#space#def('nnoremap', ['j', '$'], 'm`g_', 'jump-to-end-of-line', 0)
   call SpaceVim#mapping#space#def('nnoremap', ['j', 'b'], '<C-o>', 'jump-backward', 0)
   call SpaceVim#mapping#space#def('nnoremap', ['j', 'f'], '<C-i>', 'jump-forward', 0)
 
   " file tree key bindings
   call SpaceVim#mapping#space#def('nnoremap', ['j', 'd'], 'call call('
         \ . string(s:_function('s:explore_current_dir')) . ', [0])',
-        \ 'Explore current directory', 1)
+        \ 'explore-current-directory', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['j', 'D'], 'call call('
         \ . string(s:_function('s:explore_current_dir')) . ', [1])',
-        \ 'Explore current directory(other windows)', 1)
+        \ 'split-explore-current-directory', 1)
 
   " call SpaceVim#mapping#space#def('nmap', ['j', 'j'], '<Plug>(easymotion-overwin-f)', 'jump to a character', 0)
-  call SpaceVim#mapping#space#def('nmap', ['j', 'j'], '<Plug>(better-easymotion-overwin-f)', 'jump or select to a character', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['j', 'j'], '<Plug>(better-easymotion-overwin-f)', 'jump-or-select-to-a-character', 0, 1)
   nnoremap <silent> <Plug>(better-easymotion-overwin-f) :call <SID>better_easymotion_overwin_f(0)<Cr>
   xnoremap <silent> <Plug>(better-easymotion-overwin-f) :<C-U>call <SID>better_easymotion_overwin_f(1)<Cr>
-  call SpaceVim#mapping#space#def('nmap', ['j', 'J'], '<Plug>(easymotion-overwin-f2)', 'jump to a suite of two characters', 0)
-  call SpaceVim#mapping#space#def('nnoremap', ['j', 'k'], 'j==', 'go to next line and indent', 0)
+  call SpaceVim#mapping#space#def('nmap', ['j', 'J'], '<Plug>(easymotion-overwin-f2)', 'jump-to-suite-of-two-characters', 0)
+  call SpaceVim#mapping#space#def('nnoremap', ['j', 'k'], 'j==', 'goto-next-line-and-indent', 0)
   " call SpaceVim#mapping#space#def('nmap', ['j', 'l'], '<Plug>(easymotion-overwin-line)', 'jump to a line', 0)
-  call SpaceVim#mapping#space#def('nmap', ['j', 'l'], '<Plug>(better-easymotion-overwin-line)', 'jump or select to a line', 0, 1)
+  call SpaceVim#mapping#space#def('nmap', ['j', 'l'], '<Plug>(better-easymotion-overwin-line)', 'jump-or-select-to-a-line', 0, 1)
   nnoremap <silent> <Plug>(better-easymotion-overwin-line) :call <SID>better_easymotion_overwin_line(0)<Cr>
   xnoremap <silent> <Plug>(better-easymotion-overwin-line) :<C-U>call <SID>better_easymotion_overwin_line(1)<Cr>
-  call SpaceVim#mapping#space#def('nmap', ['j', 'v'], '<Plug>(easymotion-overwin-line)', 'jump to a line', 0)
-  call SpaceVim#mapping#space#def('nmap', ['j', 'w'], '<Plug>(easymotion-overwin-w)', 'jump to a word', 0)
-  call SpaceVim#mapping#space#def('nmap', ['j', 'q'], '<Plug>(easymotion-overwin-line)', 'jump to a line', 0)
+  call SpaceVim#mapping#space#def('nmap', ['j', 'v'], '<Plug>(easymotion-overwin-line)', 'jump-to-a-line', 0)
+  call SpaceVim#mapping#space#def('nmap', ['j', 'w'], '<Plug>(easymotion-overwin-w)', 'jump-to-a-word', 0)
+  call SpaceVim#mapping#space#def('nmap', ['j', 'q'], '<Plug>(easymotion-overwin-line)', 'jump-to-a-line', 0)
   call SpaceVim#mapping#space#def('nnoremap', ['j', 'n'], "i\<cr>\<esc>", 'sp-newline', 0)
   call SpaceVim#mapping#space#def('nnoremap', ['j', 'o'], "i\<cr>\<esc>k$", 'open-line', 0)
   call SpaceVim#mapping#space#def('nnoremap', ['j', 's'], 'call call('
         \ . string(s:_function('s:split_string')) . ', [0])',
-        \ 'split sexp', 1)
+        \ 'split-sexp', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['j', 'S'], 'call call('
         \ . string(s:_function('s:split_string')) . ', [1])',
         \ 'split-and-add-newline', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['w', 'r'], 'call call('
         \ . string(s:_function('s:next_window')) . ', [])',
-        \ 'rotate windows forward', 1)
+        \ 'rotate-windows-forward', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['w', 'R'], 'call call('
         \ . string(s:_function('s:previous_window')) . ', [])',
-        \ 'rotate windows backward', 1)
+        \ 'rotate-windows-backward', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['j', 'u'], 'call call('
         \ . string(s:_function('s:jump_to_url')) . ', [])',
-        \ 'jump to url', 1)
+        \ 'jump-to-url', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['<Tab>'], 'try | b# | catch | endtry', 'last-buffer', 1)
   let lnum = expand('<slnum>') + s:lnum - 1
   call SpaceVim#mapping#space#def('nnoremap', ['b', '.'], 'call call('
@@ -197,7 +197,7 @@ function! SpaceVim#layers#core#config() abort
   if s:SYS.isWindows
     call SpaceVim#mapping#space#def('nnoremap', ['f', 'd'], 'call call('
           \ . string(s:_function('s:ToggleWinDiskManager')) . ', [])',
-          \ 'toggle Windows disk manager', 1)
+          \ 'toggle-disk-manager', 1)
   endif
 
   " file tree key bindings
@@ -207,16 +207,16 @@ function! SpaceVim#layers#core#config() abort
     call SpaceVim#mapping#space#def('nnoremap', ['f', 'o'], 'VimFiler -find', 'find-file-in-file-tree', 1)
     call SpaceVim#mapping#space#def('nnoremap', ['b', 't'], 'VimFilerBufferDir -no-toggle', 'open-filetree-in-buffer-dir', 1)
   elseif g:spacevim_filemanager ==# 'nerdtree'
-    call SpaceVim#mapping#space#def('nnoremap', ['f', 't'], 'NERDTreeToggle', 'toggle_file_tree', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['f', 'T'], 'NERDTree', 'show_file_tree', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['f', 'o'], 'NERDTreeFind', 'open_file_tree', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['b', 't'], 'NERDTree %', 'show_file_tree_at_buffer_dir', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['f', 't'], 'NERDTreeToggle', 'toggle-file-tree', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['f', 'T'], 'NERDTree', 'show-file-tree', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['f', 'o'], 'NERDTreeFind', 'open-file-tree', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['b', 't'], 'NERDTree %', 'show-file-tree-at-buffer-dir', 1)
   elseif g:spacevim_filemanager ==# 'defx'
     " TODO: fix all these command
-    call SpaceVim#mapping#space#def('nnoremap', ['f', 't'], 'Defx', 'toggle_file_tree', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['f', 'T'], 'Defx -no-toggle', 'show_file_tree', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['f', 'o'], "Defx  -no-toggle -search=`expand('%:p')` `stridx(expand('%:p'), getcwd()) < 0? expand('%:p:h'): getcwd()`", 'open_file_tree', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['b', 't'], 'Defx -no-toggle', 'show_file_tree_at_buffer_dir', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['f', 't'], 'Defx', 'toggle-file-tree', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['f', 'T'], 'Defx -no-toggle', 'show-file-tree', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['f', 'o'], "Defx  -no-toggle -search=`expand('%:p')` `stridx(expand('%:p'), getcwd()) < 0? expand('%:p:h'): getcwd()`", 'open-file-tree', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['b', 't'], 'Defx -no-toggle', 'show-file-tree-at-buffer-dir', 1)
   endif
   call SpaceVim#mapping#space#def('nnoremap', ['f', 'y'], 'call SpaceVim#util#CopyToClipboard()', 'show-and-copy-buffer-filename', 1)
   let g:_spacevim_mappings_space.f.v = {'name' : '+Vim(SpaceVim)'}
@@ -234,7 +234,7 @@ function! SpaceVim#layers#core#config() abort
   let lnum = expand('<slnum>') + s:lnum - 1
   call SpaceVim#mapping#space#def('nnoremap', ['n', '-'], 'call call('
         \ . string(s:_function('s:number_transient_state')) . ', ["-"])',
-        \ ['Decrease number under cursor',
+        \ ['decrease-number-under-cursor',
         \ [
         \ '[SPC n -] is to decrease the number under the cursor, and open',
         \ 'the number translate state buffer',
@@ -246,7 +246,7 @@ function! SpaceVim#layers#core#config() abort
   let lnum = expand('<slnum>') + s:lnum - 1
   call SpaceVim#mapping#space#def('nnoremap', ['n', '+'], 'call call('
         \ . string(s:_function('s:number_transient_state')) . ', ["+"])',
-        \ ['Increase number under cursor',
+        \ ['increase-number-under-cursor',
         \ [
         \ '[SPC n +] is to increase the number under the cursor, and open',
         \ 'the number translate state buffer',

--- a/autoload/SpaceVim/layers/core.vim
+++ b/autoload/SpaceVim/layers/core.vim
@@ -14,8 +14,16 @@ function! SpaceVim#layers#core#plugins() abort
     call add(plugins, ['scrooloose/nerdtree', { 'merged' : 0,
           \ 'loadconf' : 1}])
   elseif g:spacevim_filemanager ==# 'vimfiler'
-    call add(plugins, ['Shougo/vimfiler.vim',{'merged' : 0, 'loadconf' : 1 , 'loadconf_before' : 1, 'on_cmd' : ['VimFiler', 'VimFilerBufferDir']}])
-    call add(plugins, ['Shougo/unite.vim',{ 'merged' : 0 , 'loadconf' : 1}])
+    call add(plugins, ['Shougo/vimfiler.vim',{
+          \ 'merged' : 0,
+          \ 'loadconf' : 1 ,
+          \ 'loadconf_before' : 1,
+          \ 'on_cmd' : ['VimFiler', 'VimFilerBufferDir']
+          \ }])
+    call add(plugins, ['Shougo/unite.vim',{
+          \ 'merged' : 0,
+          \ 'loadconf' : 1
+          \ }])
     call add(plugins, ['Shougo/vimproc.vim', {'build' : [(executable('gmake') ? 'gmake' : 'make')]}])
   elseif g:spacevim_filemanager ==# 'defx'
     call add(plugins, ['Shougo/defx.nvim',{'merged' : 0, 'loadconf' : 1 , 'loadconf_before' : 1}])
@@ -86,18 +94,19 @@ function! SpaceVim#layers#core#config() abort
   " Select last paste
   nnoremap <silent><expr> gp '`['.strpart(getregtype(), 0, 1).'`]'
 
-  call SpaceVim#mapping#space#def('nnoremap', ['f', 's'], 'write', 'save buffer', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['f', 'S'], 'wall', 'save all buffer', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['f', 's'], 'write', 'save-current-file', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['f', 'S'], 'wall', 'save-all-files', 1)
   " help mappings
-  call SpaceVim#mapping#space#def('nnoremap', ['h', 'I'], 'call SpaceVim#issue#report()', 'Report an issue of SpaceVim', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['h', 'l'], 'SPLayer -l', 'lists all the layers available in SpaceVim', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['h', 'L'], 'SPRuntimeLog', 'view SpaceVim runtime log', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['h', 'I'], 'call SpaceVim#issue#report()', 'report-issue-or-bug', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['h', 'l'], 'SPLayer -l', 'list-all-layers', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['h', 'L'], 'SPRuntimeLog', 'view-runtime-log', 1)
+  " @todo move this key binding to fuzzy layer
   call SpaceVim#mapping#space#def('nnoremap', ['h', 'm'], 'Unite manpage', 'search available man pages', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['h', 'k'], 'LeaderGuide "[KEYs]"', 'show top-level bindings with mapping guide', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['j', '0'], 'm`^', 'push mark and goto beginning of line', 0)
-  call SpaceVim#mapping#space#def('nnoremap', ['j', '$'], 'm`g_', 'push mark and goto end of line', 0)
-  call SpaceVim#mapping#space#def('nnoremap', ['j', 'b'], '<C-o>', 'jump backward', 0)
-  call SpaceVim#mapping#space#def('nnoremap', ['j', 'f'], '<C-i>', 'jump forward', 0)
+  call SpaceVim#mapping#space#def('nnoremap', ['h', 'k'], 'LeaderGuide "[KEYs]"', 'show-top-level-bindings', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['j', '0'], 'm`^', 'push-mark-and-goto-beginning-of-line', 0)
+  call SpaceVim#mapping#space#def('nnoremap', ['j', '$'], 'm`g_', 'push-mark-and-goto-end-of-line', 0)
+  call SpaceVim#mapping#space#def('nnoremap', ['j', 'b'], '<C-o>', 'jump-backward', 0)
+  call SpaceVim#mapping#space#def('nnoremap', ['j', 'f'], '<C-i>', 'jump-forward', 0)
 
   " file tree key bindings
   call SpaceVim#mapping#space#def('nnoremap', ['j', 'd'], 'call call('

--- a/autoload/SpaceVim/layers/core.vim
+++ b/autoload/SpaceVim/layers/core.vim
@@ -149,10 +149,10 @@ function! SpaceVim#layers#core#config() abort
         \ ]
         \ ]
         \ , 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['b', 'd'], 'call SpaceVim#mapping#close_current_buffer()', 'kill this buffer', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['b', 'd'], 'call SpaceVim#mapping#close_current_buffer()', 'delete-this-buffer', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['b', 'D'],
         \ 'call SpaceVim#mapping#kill_visible_buffer_choosewin()',
-        \ 'kill the buffer by selecting', 1)
+        \ 'delete-the-selected-buffer', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['b', '<C-d>'], 'call SpaceVim#mapping#clearBuffers()', 'kill-other-buffers', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['b', 'c'], 'call SpaceVim#mapping#clear_saved_buffers()', 'clear-all-saved-buffers', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['b', 'e'], 'call call('

--- a/autoload/SpaceVim/layers/core.vim
+++ b/autoload/SpaceVim/layers/core.vim
@@ -153,7 +153,7 @@ function! SpaceVim#layers#core#config() abort
   call SpaceVim#mapping#space#def('nnoremap', ['b', 'D'],
         \ 'call SpaceVim#mapping#kill_visible_buffer_choosewin()',
         \ 'delete-the-selected-buffer', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['b', '<C-d>'], 'call SpaceVim#mapping#clearBuffers()', 'kill-other-buffers', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['b', '<C-d>'], 'call SpaceVim#mapping#clear_buffers()', 'kill-other-buffers', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['b', 'c'], 'call SpaceVim#mapping#clear_saved_buffers()', 'clear-all-saved-buffers', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['b', 'e'], 'call call('
         \ . string(s:_function('s:safe_erase_buffer')) . ', [])',

--- a/autoload/SpaceVim/layers/ctrlp.vim
+++ b/autoload/SpaceVim/layers/ctrlp.vim
@@ -29,7 +29,7 @@ function! SpaceVim#layers#ctrlp#config() abort
   let lnum = expand('<slnum>') + s:lnum - 1
   call SpaceVim#mapping#space#def('nnoremap', ['?'], 'call call('
         \ . string(s:_function('s:get_menu')) . ', ["CustomKeyMaps", "[SPC]"])',
-        \ ['show mappings',
+        \ ['show-mappings',
         \ [
         \ 'SPC ? is to show mappings',
         \ '',
@@ -54,7 +54,7 @@ function! SpaceVim#layers#ctrlp#config() abort
 
   let lnum = expand('<slnum>') + s:lnum - 1
   call SpaceVim#mapping#space#def('nnoremap', ['b', 'b'], 'CtrlPBuffer',
-        \ ['buffer-list',
+        \ ['list-buffer',
         \ [
         \ 'SPC b b is to open buffer list',
         \ '',
@@ -76,7 +76,7 @@ function! SpaceVim#layers#ctrlp#config() abort
 
   let lnum = expand('<slnum>') + s:lnum - 1
   call SpaceVim#mapping#space#def('nnoremap', ['j', 'i'], 'CtrlPBufTag',
-        \ ['jump to a definition in buffer',
+        \ ['jump-to-definition-in-buffer',
         \ [
         \ 'SPC j i is to jump to a definition in buffer',
         \ '',
@@ -91,7 +91,7 @@ function! SpaceVim#layers#ctrlp#config() abort
   "@fixme ctrlp colorschemes support
   let lnum = expand('<slnum>') + s:lnum - 1
   call SpaceVim#mapping#space#def('nnoremap', ['T', 's'], 'CtrlPColorscheme',
-        \ ['fuzzy find colorschemes',
+        \ ['fuzzy-find-colorschemes',
         \ [
         \ 'SPC T s is to fuzzy find colorschemes',
         \ '',
@@ -103,7 +103,7 @@ function! SpaceVim#layers#ctrlp#config() abort
   let lnum = expand('<slnum>') + s:lnum - 1
   call SpaceVim#mapping#space#def('nnoremap', ['f', 'f'],
         \ "exe 'CtrlP ' . fnamemodify(bufname('%'), ':h')",
-        \ ['Find files in the directory of the current buffer',
+        \ ['find-files-in-buffer-directory',
         \ [
         \ '[SPC f f] is to find files in the directory of the current buffer',
         \ '',
@@ -115,7 +115,7 @@ function! SpaceVim#layers#ctrlp#config() abort
   let lnum = expand('<slnum>') + s:lnum - 1
   call SpaceVim#mapping#space#def('nnoremap', ['p', 'f'],
         \ 'CtrlP',
-        \ ['find files in current project',
+        \ ['find-files-in-project',
         \ [
         \ '[SPC p f] is to find files in the root of the current project',
         \ '',
@@ -130,7 +130,7 @@ function! SpaceVim#layers#ctrlp#config() abort
   let lnum = expand('<slnum>') + s:lnum - 1
   call SpaceVim#mapping#space#def('nnoremap', ['h', 'i'], 'call call('
         \ . string(s:_function('s:get_help_with_cursor_symbol')) . ', [])',
-        \ ['get help with the symbol at point',
+        \ ['get-help-for-cursor-symbol',
         \ [
         \ '[SPC h i] is to get help with the symbol at point',
         \ '',

--- a/autoload/SpaceVim/layers/debug.vim
+++ b/autoload/SpaceVim/layers/debug.vim
@@ -18,21 +18,21 @@ function! SpaceVim#layers#debug#plugins() abort
 endfunction
 
 function! SpaceVim#layers#debug#config() abort
-  call SpaceVim#mapping#space#def('nnoremap', ['d', 'l'], 'call SpaceVim#layers#debug#launching(&ft)', 'launching debugger', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['d', 'b'], 'VBGtoggleBreakpointThisLine', 'Toggle a breakpoint for the current line', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['d', 'B'], 'VBGclearBreakpoints', 'Clear all breakpoints', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['d', 'c'], 'VBGcontinue', 'Continue the execution', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['d', 'o'], 'VBGstepOver', 'step over', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['d', 'i'], 'VBGstepIn', 'step into functions', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['d', 'O'], 'VBGstepOut', 'step out of current function', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['d', 'k'], 'VBGkill', 'Terminates the debugger', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'l'], 'call SpaceVim#layers#debug#launching(&ft)', 'launching-debugger', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'b'], 'VBGtoggleBreakpointThisLine', 'toggle-line-breakpoint', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'B'], 'VBGclearBreakpoints', 'clear-all-breakpoints', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'c'], 'VBGcontinue', 'continue-the-execution', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'o'], 'VBGstepOver', 'step-over', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'i'], 'VBGstepIn', 'step-into-functions', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'O'], 'VBGstepOut', 'step-out-of-current-function', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'k'], 'VBGkill', 'terminates-the-debugger', 1)
   let g:_spacevim_mappings_space.d.e = {'name' : '+Evaluate/Execute'}
-  call SpaceVim#mapping#space#def('vnoremap', ['d', 'e', 's'], 'VBGevalSelectedText', 'Evaluate and print the selected text', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['d', 'e', 'e'], 'VBGevalWordUnderCursor', 'Evaluate the <cword> under the cursor', 1)
-  call SpaceVim#mapping#space#def('vnoremap', ['d', 'e', 'S'], 'VBGexecuteSelectedText', 'Execute the selected text', 1)
+  call SpaceVim#mapping#space#def('vnoremap', ['d', 'e', 's'], 'VBGevalSelectedText', 'evaluate-selected-text', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['d', 'e', 'e'], 'VBGevalWordUnderCursor', 'evaluate-cursor-symbol', 1)
+  call SpaceVim#mapping#space#def('vnoremap', ['d', 'e', 'S'], 'VBGexecuteSelectedText', 'execute-selected-text', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['d', '.'], 'call call('
         \ . string(s:_function('s:debug_transient_state')) . ', [])',
-        \ 'debug transient state', 1)
+        \ 'debug-transient-state', 1)
   let g:vebugger_breakpoint_text = '->'
   let g:vebugger_currentline_text = '++'
 endfunction

--- a/autoload/SpaceVim/layers/denite.vim
+++ b/autoload/SpaceVim/layers/denite.vim
@@ -28,7 +28,7 @@ function! SpaceVim#layers#denite#config() abort
   let lnum = expand('<slnum>') + s:lnum - 1
   call SpaceVim#mapping#space#def('nnoremap', ['?'], 'call call('
         \ . string(s:_function('s:warp_denite')) . ', ["Denite menu:CustomKeyMaps -input=[SPC]"])',
-        \ ['show mappings',
+        \ ['show-mappings',
         \ [
         \ 'SPC ? is to show mappings',
         \ '',

--- a/autoload/SpaceVim/layers/git.vim
+++ b/autoload/SpaceVim/layers/git.vim
@@ -43,32 +43,32 @@ function! SpaceVim#layers#git#config() abort
   let g:signify_vcs_list = ['hg']
   let g:_spacevim_mappings_space.g = get(g:_spacevim_mappings_space, 'g',  {'name' : '+VersionControl/git'})
   if s:git_plugin ==# 'gina'
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 's'], 'Gina status --opener=10split', 'git status', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'S'], 'Gina add %', 'stage current file', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'U'], 'Gina reset -q %', 'unstage current file', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'c'], 'Gina commit', 'edit git commit', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'p'], 'Gina push', 'git push', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'd'], 'Gina diff', 'view git diff', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'A'], 'Gina add .', 'stage all files', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'b'], 'Gina blame', 'view git blame', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 's'], 'Gina status --opener=10split', 'git-status', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'S'], 'Gina add %', 'stage-current-file', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'U'], 'Gina reset -q %', 'unstage-current-file', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'c'], 'Gina commit', 'edit-git-commit', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'p'], 'Gina push', 'git-push', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'd'], 'Gina diff', 'view-git-diff', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'A'], 'Gina add .', 'stage-all-files', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'b'], 'Gina blame', 'view-git-blame', 1)
   elseif s:git_plugin ==# 'fugitive'
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 's'], 'Gstatus', 'git status', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'S'], 'Git add %', 'stage current file', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'U'], 'Git reset -q %', 'unstage current file', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'c'], 'Git commit', 'edit git commit', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'p'], 'Gpush', 'git push', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'd'], 'Gdiff', 'view git diff', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'A'], 'Git add .', 'stage all files', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'b'], 'Gblame', 'view git blame', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 's'], 'Gstatus', 'git-status', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'S'], 'Git add %', 'stage-current-file', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'U'], 'Git reset -q %', 'unstage-current-file', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'c'], 'Git commit', 'edit-git-commit', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'p'], 'Gpush', 'git-push', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'd'], 'Gdiff', 'view-git-diff', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'A'], 'Git add .', 'stage-all-files', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'b'], 'Gblame', 'view-git-blame', 1)
   else
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 's'], 'Gita status', 'git status', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'S'], 'Gita add %', 'stage current file', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'U'], 'Gita reset %', 'unstage current file', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'c'], 'Gita commit', 'edit git commit', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'p'], 'Gita push', 'git push', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'd'], 'Gita diff', 'view git diff', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'A'], 'Gita add .', 'stage all files', 1)
-    call SpaceVim#mapping#space#def('nnoremap', ['g', 'b'], 'Gina blame', 'view git blame', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 's'], 'Gita status', 'git-status', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'S'], 'Gita add %', 'stage-current-file', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'U'], 'Gita reset %', 'unstage-current-file', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'c'], 'Gita commit', 'edit-git-commit', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'p'], 'Gita push', 'git-push', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'd'], 'Gita diff', 'view-git-diff', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'A'], 'Gita add .', 'stage-all-files', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['g', 'b'], 'Gina blame', 'view-git-blame', 1)
   endif
   augroup spacevim_layer_git
     autocmd!
@@ -82,12 +82,12 @@ function! SpaceVim#layers#git#config() abort
   call SpaceVim#mapping#space#def('nnoremap', ['g', 'M'], 'call call('
         \ . string(function('s:display_last_commit_of_current_line')) . ', [])',
         \ 'commit-message-of-current-line', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['g', 'V'], 'GV!', 'View git log of current file', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['g', 'v'], 'GV', 'View git log of current repo', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['g', 'V'], 'GV!', 'git-log-of-current-file', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['g', 'v'], 'GV', 'git-log-of-current-repo', 1)
   let g:_spacevim_mappings_space.g.h = {'name' : '+Hunks'}
-  call SpaceVim#mapping#space#def('nmap', ['g', 'h', 'a'], '<Plug>GitGutterStageHunk', 'stage current hunk', 0)
-  call SpaceVim#mapping#space#def('nmap', ['g', 'h', 'r'], '<Plug>GitGutterUndoHunk', 'undo cursor hunk', 0)
-  call SpaceVim#mapping#space#def('nmap', ['g', 'h', 'v'], '<Plug>GitGutterPreviewHunk', 'preview cursor hunk', 0)
+  call SpaceVim#mapping#space#def('nmap', ['g', 'h', 'a'], '<Plug>GitGutterStageHunk', 'stage-current-hunk', 0)
+  call SpaceVim#mapping#space#def('nmap', ['g', 'h', 'r'], '<Plug>GitGutterUndoHunk', 'undo-cursor-hunk', 0)
+  call SpaceVim#mapping#space#def('nmap', ['g', 'h', 'v'], '<Plug>GitGutterPreviewHunk', 'preview-cursor-hunk', 0)
 endfunction
 
 function! SpaceVim#layers#git#set_variable(var) abort

--- a/autoload/SpaceVim/layers/git.vim
+++ b/autoload/SpaceVim/layers/git.vim
@@ -81,7 +81,7 @@ function! SpaceVim#layers#git#config() abort
   augroup END
   call SpaceVim#mapping#space#def('nnoremap', ['g', 'M'], 'call call('
         \ . string(function('s:display_last_commit_of_current_line')) . ', [])',
-        \ 'display the last commit message of the current line', 1)
+        \ 'commit-message-of-current-line', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['g', 'V'], 'GV!', 'View git log of current file', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['g', 'v'], 'GV', 'View git log of current repo', 1)
   let g:_spacevim_mappings_space.g.h = {'name' : '+Hunks'}

--- a/autoload/SpaceVim/layers/lang/ruby.vim
+++ b/autoload/SpaceVim/layers/lang/ruby.vim
@@ -29,8 +29,15 @@ function! SpaceVim#layers#lang#ruby#config() abort
   endif
 endfunction
 
+let s:ruby_file_head = [
+      \ '#!/usr/bin/ruby -w',
+      \ '# -*- coding : utf-8 -*-',
+      \ ''
+      \ ]
+
 function! SpaceVim#layers#lang#ruby#set_variable(var) abort
   let s:ruby_repl_command = get(a:var, 'repl_command', '') 
+  let s:ruby_file_head = get(a:var, 'ruby-file-head', s:ruby_file_head)
 endfunction
 
 function! s:language_specified_mappings() abort
@@ -69,4 +76,11 @@ function! s:go_to_def() abort
   else
     call SpaceVim#lsp#go_to_def()
   endif
+endfunction
+
+function! SpaceVim#layers#lang#ruby#get_options() abort
+  return [
+        \ 'repl_command',
+        \ 'ruby-file-head'
+        \ ]
 endfunction

--- a/autoload/SpaceVim/layers/lang/vim.vim
+++ b/autoload/SpaceVim/layers/lang/vim.vim
@@ -54,9 +54,8 @@ endfunction
 function! s:eval_cursor() abort
   let is_keyword = &iskeyword
   set iskeyword+=:
-  set iskeyword+=(
   let cword = expand('<cword>')
-  if cword =~# '^g:'
+  if exists(cword)
     echo  cword . ' is ' eval(cword)
     " if is script function
   elseif cword =~# '^s:' && cword =~# '('

--- a/autoload/SpaceVim/layers/shell.vim
+++ b/autoload/SpaceVim/layers/shell.vim
@@ -38,7 +38,7 @@ let s:lnum = expand('<slnum>') + 2
 function! SpaceVim#layers#shell#config() abort
   call SpaceVim#mapping#space#def('nnoremap', ["'"], 'call call('
         \ . string(function('s:open_default_shell')) . ', [0])',
-        \ ['open shell',
+        \ ['open-shell',
         \ [
         \ "[SPC '] is to open or jump to default shell window",
         \ '',
@@ -47,7 +47,7 @@ function! SpaceVim#layers#shell#config() abort
         \ ], 1)
   call SpaceVim#mapping#space#def('nnoremap', ["\""], 'call call('
         \ . string(function('s:open_default_shell')) . ', [1])',
-        \ ["open shell in current file's path",
+        \ ["open-shell-in-buffer-dir",
         \ [
         \ "[SPC \"] is to open or jump to default shell window with the current file's pwd",
         \ '',

--- a/autoload/SpaceVim/layers/tools.vim
+++ b/autoload/SpaceVim/layers/tools.vim
@@ -41,14 +41,14 @@ endfunction
 
 function! SpaceVim#layers#tools#config() abort
   let g:better_whitespace_filetypes_blacklist = ['diff', 'gitcommit', 'unite', 'qf', 'help', 'markdown', 'leaderGuide']
-  call SpaceVim#mapping#space#def('nnoremap', ['a', 'l'], 'Calendar', 'vim calendar', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['a', 'l'], 'Calendar', 'vim-calendar', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['e', 'a'], 'FencAutoDetect',
-        \ 'Auto detect the file encoding', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['a', 'c'], 'Calc', 'vim calculator', 1)
+        \ 'auto-detect-file-encoding', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['a', 'c'], 'Calc', 'vim-calculator', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['w', 'c'],
         \ 'Goyo', 'centered-buffer-mode', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['w', 'C'],
-        \ 'ChooseWin | Goyo', 'centered-buffer-mode(other windows)', 1)
+        \ 'ChooseWin | Goyo', 'choose-window-centered-buffer-mode', 1)
 
   " bootmark key binding
   nnoremap <silent> mm :<C-u>BookmarkToggle<Cr>

--- a/autoload/SpaceVim/layers/ui.vim
+++ b/autoload/SpaceVim/layers/ui.vim
@@ -52,7 +52,7 @@ function! SpaceVim#layers#ui#config() abort
 
   if !empty(g:spacevim_windows_smartclose)
     call SpaceVim#mapping#def('nnoremap <silent>', g:spacevim_windows_smartclose, ':<C-u>call SpaceVim#mapping#SmartClose()<cr>',
-          \ 'Smart close windows',
+          \ 'smart-close-windows',
           \ 'call SpaceVim#mapping#SmartClose()')
   endif
   " Ui toggles
@@ -66,29 +66,29 @@ function! SpaceVim#layers#ui#config() abort
         \ . string(s:_function('s:toggle_conceallevel')) . ', [])',
         \ 'toggle conceallevel', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['t', 't'], 'call SpaceVim#plugins#tabmanager#open()',
-        \ 'Open tabs manager', 1)
+        \ 'open-tabs-manager', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['t', 'f'], 'call call('
         \ . string(s:_function('s:toggle_colorcolumn')) . ', [])',
         \ 'fill-column-indicator', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['t', 'h', 'h'], 'call call('
         \ . string(s:_function('s:toggle_cursorline')) . ', [])',
-        \ ['toggle highlight of the current line',
+        \ ['toggle-highlight-current-line',
         \ [
         \ 'SPC t h h is to toggle the highlighting of cursorline'
         \ ]
         \ ], 1)
   call SpaceVim#mapping#space#def('nnoremap', ['t', 'h', 'i'], 'call call('
         \ . string(s:_function('s:toggle_indentline')) . ', [])',
-        \ ['toggle highlight indentation levels',
+        \ ['toggle-highlight-indentation-levels',
         \ [
         \ 'SPC t h i is to running :IndentLinesToggle which is definded in indentLine'
         \ ]
         \ ], 1)
   call SpaceVim#mapping#space#def('nnoremap', ['t', 'h', 'c'], 'set cursorcolumn!',
-        \ 'toggle highlight indentation current column', 1)
+        \ 'toggle-highlight-current-column', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['t', 'h', 's'], 'call call('
         \ . string(s:_function('s:toggle_syntax_hi')) . ', [])',
-        \ 'toggle syntax highlighting', 1)
+        \ 'toggle-syntax-highlighting', 1)
 
   call SpaceVim#mapping#space#def('nnoremap', ['T', 'F'], '<F11>',
         \ 'fullscreen-frame', 0)
@@ -106,14 +106,14 @@ function! SpaceVim#layers#ui#config() abort
         \ 'display ~ in the fringe on empty lines', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['t', 'S'], 'call call('
         \ . string(s:_function('s:toggle_spell_check')) . ', [])',
-        \ 'toggle spell checker', 1)
+        \ 'toggle-spell-checker', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['t', 'l'], 'setlocal list!',
-        \ 'toggle hidden listchars', 1)
+        \ 'toggle-hidden-listchars', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['t', 'W'], 'setlocal wrap!',
-        \ 'toggle wrap line', 1)
+        \ 'toggle-wrap-line', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['t', 'w'], 'call call('
         \ . string(s:_function('s:toggle_whitespace')) . ', [])',
-        \ 'toggle highlight tail spaces', 1)
+        \ 'toggle-highlight-tail-spaces', 1)
 
   " download gvimfullscreen.dll from github, copy gvimfullscreen.dll to
   " the directory that has gvim.exe

--- a/autoload/SpaceVim/mapping.vim
+++ b/autoload/SpaceVim/mapping.vim
@@ -113,7 +113,7 @@ function! SpaceVim#mapping#gd() abort
   endif
 endfunction
 
-function! SpaceVim#mapping#clearBuffers() abort
+function! SpaceVim#mapping#clear_buffers() abort
   if confirm('Kill all other buffers?', "&Yes\n&No\n&Cancel") == 1
     let blisted = filter(range(1, bufnr('$')), 'buflisted(v:val)')
     for i in blisted

--- a/autoload/SpaceVim/mapping/leader.vim
+++ b/autoload/SpaceVim/mapping/leader.vim
@@ -125,9 +125,9 @@ function! SpaceVim#mapping#leader#defindWindowsLeader(key) abort
           \ ]
           \ ]
     nnoremap <silent> [Window]c
-          \ :<C-u>call SpaceVim#mapping#clearBuffers()<CR>
+          \ :<C-u>call SpaceVim#mapping#clear_buffers()<CR>
     let lnum = expand('<slnum>') + s:lnum - 4
-    let g:_spacevim_mappings_windows.c = ['call SpaceVim#mapping#clearBuffers()',
+    let g:_spacevim_mappings_windows.c = ['call SpaceVim#mapping#clear_buffers()',
           \ 'Clear all the buffers',
           \ [
           \ '[WIN c] is to clear all the buffers',

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -44,7 +44,7 @@ function! SpaceVim#mapping#space#init() abort
   for i in range(1, 9)
     exe "call SpaceVim#mapping#space#def('nnoremap', ["
           \ . i . "], 'call SpaceVim#layers#core#statusline#jump("
-          \ . i . ")', 'window " . i . "', 1)"
+          \ . i . ")', 'window-" . i . "', 1)"
   endfor
   let g:_spacevim_mappings_space.w['<Tab>'] = ['wincmd w', 'alternate-window']
   nnoremap <silent> [SPC]w<tab> :wincmd w<cr>
@@ -208,7 +208,7 @@ function! SpaceVim#mapping#space#init() abort
         \ , 1)
   let s:lnum = expand('<slnum>') + s:funcbeginline
   call SpaceVim#mapping#space#def('nnoremap', ['w', 'o'], 'tabnext',
-        \ ['other tabs',
+        \ ['other-tabs',
         \ [
         \ '[SPC w o] is to switch to next tabs',
         \ '',
@@ -320,7 +320,7 @@ function! SpaceVim#mapping#space#init() abort
         \ , 1)
 
   let g:_spacevim_mappings_space.e = {'name' : '+Errors/Encoding'}
-  let g:_spacevim_mappings_space.B = {'name' : '+Global-buffers'}
+  let g:_spacevim_mappings_space.B = {'name' : '+Global buffers'}
   if g:spacevim_relativenumber
     nnoremap <silent> [SPC]tn  :<C-u>setlocal nonumber! norelativenumber!<CR>
     let g:_spacevim_mappings_space.t.n = ['setlocal nonumber! norelativenumber!', 'toggle line number']

--- a/docs/cn/conventions.md
+++ b/docs/cn/conventions.md
@@ -1,10 +1,10 @@
 ---
-title: "约定"
+title: "基本约定"
 description: "描述贡献代码所需遵循的约定俗成的规范，包括 Vim 脚本的代码规范以及 MarkDown 文件的代码规范。"
 lang: cn
 ---
 
-# Conventions
+# 基本约定
 
 <!-- vim-markdown-toc GFM -->
 
@@ -89,7 +89,7 @@ Vim 具有高度可定制性。用户可以更改很多的默认设置，包括�
 这意味着 `g` 标志取决于上层中 gdefault 的设置。如果你用了 `:substitute` 你必须要保存 gdefault,
 把它设置为 0 或 1，预先生成替换并且在操作完成后还原它。
 
-有很多内置的函数可以代替Vim 命令在影响更小的情况下完成同样的事情。
+有很多内置的函数可以代替 Vim 命令在影响更小的情况下完成同样的事情。
 查看 `:help functions` 查看内置的函数表。
 
 #### 脆弱命令
@@ -268,35 +268,30 @@ autocommand BufEnter <buffer>
 
 #### 命名
 
-- 保持简单易于理解
+在 SpaceVim 中，函数、变量以及各自提示的命名应当保持简单易于理解，应遵循以下基本命名规范：
 
-- 总的来说，使用
-    - 像这样的插件名 `plugin-names-like-this`
-    - 像这样的函数名 `FunctionNamesLikeThis`
-    - 像这样的命令名 `CommandNamesLikeThis`
-    - 像这样的参数组 `augroup_names_like_this`
-    - 像这样的变量名 `variable_names_like_this`
-    - 像这样的提示 `hints-like-this`
-
-- 不要编写(create)全局函数，用自动运行函数(autoloaded functions)来替代全局函数。
+- 像这样的函数名 `FunctionNamesLikeThis`
+- 像这样的命令名 `CommandNamesLikeThis`
+- 像这样的参数组 `augroup_names_like_this`
+- 像这样的变量名 `variable_names_like_this`
+- 像这样的提示 `hints-like-this`
+- 全局及模块选项 `option_name`
+- 不要定义全局函数，而使用自动运行函数来替代全局函数。
 - 通用命令优先于一般的前缀
-- 参数组(augroup)名字像变量一样命名。(Augroup names count as variables for naming purposes.)
-- 所有的变量据需要加上它们的范围前缀。
-    - 全局变量的前缀为`g:`
-    - 本地脚本变量的前缀为`s:`
-    - 函数的参数前缀为`a:`
-    - 本地函数的变量前缀为`l:`
-    - Vim 预定义(Vim-predefinded)变量前缀为`v:`
-    - 本地缓冲区(Buffer-local)变量的前缀为`b:`
-    - `g:`,`s:`,和`a:`前缀必须使用
-    - `b:`当你想要改变本地缓冲区(buffer-local)的变量的语义时前缀为`b:`
-    - `l:`and`v:`should be used for consistency, future proofing, and to avoid subtle bugs. They are not strictly required. Add them in new code but don’t go out of your way to add them elsewhere.
-    - 自动运行函数(autoloaded functions)可以没有范围前缀。
+- 自动命令组名像变量一样命名。
+- 全局变量的前缀为`g:`
+- 本地脚本变量的前缀为`s:`
+- 函数的参数前缀为`a:`
+- 本地函数的变量前缀为`l:`
+- Vim 预定义变量前缀为`v:`
+- 本地缓冲区变量的前缀为`b:`
+- `g:`,`s:`,和`a:`前缀必须使用
+- `b:`当你想要改变本地缓冲区的变量的语义时前缀为`b:`
 
 ## 按键表示
 
 - 使用首字母大写的单词和尖括号来表示按键：`<Down>`, `<Up>`。
-- 使用大写字母来表示custom leader：`SPC`, `WIN`, `UNITE`, `DENITE`。
+- 使用大写字母来表示 custom leader：`SPC`, `WIN`, `UNITE`, `DENITE`。
 - 使用空格来分隔按键序列：`SPC t w`, `<Leader> f o`.
 - 使用`/` 来分隔多个可选的按键序列：`<Tab>` / `<C-n>`.
 - 在文档中使用`Ctrl-e`而不是`<C-e>`。
@@ -310,4 +305,3 @@ autocommand BufEnter <buffer>
 ## Markdown 代码规范
 
 - [Google's Markdown style guide](https://github.com/google/styleguide/blob/3591b2e540cbcb07423e02d20eee482165776603/docguide/style.md)
-

--- a/docs/development.md
+++ b/docs/development.md
@@ -249,6 +249,17 @@ function! SpaceVim#layers#foo#config() abort
   let g:foo_option3 = get(g:, 'foo_option3', 3)
   " ...
 endfunction
+
+" add layer options:
+let s:layer_option = 'default var'
+function! SpaceVim#layers#foo#set_variable(var) abort
+  let s:layer_option = get(a:var, 'layer_option', s:layer_option)
+endfunction
+
+" completion function for layer options:
+function! SpaceVim#layers#foo#get_options() abort
+    return ['layer_option']
+endfunction
 ```
 
 4. Add layer document `docs/layers/foo.md` for `foo` layer.


### PR DESCRIPTION
Hi everyone, this PR is about the naming rules in SpaceVim, including:

1. global option naming rules

This is used in toml file, such as:

```toml
[options]
    default_indent = 4
    enable_debug = 1
    enable_ale = 0
```

2. layer option naming rules:


```toml
[[layers]]
    name = 'autocomplete'
    auto_completion_delay = 10
    auto_completion_return_key_behavior = "smart"
    auto_completion_tab_key_behavior = "smart"
```

3. autoload function name

```vim
SpaceVim#layers#import()
SpaceVim#mapping#clearBuffers()
```

4. local function

```vim
s:toggle_windows()
```

5. API name

```
job
system
transient_state
data#string
```


ref:

- twitter vote: https://twitter.com/SpaceVim/status/1170354969892929537?s=20