### PR TITLE
Add chez dialect for lang#scheme layer

### DIFF
--- a/autoload/SpaceVim/layers/lang/scheme.vim
+++ b/autoload/SpaceVim/layers/lang/scheme.vim
@@ -9,16 +9,26 @@
 function! SpaceVim#layers#lang#scheme#config() abort
   if s:scheme_dialect ==# 'mit-scheme'
     call SpaceVim#plugins#runner#reg_runner('scheme', 'echo | mit-scheme --quiet --load %s && echo')
+    call SpaceVim#plugins#repl#reg('scheme', ['scheme', '--quiet'])
   elseif s:scheme_dialect ==# 'guile'
     call SpaceVim#plugins#runner#reg_runner('scheme', 'echo | guile -q %s && echo')
+    call SpaceVim#plugins#repl#reg('scheme', ['guile', '-q'])
+  elseif s:scheme_dialect ==# 'chez'
+    if executable('chez')
+      call SpaceVim#plugins#runner#reg_runner('scheme', 'chez --script %s')
+      call SpaceVim#plugins#repl#reg('scheme', ['chez', '-q'])
+    else
+      call SpaceVim#plugins#runner#reg_runner('scheme', 'scheme --script %s')
+      call SpaceVim#plugins#repl#reg('scheme', ['scheme', '-q'])
+    endif
   else
 		try 
 			call SpaceVim#plugins#runner#reg_runner('scheme', 'echo | ' . s:scheme_dialect . ' %s && echo')
+      call SpaceVim#plugins#repl#reg('scheme', [s:scheme_dialect])
 		catch /^Vim\%((\a\+)\)\=:E117/
 		endtry
   endif
   call SpaceVim#mapping#space#regesit_lang_mappings('scheme', function('s:language_specified_mappings'))
-  call SpaceVim#plugins#repl#reg('scheme', ['scheme', '--silent'])
 endfunction
 
 function! SpaceVim#layers#lang#scheme#set_variable(opt) abort


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Solve #3298.

1. Using chez as executable if available, falling back to scheme,
   while chez dialect is used.

2. Set repl in additional to runner.

BTW, I don't quite understand why the leading and following ``echo`` in the ``reg_runner()`` is needed, and it seems that they are unnecessary for chez scheme.
