### PR TITLE
change lang#java mapping-gd

### DIFF
--- a/autoload/SpaceVim/layers/lang/java.vim
+++ b/autoload/SpaceVim/layers/lang/java.vim
@@ -102,12 +102,17 @@ function! SpaceVim#layers#lang#java#config() abort
   call SpaceVim#mapping#space#regesit_lang_mappings('java', function('s:language_specified_mappings'))
   call SpaceVim#plugins#repl#reg('java', 'jshell')
   call add(g:spacevim_project_rooter_patterns, 'pom.xml')
+
+  if SpaceVim#layers#lsp#check_filetype('java')
+    call SpaceVim#mapping#gd#add('java', function('SpaceVim#lsp#go_to_def'))
+  else
+    call SpaceVim#mapping#gd#add('java', function('s:go_to_def'))
+  endif
   augroup SpaceVim_lang_java
     au!
     if !SpaceVim#layers#lsp#check_filetype('java')
       " omnifunc will be used only when no java lsp support
       autocmd FileType java setlocal omnifunc=javacomplete#Complete
-      call SpaceVim#mapping#gd#add('java', function('s:go_to_def'))
     endif
     autocmd FileType jsp call <SID>JspFileTypeInit()
   augroup END
@@ -189,6 +194,9 @@ function! s:language_specified_mappings() abort
   call SpaceVim#mapping#space#langSPC('nmap', ['l', 'g', 't'],
         \ '<Plug>(JavaComplete-Generate-ToString)',
         \ 'Generate toString function', 0)
+  call SpaceVim#mapping#space#langSPC('nmap', ['l', 'g', 'n'],
+        \ '<Plug>(JavaComplete-Generate-NewClass)',
+        \ 'Generate NewClass in current Package', 0)
 
   " Jump
   let g:_spacevim_mappings_space.l.j = {'name' : '+Jump'}
@@ -240,6 +248,8 @@ function! s:language_specified_mappings() abort
   call SpaceVim#mapping#space#langSPC('nnoremap', ['l','g', 't'], 'call call('
         \ . string(function('s:execCMD')) . ', ["gradle test"])',
         \ 'Run gradle test', 1)
+  
+  " REPL
   let g:_spacevim_mappings_space.l.s = {'name' : '+Send'}
   call SpaceVim#mapping#space#langSPC('nmap', ['l','s', 'i'],
         \ 'call SpaceVim#plugins#repl#start("java")',
@@ -269,7 +279,7 @@ function! s:java_mappings() abort
 endfunction
 
 function! s:go_to_def() abort
-  call SpaceVim#lsp#go_to_def()
+    
 endfunction
 
 function! s:execCMD(cmd) abort

--- a/autoload/SpaceVim/layers/lang/java.vim
+++ b/autoload/SpaceVim/layers/lang/java.vim
@@ -279,7 +279,7 @@ function! s:java_mappings() abort
 endfunction
 
 function! s:go_to_def() abort
-    
+  exe 'normal! gd'
 endfunction
 
 function! s:execCMD(cmd) abort


### PR DESCRIPTION
### Why this change is necessary and useful?
1. **lang#java** layers  **gd**  mapping is wrong,  I update it. 
The original file has problem with gd, it doesn`t work.
I dont know which function should use when there is no lsp support. 
I havent found any function can go to definition in vim-javacomplete2.
Does **original gd** ok?

2. add a new **mapping** based on vim-javacomplete2.
pls check the changed file for details.
