### PR TITLE
Preserve Git Hunks while using Github Layer

### DIFF
--- a/autoload/SpaceVim/layers/git.vim
+++ b/autoload/SpaceVim/layers/git.vim
@@ -85,12 +85,14 @@ function! SpaceVim#layers#git#config() abort
   call SpaceVim#mapping#space#def('nnoremap', ['g', 'V'], 'GV!', 'git-log-of-current-file', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['g', 'v'], 'GV', 'git-log-of-current-repo', 1)
 
-  " If github layer enabled, change Hunks key from 'h' to 'H' to avoid its functionality from being overwritten
-  let git_hunks_key = SpaceVim#layers#isLoaded('github') ? 'H' : 'h'
-  let g:_spacevim_mappings_space.g[git_hunks_key] = {'name' : '+Hunks'}
-  call SpaceVim#mapping#space#def('nmap', ['g', git_hunks_key, 'a'], '<Plug>(GitGutterStageHunk)', 'stage-current-hunk', 0)
-  call SpaceVim#mapping#space#def('nmap', ['g', git_hunks_key, 'r'], '<Plug>(GitGutterUndoHunk)', 'undo-cursor-hunk', 0)
-  call SpaceVim#mapping#space#def('nmap', ['g', git_hunks_key, 'v'], '<Plug>(GitGutterPreviewHunk)', 'preview-cursor-hunk', 0)
+	if !exists('g:_spacevim_mappings_space.g.h')
+		let g:_spacevim_mappings_space.g.h = {'name' : ''}
+	endif
+	let l:h_submenu_name = SpaceVim#layers#isLoaded('github') ? '+GitHub/Hunks' : '+Hunks'
+	let g:_spacevim_mappings_space.g.h['name'] = l:h_submenu_name
+	call SpaceVim#mapping#space#def('nmap', ['g', 'h', 's'], '<Plug>(GitGutterStageHunk)', 'stage-current-hunk', 0)
+	call SpaceVim#mapping#space#def('nmap', ['g', 'h', 'r'], '<Plug>(GitGutterUndoHunk)', 'undo-cursor-hunk', 0)
+	call SpaceVim#mapping#space#def('nmap', ['g', 'h', 'v'], '<Plug>(GitGutterPreviewHunk)', 'preview-cursor-hunk', 0)
 endfunction
 
 function! SpaceVim#layers#git#set_variable(var) abort

--- a/autoload/SpaceVim/layers/git.vim
+++ b/autoload/SpaceVim/layers/git.vim
@@ -84,10 +84,13 @@ function! SpaceVim#layers#git#config() abort
         \ 'commit-message-of-current-line', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['g', 'V'], 'GV!', 'git-log-of-current-file', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['g', 'v'], 'GV', 'git-log-of-current-repo', 1)
-  let g:_spacevim_mappings_space.g.h = {'name' : '+Hunks'}
-  call SpaceVim#mapping#space#def('nmap', ['g', 'h', 'a'], '<Plug>(GitGutterStageHunk)', 'stage-current-hunk', 0)
-  call SpaceVim#mapping#space#def('nmap', ['g', 'h', 'r'], '<Plug>(GitGutterUndoHunk)', 'undo-cursor-hunk', 0)
-  call SpaceVim#mapping#space#def('nmap', ['g', 'h', 'v'], '<Plug>(GitGutterPreviewHunk)', 'preview-cursor-hunk', 0)
+
+  " If github layer enabled, change Hunks key from 'h' to 'H' to avoid its functionality from being overwritten
+  let git_hunks_key = SpaceVim#layers#isLoaded('github') ? 'H' : 'h'
+  let g:_spacevim_mappings_space.g[git_hunks_key] = {'name' : '+Hunks'}
+  call SpaceVim#mapping#space#def('nmap', ['g', git_hunks_key, 'a'], '<Plug>(GitGutterStageHunk)', 'stage-current-hunk', 0)
+  call SpaceVim#mapping#space#def('nmap', ['g', git_hunks_key, 'r'], '<Plug>(GitGutterUndoHunk)', 'undo-cursor-hunk', 0)
+  call SpaceVim#mapping#space#def('nmap', ['g', git_hunks_key, 'v'], '<Plug>(GitGutterPreviewHunk)', 'preview-cursor-hunk', 0)
 endfunction
 
 function! SpaceVim#layers#git#set_variable(var) abort

--- a/autoload/SpaceVim/layers/git.vim
+++ b/autoload/SpaceVim/layers/git.vim
@@ -90,7 +90,9 @@ function! SpaceVim#layers#git#config() abort
 	endif
 	let l:h_submenu_name = SpaceVim#layers#isLoaded('github') ? '+GitHub/Hunks' : '+Hunks'
 	let g:_spacevim_mappings_space.g.h['name'] = l:h_submenu_name
-	call SpaceVim#mapping#space#def('nmap', ['g', 'h', 's'], '<Plug>(GitGutterStageHunk)', 'stage-current-hunk', 0)
+
+	let l:stage_hunk_key = SpaceVim#layers#isLoaded('github') ? 's' : 'a'
+	call SpaceVim#mapping#space#def('nmap', ['g', 'h', l:stage_hunk_key], '<Plug>(GitGutterStageHunk)', 'stage-current-hunk', 0)
 	call SpaceVim#mapping#space#def('nmap', ['g', 'h', 'r'], '<Plug>(GitGutterUndoHunk)', 'undo-cursor-hunk', 0)
 	call SpaceVim#mapping#space#def('nmap', ['g', 'h', 'v'], '<Plug>(GitGutterPreviewHunk)', 'preview-cursor-hunk', 0)
 endfunction

--- a/autoload/SpaceVim/layers/github.vim
+++ b/autoload/SpaceVim/layers/github.vim
@@ -43,8 +43,14 @@ function! SpaceVim#layers#github#config() abort
   let g:_spacevim_mappings_space.g = get(g:_spacevim_mappings_space, 'g',  {
         \ 'name' : '+VersionControl/git',
         \ })
-  let g:_spacevim_mappings_space.g.h = { 'name': '+GitHub' }
-  let g:_spacevim_mappings_space.g.g = { 'name': '+Gist' }
+
+	if !exists('g:_spacevim_mappings_space.g.h')
+		let g:_spacevim_mappings_space.g.h = {'name' : ''}
+	endif
+	let l:h_submenu_name = SpaceVim#layers#isLoaded('git') ? '+GitHub/Hunks' : '+GitHub'
+	let g:_spacevim_mappings_space.g.h['name'] = l:h_submenu_name
+
+	let g:_spacevim_mappings_space.g.g = { 'name': '+Gist' }
 
   " @todo remove the username
   " autoload to set default username


### PR DESCRIPTION
- check if github layer enabled
- if so, change Hunnks key from 'h' to 'H'
- otherwise, leave it as 'h' for compat

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Currently, when the Github layer is enabled, the "+Hunks" functionality under the Git layer disappears. This PR fixes that.