### PR TITLE
Add: Spacevim#custom#LangSPC and SpaceVim#custom#LangSPCGroupName

### DIFF
--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -725,13 +725,13 @@ let g:spacevim_filemanager             = 'vimfiler'
 " @section filetree_direction, options-filetree_direction
 " @parentsection options
 " Config the direction of file tree. Default is 'right'. you can also set to
-" 'left'. 
+" 'left'.
 "
 " NOTE: if it is 'left', the tagbar will be move to right.
 
 ""
 " Config the direction of file tree. Default is 'right'. you can also set to
-" 'left'. 
+" 'left'.
 "
 " NOTE: if it is 'left', the tagbar will be move to right.
 let g:spacevim_filetree_direction             = 'right'
@@ -773,7 +773,7 @@ let g:spacevim_checkinstall            = 1
 ""
 " @section vimcompatible, options-vimcompatible
 " @parentsection options
-" Enable/Disable vimcompatible mode, by default it is false. 
+" Enable/Disable vimcompatible mode, by default it is false.
 " to enable vimcompatible mode, just add:
 " >
 "   vimcompatible = true
@@ -788,7 +788,7 @@ let g:spacevim_checkinstall            = 1
 " <
 
 ""
-" Enable/Disable vimcompatible mode, by default it is false. 
+" Enable/Disable vimcompatible mode, by default it is false.
 " to enable vimcompatible mode, just add:
 " >
 "   let g:spacevim_vimcompatible = 1
@@ -1065,6 +1065,8 @@ let g:spacevim_wildignore
 let g:_spacevim_mappings = {}
 let g:_spacevim_mappings_space_custom = []
 let g:_spacevim_mappings_space_custom_group_name = []
+let g:_spacevim_mappings_language_specified_space_custom = {}
+let g:_spacevim_mappings_language_specified_space_custom_group_name = {}
 let g:_spacevim_neobundle_installed     = 0
 let g:_spacevim_dein_installed          = 0
 let g:_spacevim_vim_plug_installed      = 0

--- a/autoload/SpaceVim/custom.vim
+++ b/autoload/SpaceVim/custom.vim
@@ -83,6 +83,19 @@ function! SpaceVim#custom#SPCGroupName(keys, name) abort
   call add(g:_spacevim_mappings_space_custom_group_name, [a:keys, a:name])
 endfunction
 
+function! SpaceVim#custom#LangSPC(ft, m, keys, cmd, desc, is_cmd) abort
+  if !has_key(g:_spacevim_mappings_language_specified_space_custom, a:ft)
+    let g:_spacevim_mappings_language_specified_space_custom[a:ft] = []
+  endif
+  call add(g:_spacevim_mappings_language_specified_space_custom[a:ft], [a:m, a:keys, a:cmd, a:desc, a:is_cmd])
+endfunction
+
+function! SpaceVim#custom#LangSPCGroupName(ft, keys, name) abort
+  if !has_key(g:_spacevim_mappings_language_specified_space_custom_group_name, a:ft)
+    let g:_spacevim_mappings_language_specified_space_custom_group_name[a:ft] = []
+  endif
+  call add(g:_spacevim_mappings_language_specified_space_custom_group_name[a:ft], [a:keys, a:name])
+endfunction
 
 function! SpaceVim#custom#apply(config, type) abort
   " the type can be local or global

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -49,7 +49,7 @@ function! SpaceVim#mapping#space#init() abort
   let g:_spacevim_mappings_space.w['<Tab>'] = ['wincmd w', 'alternate-window']
   nnoremap <silent> [SPC]w<tab> :wincmd w<cr>
   call SpaceVim#mapping#menu('alternate-window', '[SPC]w<Tab>', 'wincmd w')
-  call SpaceVim#mapping#space#def('nnoremap', ['w', '+'], 
+  call SpaceVim#mapping#space#def('nnoremap', ['w', '+'],
         \ 'call call('
         \ . string(function('s:windows_layout_toggle'))
         \ . ', [])', 'windows-layout-toggle', 1)
@@ -197,7 +197,7 @@ function! SpaceVim#mapping#space#init() abort
         \ ]
         \ , 1)
   let s:lnum = expand('<slnum>') + s:funcbeginline
-  call SpaceVim#mapping#space#def('nnoremap', ['w', 'M'], 
+  call SpaceVim#mapping#space#def('nnoremap', ['w', 'M'],
         \ "execute eval(\"winnr('$')<=2 ? 'wincmd x' : 'ChooseWinSwap'\")",
         \ ['swap window',
         \ [
@@ -521,8 +521,8 @@ function! SpaceVim#mapping#space#def(m, keys, cmd, desc, is_cmd, ...) abort
   endif
   let is_visual = a:0 > 0 ? a:1 : 0
   if a:is_cmd
-    let cmd = ':<C-u>' . a:cmd . '<CR>' 
-    let xcmd = ':' . a:cmd . '<CR>' 
+    let cmd = ':<C-u>' . a:cmd . '<CR>'
+    let xcmd = ':' . a:cmd . '<CR>'
     let lcmd = a:cmd
   else
     let cmd = a:cmd
@@ -578,7 +578,7 @@ function! s:windows_layout_toggle() abort
     echohl WarningMsg
     echom "Can't toggle window layout when the number of windows isn't two."
     echohl None
-  else 
+  else
     if winnr() == 1
       let b = winbufnr(2)
     else
@@ -599,12 +599,29 @@ endfunction
 
 let s:language_specified_mappings = {}
 function! SpaceVim#mapping#space#refrashLSPC() abort
+  " Predefined mappings
   let g:_spacevim_mappings_space.l = {'name' : '+Language Specified'}
   if !empty(&filetype) && has_key(s:language_specified_mappings, &filetype)
     call call(s:language_specified_mappings[&filetype], [])
     let b:spacevim_lang_specified_mappings = g:_spacevim_mappings_space.l
   endif
 
+  " Customized mappings
+  if has_key(g:_spacevim_mappings_language_specified_space_custom_group_name, &filetype)
+    for argv in g:_spacevim_mappings_language_specified_space_custom_group_name[&filetype]
+      " Only support one layer of groups
+      if !has_key(g:_spacevim_mappings_space.l, argv[0][0])
+        let g:_spacevim_mappings_space.l[argv[0][0]] = {'name' : argv[1]}
+      endif
+    endfor
+  endif
+  if has_key(g:_spacevim_mappings_language_specified_space_custom, &filetype)
+    for argv in g:_spacevim_mappings_language_specified_space_custom[&filetype]
+      let argv = deepcopy(argv)
+      let argv[1] = ['l'] + argv[1]
+      call call('SpaceVim#mapping#space#langSPC', argv)
+    endfor
+  endif
 endfunction
 
 function! SpaceVim#mapping#space#regesit_lang_mappings(ft, func) abort
@@ -617,7 +634,7 @@ function! SpaceVim#mapping#space#langSPC(m, keys, cmd, desc, is_cmd, ...) abort
   endif
   let is_visual = a:0 > 0 ? a:1 : 0
   if a:is_cmd
-    let cmd = ':<C-u>' . a:cmd . '<CR>' 
+    let cmd = ':<C-u>' . a:cmd . '<CR>'
     let lcmd = a:cmd
   else
     let cmd = a:cmd
@@ -661,7 +678,7 @@ endfunction
 
 function! s:windows_transient_state() abort
 
-  let state = SpaceVim#api#import('transient_state') 
+  let state = SpaceVim#api#import('transient_state')
   call state.set_title('Buffer Selection Transient State')
   call state.defind_keys(
         \ {


### PR DESCRIPTION
with these two interface, users are able to customize language specific commands (SPC+l) for any file types. For example:
```
  call SpaceVim#custom#LangSPCGroupName('python', ['d'], '+Debug')
  call SpaceVim#custom#LangSPC('python', 'nmap', ['d', 's'], 'echo "good"', 'let vim say good', 1)

```
defines a SPC+l+d group names '+Debug', and a key binding SPC+l+d+s for 'echo "good" ', exclusively for python