### PR TITLE
Add icons and git status to defx

### DIFF
--- a/autoload/SpaceVim/layers/core.vim
+++ b/autoload/SpaceVim/layers/core.vim
@@ -27,6 +27,8 @@ function! SpaceVim#layers#core#plugins() abort
     call add(plugins, ['Shougo/vimproc.vim', {'build' : [(executable('gmake') ? 'gmake' : 'make')]}])
   elseif g:spacevim_filemanager ==# 'defx'
     call add(plugins, ['Shougo/defx.nvim',{'merged' : 0, 'loadconf' : 1 , 'loadconf_before' : 1}])
+    call add(plugins, ['kristijanhusak/defx-icons',{'merged' : 0}])
+    call add(plugins, ['kristijanhusak/defx-git',{'merged' : 0, 'loadconf' : 1}])
   endif
 
   if !g:spacevim_vimcompatible

--- a/config/plugins/defx-git.vim
+++ b/config/plugins/defx-git.vim
@@ -1,0 +1,10 @@
+let g:defx_git#indicators = {
+	\ 'Modified'  : '•',
+	\ 'Staged'    : '✚',
+	\ 'Untracked' : 'ᵁ',
+	\ 'Renamed'   : '≫',
+	\ 'Unmerged'  : '≠',
+	\ 'Ignored'   : 'ⁱ',
+	\ 'Deleted'   : '✖',
+	\ 'Unknown'   : '⁇'
+	\ }

--- a/config/plugins/defx.vim
+++ b/config/plugins/defx.vim
@@ -15,6 +15,7 @@ else
 endif
 
 call defx#custom#option('_', {
+      \ 'columns': 'indent:git:icons:filename',
       \ 'winwidth': g:spacevim_sidebar_width,
       \ 'split': 'vertical',
       \ 'direction': s:direction,


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?
Both Vimfiler and Nerdtree have icons and git status, adding these to Defx would make the appearances of the file trees more uniform.