### PR TITLE
Fix: Silence FlyGrep opens to avoid hit-enter-prompt

### DIFF
--- a/autoload/SpaceVim/plugins/flygrep.vim
+++ b/autoload/SpaceVim/plugins/flygrep.vim
@@ -477,7 +477,7 @@ function! s:open_item() abort
     endif
     let s:preview_able = 0
     noautocmd q
-    exe 'e ' . filename
+    exe 'silent e ' . filename
     call s:update_history()
     call cursor(linenr, colum)
     noautocmd normal! :
@@ -501,7 +501,7 @@ function! s:open_item_vertically() abort
     endif
     let s:preview_able = 0
     noautocmd q
-    exe 'vsplit ' . filename
+    exe 'silent vsplit ' . filename
     call s:update_history()
     call cursor(linenr, colum)
     noautocmd normal! :
@@ -525,7 +525,7 @@ function! s:open_item_horizontally() abort
     endif
     let s:preview_able = 0
     noautocmd q
-    exe 'split ' . filename
+    exe 'silent split ' . filename
     call s:update_history()
     call cursor(linenr, colum)
     noautocmd normal! :


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x ] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x ] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [ x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

When using FlyGrep outside of SpaceVim, I get the "Press ENTER or type command to continue" prompt when opening a selection with FlyGrep. I couldn't make this go away with shortmess changes. This change seems like a sane default but I'm also not that familiar with all of its potential implications on the rest of the codebase.

I validated this change in the standalone plugin and I followed the existing conventions of the use of 'silent' in the flygrep.vim file (silence the command rather than the 'exe').
