### PR TITLE
Fixed output error where open file by flyGrep

### DIFF
--- a/autoload/SpaceVim/plugins/flygrep.vim
+++ b/autoload/SpaceVim/plugins/flygrep.vim
@@ -51,6 +51,9 @@ function! s:update_history() abort
     call remove(s:grep_history, index(s:grep_history, s:grep_expr))
   endif
   call add(s:grep_history, s:grep_expr)
+  if !isdirectory(expand('~/.cache/SpaceVim'))
+      call mkdir(expand('~/.cache/SpaceVim'))
+  endif
   call writefile([s:JSON.json_encode(s:grep_history)], expand('~/.cache/SpaceVim/flygrep_history'))
 endfunction
 let s:grep_history = s:read_histroy()


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [√ ] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [ √] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [ √] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

To vim's users(not SpaceVim's users), use flygrep find and open file,  will ouput an error:Can't create file ~/.cache/SpaceVim/flygrep_history. Normally, this directory does not exist on these users' machines. So they have to create the directory by theirself, it's not friendly. So I add 3 line code to check and create the directory before call writefile the file(Check codes is exist before call readfile). 