### PR TITLE
GitGutter event conditional on core#statusline.

### DIFF
--- a/autoload/SpaceVim/layers/git.vim
+++ b/autoload/SpaceVim/layers/git.vim
@@ -81,7 +81,9 @@ function! SpaceVim#layers#git#config() abort
     autocmd!
     autocmd FileType diff nnoremap <buffer><silent> q :call SpaceVim#mapping#close_current_buffer()<CR>
     autocmd FileType gitcommit setl omnifunc=SpaceVim#plugins#gitcommit#complete
-    autocmd User GitGutter let &l:statusline = SpaceVim#layers#core#statusline#get(1)
+    if SpaceVim#layers#isLoaded('core#statusline')
+        autocmd User GitGutter let &l:statusline = SpaceVim#layers#core#statusline#get(1)
+    endif
     " Instead of reverting the cursor to the last position in the buffer, we
     " set it to the first line when editing a git commit message
     au FileType gitcommit au! BufEnter COMMIT_EDITMSG call setpos('.', [0, 1, 1, 0])


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

When disabling core#statusline layer to use play airline, enabling git layer caused the core#statusline to be loaded and replaced the airline anyway.

I made the event conditional on statuline layer being enabled. I'm not entirely sure what has been the goal of the event, so there might be a better way to fix it to keep the original intent.
