### PR TITLE
Fix typo in imports in go doc

### DIFF
--- a/docs/layers/lang/go.md
+++ b/docs/layers/lang/go.md
@@ -62,7 +62,7 @@ go get -u github.com/jstemmer/gotags
 | `SPC l k`    | add tags                  |
 | `SPC l K`    | remove tags               |
 | `SPC l l`    | list declarations in file |
-| `SPC l m`    | format improts            |
+| `SPC l m`    | format imports            |
 | `SPC l M`    | add import                |
 | `SPC l r`    | go run                    |
 | `SPC l s`    | fill struct               |


### PR DESCRIPTION
- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

While looking through the documentation of the go layer I found the small typo and figured I'd fix it.

Thank you for the awesome work with spacevim!
