### PR TITLE
Support search key with prefix

### DIFF
--- a/autoload/SpaceVim/plugins/a.vim
+++ b/autoload/SpaceVim/plugins/a.vim
@@ -37,9 +37,10 @@ endfunction
 
 function! s:paser(conf, root) abort
   for key in keys(a:conf)
-    let with_sub = s:CMP.globpath('.', substitute(key, '*', '**/*', 'g'))
-    let no_sub = s:CMP.globpath('.', key)
-    for file in with_sub + no_sub
+    let searchpath = key
+    if match(key, '/*')
+        let searchpath = substitute(key, '*', '**/*', 'g')
+    for file in s:CMP.globpath('.', searchpath)
       let file = s:FILE.unify_path(file, ':.')
       if has_key(a:conf, file)
         if has_key(a:conf[file], 'alternate')

--- a/autoload/SpaceVim/plugins/a.vim
+++ b/autoload/SpaceVim/plugins/a.vim
@@ -37,7 +37,9 @@ endfunction
 
 function! s:paser(conf, root) abort
   for key in keys(a:conf)
-    for file in s:CMP.globpath('.', substitute(key, '*', '**/*', 'g'))
+    let with_sub = s:CMP.globpath('.', substitute(key, '*', '**/*', 'g'))
+    let no_sub = s:CMP.globpath('.', key)
+    for file in with_sub + no_sub
       let file = s:FILE.unify_path(file, ':.')
       if has_key(a:conf, file)
         if has_key(a:conf[file], 'alternate')

--- a/autoload/SpaceVim/plugins/a.vim
+++ b/autoload/SpaceVim/plugins/a.vim
@@ -40,6 +40,7 @@ function! s:paser(conf, root) abort
     let searchpath = key
     if match(key, '/*')
         let searchpath = substitute(key, '*', '**/*', 'g')
+    endif
     for file in s:CMP.globpath('.', searchpath)
       let file = s:FILE.unify_path(file, ':.')
       if has_key(a:conf, file)


### PR DESCRIPTION

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Right now, one cannot have a search pattern for a file with a prefix. But by default, python's pyunit default filename format is either `test_script.py` or `testscript.py` 

If the key is in the format `path/prefix_*.ext`, then `substitute(key, '*', '**/*', 'g')` returns `path/prefix_**/*.ext` and therefore `CMP.globpath` is empty although the key is already a valid format.

Adding both search with and without sub let you take both formats.
