### PR TITLE
Fix(lsp): multiple language server registration bug

### DIFF
--- a/autoload/SpaceVim/lsp.vim
+++ b/autoload/SpaceVim/lsp.vim
@@ -114,7 +114,7 @@ else
   " use vim-lsp
   function! SpaceVim#lsp#reg_server(ft, cmds) abort
     exe 'au User lsp_setup call lsp#register_server({'
-          \ . "'name': 'LSP',"
+          \ . "'name': '" . a:ft . "-lsp',"
           \ . "'cmd': {server_info -> " . string(a:cmds) . '},'
           \ . "'whitelist': ['" .  a:ft . "' ],"
           \ . '})'


### PR DESCRIPTION
### PR Prelude

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

if we register multiple language servers in our `init.toml` like following below:

```
[[layers]]
    name = "lsp"
    filetypes = [
        "rust",
        "c",
        "cpp",
    ]
    [layers.override_cmd]
        rust = ["rustup", "run", "nightly", "rls"]
        c = ["clangd"]
```

`vim-lsp` will always store the last language server instance since every time we register a new language server, we always use `LSP` as the instance name which is also the [index](https://github.com/prabirshrestha/vim-lsp/blob/master/autoload/lsp.vim#L151-L163) used inside `vim-lsp`, we can check this by `:call lsp#print_server_status()`

![image](https://user-images.githubusercontent.com/6234553/73925326-ddebb700-4908-11ea-858d-a7e0c44707fa.png)

and this simple fix is to change the name of each lsp instance from fixed `LSP` to `filetype-lsp`, e.g. `rust-lsp`, `cpp-lsp`, etc, and then everything just goes well as expected :)

![image](https://user-images.githubusercontent.com/6234553/73925547-302cd800-4909-11ea-822b-3f12b0a3f3e3.png)



