### PR TITLE
Add npm support for building 2 plugins

### DIFF
--- a/autoload/SpaceVim/layers/lang/markdown.vim
+++ b/autoload/SpaceVim/layers/lang/markdown.vim
@@ -25,13 +25,22 @@ function! SpaceVim#layers#lang#markdown#plugins() abort
   call add(plugins, ['joker1007/vim-markdown-quote-syntax',{ 'on_ft' : 'markdown'}])
   call add(plugins, ['mzlogin/vim-markdown-toc',{ 'on_ft' : 'markdown'}])
   call add(plugins, ['iamcco/mathjax-support-for-mkdp',{ 'on_ft' : 'markdown'}])
+  call add(plugins, ['lvht/tagbar-markdown',{'merged' : 0}])
+  " check node package managers to ensure building of 2 plugins below
+  if executable('npm')
+    let s:node_pkgm = 'npm'
+  elseif executable('yarn')
+    let s:node_pkgm = 'yarn'
+  else
+    let s:node_pkgm = ''
+    call SpaceVim#logger#error('npm or yarn is required to build iamcco/markdown-preview and neoclide/vim-node-rpc')
+  endif
   call add(plugins, ['iamcco/markdown-preview.nvim',
         \ { 'on_ft' : 'markdown',
         \ 'depends': 'open-browser.vim',
-        \ 'build' : 'cd app & yarn install' }])
-  call add(plugins, ['lvht/tagbar-markdown',{'merged' : 0}])
+        \ 'build' : 'cd app & ' . s:node_pkgm . ' install' }])
   if !has('nvim')
-    call add(plugins, ['neoclide/vim-node-rpc',  {'merged': 0, 'build' : 'yarn install'}])
+    call add(plugins, ['neoclide/vim-node-rpc',  {'merged': 0, 'build' : s:node_pkgm . ' install'}])
   endif
   return plugins
 endfunction


### PR DESCRIPTION
- with only 'yarn install', build fails on systems without yarn
- log error to SpaceVim if neither npm or yarn are found

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.