### PR TITLE
[Docs] vimproc_linux64.so DLL issues pointers

### DIFF
--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -42,6 +42,8 @@ For more info about the install script, please check:
 curl -sLf https://spacevim.org/install.sh | bash -s -- -h
 ```
 
+If you got a vimproc error like `[vimproc] vimproc's DLL: "~/.cache/vimfiles/vimproc.vim/lib/vimproc_linux64.so" is not found.  Please read :help vimproc and make it`, you may need to install make (from `build-essential)` and a C compilator (like `gcc`) to build the dll (see issue [#435](https://github.com/SpaceVim/SpaceVim/issues/435) and [#544](https://github.com/SpaceVim/SpaceVim/issues/544)).
+
 ### Windows
 
 The easiest way is to download [install.cmd](https://spacevim.org/install.cmd) and run it as administrator, or install SpaceVim manually.


### PR DESCRIPTION
Just because I ran into this with a fresh install on a server without c compiler, I put this here as a reminder and for others SpaceVim fans :-)

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [V] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [V] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [V] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

When you install SpaceVim on a Unix System without `cc`, you can't compile vimproc.