### PR TITLE
feat: optional support of vim-devicons

### DIFF
--- a/autoload/SpaceVim/api/file.vim
+++ b/autoload/SpaceVim/api/file.vim
@@ -141,6 +141,9 @@ let s:file_node_pattern_matches = {
 
 
 function! s:filetypeIcon(path) abort
+  if exists('*WebDevIconsGetFileTypeSymbol')  " support for vim-devicons
+    return WebDevIconsGetFileTypeSymbol(a:path)
+  endif
   let file = fnamemodify(a:path, ':t')
   if has_key(s:file_node_exact_matches, file)
     return s:file_node_exact_matches[file]
@@ -157,7 +160,6 @@ function! s:filetypeIcon(path) abort
     return s:file_node_extensions[ext]
   endif
   return ''
-
 endfunction
 
 let s:file['fticon'] = function('s:filetypeIcon')


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

The default icon API present in files supports very few icons. I see my React TSX files as TypeScript for example. [vim-devicons](https://www.github.com/ryanoasis/vim-devicons) supports a lot more. Unfortunately, SpaceVim makes this plugin useless due to its heavy customization (icons, airline formatter, etc). This PR addresses the icon part by optionally choosing to use devicons if the user has installed it.
By changing the SpaceVim's API we ensure that both startify and tabline work with this.
