### PR TITLE
Set search tools for Grepper

### DIFF
--- a/config/plugins/vim-grepper.vim
+++ b/config/plugins/vim-grepper.vim
@@ -1,0 +1,9 @@
+" initialize g:grepper if it does not exist
+if !exists('g:grepper')
+  let g:grepper = {}
+endif
+
+" set value of g:grepper['tools'] to the same list of tools used by FlyGrep
+if !has_key(g:grepper, 'tools')
+  let g:grepper = {'tools': g:spacevim_search_tools}
+endif


### PR DESCRIPTION
- set default search tools available to Grepper (before filtering)
  to be the same as the tools available to FlyGrep

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

I believe having the same set of search tools for both FlyGrep and Grepper is a more sensible default setting.

One suggestion I'd might add is that you should consider amending the list of default search tools defined by `g:spacevim_search_tools` in `.SpaceVim/autoload/SpaceVim.vim` to also include git-grep and sift, the only 2 tools supported by Grepper but not by FlyGrep (and have them fail silently when encountered by FlyGrep). This way, those who prefers to use git-grep or sift in Grepper can still do so.