### PR TITLE
Add plugin to enable search via */# in visual mode

### DIFF
--- a/autoload/SpaceVim/layers/incsearch.vim
+++ b/autoload/SpaceVim/layers/incsearch.vim
@@ -39,6 +39,7 @@ function! SpaceVim#layers#incsearch#plugins() abort
   call add(plugins, ['haya14busa/vim-asterisk', {'merged' : 0}])
   call add(plugins, ['osyo-manga/vim-over', {'merged' : 0}])
   call add(plugins, ['haya14busa/incsearch-easymotion.vim', {'merged' : 0}])
+  call add(plugins, ['nelstrom/vim-visual-star-search', {'merged' : 0}])
   return plugins
 endfunction
 


### PR DESCRIPTION
It's a useful addition that makes `*` and `#` work as one'd intuitively expect in visual mode.

the `incsearch` layer seemed like the most fitting place to add the plugin. Let me know if you think there's a better location; while convenient, the functionality itself doesn't seem critical enough for it to be added into core.