### PR TITLE
Improve window swapping

### DIFF
--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -198,7 +198,7 @@ function! SpaceVim#mapping#space#init() abort
         \ , 1)
   let s:lnum = expand('<slnum>') + s:funcbeginline
   call SpaceVim#mapping#space#def('nnoremap', ['w', 'M'], 
-        \ "execute {-> winnr('$')<=2 ? 'wincmd x' : 'ChooseWinSwap'}()",
+        \ "execute eval(\"winnr('$')<=2 ? 'wincmd x' : 'ChooseWinSwap'\")",
         \ ['swap window',
         \ [
         \ '[SPC w M] is to swap window',

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -197,7 +197,8 @@ function! SpaceVim#mapping#space#init() abort
         \ ]
         \ , 1)
   let s:lnum = expand('<slnum>') + s:funcbeginline
-  call SpaceVim#mapping#space#def('nnoremap', ['w', 'M'], 'ChooseWinSwap',
+  call SpaceVim#mapping#space#def('nnoremap', ['w', 'M'], 
+        \ "execute {-> winnr('$')<=2 ? 'wincmd x' : 'ChooseWinSwap'}()",
         \ ['swap window',
         \ [
         \ '[SPC w M] is to swap window',


### PR DESCRIPTION
- swap windows without needing to choose when there are only 2 windows

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Currently `SPC w M` always prompts users to choose a window to swap with your active one using the command `ChooseWinSwap` from the vim-choosewin plugin, even when there are no windows to be swapped with or only one other window.

This change fixes that, so when there are only 1 or 2 windows, the equivalent of `<C-w> x` is pressed.