### PR TITLE
Fix spc s a j text

### DIFF
--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -387,9 +387,9 @@ function! SpaceVim#mapping#space#init() abort
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'a', 'P'], 'call SpaceVim#mapping#search#grep("a", "P")',
         \ 'search cursor word in project with ag', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'a', 'f'], 'call SpaceVim#mapping#search#grep("a", "f")',
-        \ 'search in arbitrary directory  with ag', 1)
+        \ 'search in arbitrary directory with ag', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'a', 'F'], 'call SpaceVim#mapping#search#grep("a", "F")',
-        \ 'search cursor word in arbitrary directory  with ag', 1)
+        \ 'search cursor word in arbitrary directory with ag', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'a', 'j'], 'call SpaceVim#plugins#searcher#find("", "ag")',
         \ 'Background search cursor words in project with ag', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'a', 'J'], 'call SpaceVim#plugins#searcher#find(expand("<cword>"), "ag")',

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -391,7 +391,7 @@ function! SpaceVim#mapping#space#init() abort
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'a', 'F'], 'call SpaceVim#mapping#search#grep("a", "F")',
         \ 'search cursor word in arbitrary directory with ag', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'a', 'j'], 'call SpaceVim#plugins#searcher#find("", "ag")',
-        \ 'Background search cursor words in project with ag', 1)
+        \ 'Background search in project with ag', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['s', 'a', 'J'], 'call SpaceVim#plugins#searcher#find(expand("<cword>"), "ag")',
         \ 'Background search cursor words in project with ag', 1)
   " grep


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [X] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [X] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?
Both of these commits are trivial text changes. One commit removes some spurious whitespcae and the second clarifies the distinctions already present in the documentation between the `[SPC] s a j` as opposed to `[SPC] s a J` commands.