### PR TITLE
highlight-long-lines defaults to 80

### DIFF
--- a/autoload/SpaceVim/layers/ui.vim
+++ b/autoload/SpaceVim/layers/ui.vim
@@ -191,7 +191,11 @@ let s:fcflag = 0
 " use &textwidth option instead of 80
 function! s:toggle_fill_column() abort
   if !s:fcflag
-    let &colorcolumn=join(range(&textwidth + 1,999),',')
+    if !&textwidth
+      let &colorcolumn=join(range(81,999),',')
+    else
+      let &colorcolumn=join(range(&textwidth + 1,999),',')
+    endif
     let s:fcflag = 1
   else
     set cc=


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

This patch completes #3226 in the case where `&textwidth` is not set. The `highlight-long-lines` features then defaults to 80 columns.
