### PR TITLE
Add: easy way to send esc to the shell layer

### DIFF
--- a/autoload/SpaceVim/layers/shell.vim
+++ b/autoload/SpaceVim/layers/shell.vim
@@ -18,8 +18,9 @@
 "
 " @subsection key bindings
 " >
-"   SPC '   Open or switch to terminal windows
-"   q       Hide terminal windows in normal mode
+"   SPC '         Open or switch to terminal windows
+"   q             Hide terminal windows in normal mode
+"   <Esc><Esc>    Send <Esc> to the terminal in insert mode
 " <
 
 let s:SYSTEM = SpaceVim#api#import('system')
@@ -56,13 +57,14 @@ function! SpaceVim#layers#shell#config() abort
         \ ], 1)
 
   if has('nvim') || exists(':tnoremap') == 2
-    exe 'tnoremap <silent><C-Right> <C-\><C-n>:<C-u>wincmd l<CR>'
-    exe 'tnoremap <silent><C-Left>  <C-\><C-n>:<C-u>wincmd h<CR>'
-    exe 'tnoremap <silent><C-Up>    <C-\><C-n>:<C-u>wincmd k<CR>'
-    exe 'tnoremap <silent><C-Down>  <C-\><C-n>:<C-u>wincmd j<CR>'
-    exe 'tnoremap <silent><M-Left>  <C-\><C-n>:<C-u>bprev<CR>'
-    exe 'tnoremap <silent><M-Right>  <C-\><C-n>:<C-u>bnext<CR>'
-    exe 'tnoremap <silent><esc>     <C-\><C-n>'
+    exe 'tnoremap <silent><C-Right>   <C-\><C-n>:<C-u>wincmd l<CR>'
+    exe 'tnoremap <silent><C-Left>    <C-\><C-n>:<C-u>wincmd h<CR>'
+    exe 'tnoremap <silent><C-Up>      <C-\><C-n>:<C-u>wincmd k<CR>'
+    exe 'tnoremap <silent><C-Down>    <C-\><C-n>:<C-u>wincmd j<CR>'
+    exe 'tnoremap <silent><M-Left>    <C-\><C-n>:<C-u>bprev<CR>'
+    exe 'tnoremap <silent><M-Right>   <C-\><C-n>:<C-u>bnext<CR>'
+    exe 'tnoremap <silent><esc>       <C-\><C-n>'
+    exe 'tnoremap <silent><esc><esc>  <esc>'
     if s:SYSTEM.isWindows
       exe 'tnoremap <expr><silent><C-d>  SpaceVim#layers#shell#terminal()'
       exe 'tnoremap <expr><silent><C-u>  SpaceVim#layers#shell#ctrl_u()'

--- a/docs/layers/shell.md
+++ b/docs/layers/shell.md
@@ -13,6 +13,7 @@ description: "This layer provide shell support in SpaceVim"
   - [Default shell](#default-shell)
   - [Default shell position and height](#default-shell-position-and-height)
 - [Key bindings](#key-bindings)
+  - [Additional key bindings on Windows](#additional-key-bindings-on-windows)
 
 <!-- vim-markdown-toc -->
 
@@ -58,16 +59,17 @@ in percents with the variable `default_height`. Default value is 30.
 
 ## Key bindings
 
-| Key Binding | Description                              |
-| ----------- | ---------------------------------------- |
-| `SPC '`     | Open or switch to the terminal windows   |
-| `Ctrl-d`    | Close terminal windows in terminal mode  |
-| `q`         | Hide terminal windows in Normal mode    |
-| `<Esc>`     | Switch to Normal mode from terminal mode |
-| `Ctrl-h`    | Switch to the windows on the left        |
-| `Ctrl-j`    | Switch to the windows below              |
-| `Ctrl-k`    | Switch to the windows on the top         |
-| `Ctrl-l`    | Switch to the windows on the right       |
+| Key Binding  | Description                              |
+| ------------ | ---------------------------------------- |
+| `SPC '`      | Open or switch to the terminal windows   |
+| `Ctrl-d`     | Close terminal windows in terminal mode  |
+| `q`          | Hide terminal windows in Normal mode    |
+| `<Esc>`      | Switch to Normal mode from terminal mode |
+| `<Esc><Esc>` | Send `<Esc>` from terminal mode          |
+| `Ctrl-h`     | Switch to the windows on the left        |
+| `Ctrl-j`     | Switch to the windows below              |
+| `Ctrl-k`     | Switch to the windows on the top         |
+| `Ctrl-l`     | Switch to the windows on the right       |
 
 ### Additional key bindings on Windows
 


### PR DESCRIPTION
Add a simple key binding to send Esc in a terminal.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [X] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [X] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

*I preserved indentation in `shell.vim`, despite [the conventions](https://spacevim.org/conventions/), because it existed there. Let me know if you prefer I don’t adapt spacing.*

### Why this change is necessary and useful?

Fairly often, you need to send the `<Esc>` key in a terminal, especially with `fzf` to cancel current input. I think this change provides an handy way to do this, without changing existing habits.