### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1162,7 +1162,7 @@ To change the filemanager plugin:
     filemanager = "defx"
 ```
 
-VCS integration is supported, there will be a column status, this feature maybe make vimfiler slow, so it is not enabled by default.
+VCS integration is supported, there will be a column status, this feature may make vimfiler slow, so it is not enabled by default.
 To enable this feature, add `enable_vimfiler_gitstatus = true` to your custom configure.
 Here is a picture for this feature:
 


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x ] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x ] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x ] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

There's a small typo in the docs under the **File tree** section. The word `maybe` seems a bit out of place in the sentence. `may` fits better.
