### PR TITLE
urlescape spaces in font names

### DIFF
--- a/docs/install.sh
+++ b/docs/install.sh
@@ -337,8 +337,13 @@ welcome () {
 
 # download_font {{{
 download_font () {
-  url="https://raw.githubusercontent.com/wsdjeg/DotFiles/master/local/share/fonts/$1"
+  url="https://raw.githubusercontent.com/wsdjeg/DotFiles/master/local/share/fonts/${1// /%20}"
   path="$HOME/.local/share/fonts/$1"
+  # Clean up after https://github.com/SpaceVim/SpaceVim/issues/2532
+  if [[ -f "$path" && ! -s "$path" ]]
+  then
+    rm "$path"
+  fi
   if [[ -f "$path" ]]
   then
     success "Downloaded $1"


### PR DESCRIPTION
Fixes #2532 

Also cleans up empty files so rerunning install.sh gets existing users in a good state

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Fix for #2532 provided by @cebaa, also cleanup empty font files from that bug. The cleanup block can be removed if preferred.