### PR TITLE
Tasks provider

### DIFF
--- a/.SpaceVim.d/tasks.toml
+++ b/.SpaceVim.d/tasks.toml
@@ -1,10 +1,1 @@
-[file-build]
-    command = 'echo ${relativeFile}'
-    isBackground = false
-[file-build.options]
-    cmd = '${workspaceFolder}'
-[file-run]
-    command = "echo"
-    args = ['hello']
-    isBackground = false
 

--- a/autoload/SpaceVim/plugins/tasks.vim
+++ b/autoload/SpaceVim/plugins/tasks.vim
@@ -88,7 +88,7 @@ endfunction
 function! SpaceVim#plugins#tasks#get()
   call s:load()
   for Provider in s:providers
-    call call(Provider, [])
+    call extend(s:conf, call(Provider, []))
   endfor
   call s:init_variables()
   let task = s:pick()
@@ -155,17 +155,19 @@ function! SpaceVim#plugins#tasks#edit(...)
 endfunction
 
 function! s:detect_npm_tasks() abort
+  let detect_task = {}
   let conf = {}
   if filereadable('package.json')
       let conf = s:JSON.json_decode(join(readfile('package.json', ''), ''))
   endif
   if has_key(conf, 'scripts')
     for task_name in keys(conf.scripts)
-      call extend(s:conf, {
+      call extend(detect_task, {
             \ task_name : {'command' : conf.scripts[task_name], 'isDetected' : 1, 'detectedName' : 'npm:'}
             \ })
     endfor
   endif
+  return detect_task
 endfunction
 
 function! SpaceVim#plugins#tasks#reg_provider(provider)

--- a/autoload/SpaceVim/plugins/tasks.vim
+++ b/autoload/SpaceVim/plugins/tasks.vim
@@ -87,8 +87,8 @@ endfunction
 
 function! SpaceVim#plugins#tasks#get()
   call s:load()
-  for provider in s:providers
-    call call(provider, [])
+  for Provider in s:providers
+    call call(Provider, [])
   endfor
   call s:init_variables()
   let task = s:pick()

--- a/autoload/SpaceVim/plugins/tasks.vim
+++ b/autoload/SpaceVim/plugins/tasks.vim
@@ -24,6 +24,7 @@ let s:select_task = {}
 let s:conf = []
 let s:bufnr = -1
 let s:variables = {}
+let s:providers = []
 
 
 function! s:load() abort
@@ -86,7 +87,9 @@ endfunction
 
 function! SpaceVim#plugins#tasks#get()
   call s:load()
-  call s:detect_npm_tasks()
+  for provider in s:providers
+    call call(provider, [])
+  endfor
   call s:init_variables()
   let task = s:pick()
   if has_key(task, 'windows') && s:SYS.isWindows
@@ -164,3 +167,9 @@ function! s:detect_npm_tasks() abort
     endfor
   endif
 endfunction
+
+function! SpaceVim#plugins#tasks#reg_provider(provider)
+  call add(s:providers, a:provider)
+endfunction
+
+call SpaceVim#plugins#tasks#reg_provider(funcref('s:detect_npm_tasks'))

--- a/docs/cn/documentation.md
+++ b/docs/cn/documentation.md
@@ -80,6 +80,7 @@ lang: zh
   - [标签管理](#标签管理)
   - [任务管理](#任务管理)
     - [任务自动识别](#任务自动识别)
+    - [任务提供源](#任务提供源)
     - [自定义任务](#自定义任务)
   - [Iedit 多光标编辑](#iedit-多光标编辑)
     - [Iedit 快捷键](#iedit-快捷键)
@@ -1703,6 +1704,49 @@ SpaceVim 目前支持自动识别以下构建系统的任务：npm。
 编辑其中的任意文件，然后按下快捷键`SPC p t r`，将会显示如下任务列表：
 
 ![task-auto-detection](https://user-images.githubusercontent.com/13142418/75089003-471d2c80-558f-11ea-8aea-cbf7417191d9.png)
+
+#### 任务提供源
+
+任务提供源可以自动检测并新建任务。例如，一个任务提供源可以自动检测是否存在项目构建文件，比如：`package.json`，
+如果存在则根据其内容创建 npm 的构建任务。
+
+
+在 SpaceVim 里，如果需要新建任务提供源，需要使用启动函数，任务提供源是一个 Vim 函数，该函数返回一系列任务对象。
+
+以下为一个简单的示例：
+
+
+```vim
+function! s:make_tasks() abort
+    if filereadable('Makefile')
+        let subcmd = filter(readfile('Makefile', ''), "v:val=~#'^.PHONY'")
+        if !empty(subcmd)
+            let commands = split(subcmd[0])[1:]
+            let conf = {}
+            for cmd in commands
+                call extend(conf, {
+                            \ cmd : {
+                            \ 'command': 'make',
+                            \ 'args' : [cmd],
+                            \ 'isDetected' : 1,
+                            \ 'detectedName' : 'make:'
+                            \ }
+                            \ })
+            endfor
+            return conf
+        else
+            return {}
+        endif
+    else
+        return {}
+    endif
+endfunction
+call SpaceVim#plugins#tasks#reg_provider(funcref('s:make_tasks'))
+```
+
+将以上内容加入启动函数，在 SpceVim 仓库内按下 `SPC p t r` 快捷键，将会展示如下任务：
+
+![task-make](https://user-images.githubusercontent.com/13142418/75105016-084cac80-564b-11ea-9fe6-75d86a0dbb9b.png)
 
 
 #### 自定义任务

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1745,18 +1745,34 @@ here is an example for building task provider.
 ```vim
 function! s:make_tasks() abort
     if filereadable('Makefile')
-        return {
-             \ 'make:build' {
-                         \ 'command': 'make',
-                         \ 'args' : ['build']
-                         \ }
-             \ }
+        let subcmd = filter(readfile('Makefile', ''), "v:val=~#'^.PHONY'")
+        if !empty(subcmd)
+            let commands = split(subcmd[0])[1:]
+            let conf = {}
+            for cmd in commands
+                call extend(conf, {
+                            \ cmd : {
+                            \ 'command': 'make',
+                            \ 'args' : [cmd],
+                            \ 'isDetected' : 1,
+                            \ 'detectedName' : 'make:'
+                            \ }
+                            \ })
+            endfor
+            return conf
+        else
+            return {}
+        endif
     else
         return {}
     endif
 endfunction
 call SpaceVim#plugins#tasks#reg_provider(funcref('s:make_tasks'))
 ```
+
+with above configuration, you will see following tasks in SpaceVim repo:
+
+![task-make](https://user-images.githubusercontent.com/13142418/75105016-084cac80-564b-11ea-9fe6-75d86a0dbb9b.png)
 
 #### Custom tasks
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -79,6 +79,7 @@ description: "General documentation about how to using SpaceVim, including the q
   - [Bookmarks management](#bookmarks-management)
   - [Tasks](#tasks)
     - [Task auto-detection](#task-auto-detection)
+    - [Task provider](#task-provider)
     - [Custom tasks](#custom-tasks)
   - [Replace text with iedit](#replace-text-with-iedit)
     - [iedit states key bindings](#iedit-states-key-bindings)
@@ -1728,6 +1729,34 @@ If you have cloned the [eslint-starter](https://github.com/spicydonuts/eslint-st
 then pressing `SPC p t r` shows the following list:
 
 ![task-auto-detection](https://user-images.githubusercontent.com/13142418/75089003-471d2c80-558f-11ea-8aea-cbf7417191d9.png)
+
+
+#### Task provider
+
+Some tasks can be automatically detected by task provider. For example,
+a Task Provider could check if there is a specific build file, such as `package.json`,
+and create npm tasks. 
+
+To build a task provider, you need to use Bootstrap function. The task provider should be a vim function.
+and return a task object. 
+
+here is an example for building task provider.
+
+```vim
+function! s:make_tasks() abort
+    if filereadable('Makefile')
+        return {
+             \ 'make:build' {
+                         \ 'command': 'make',
+                         \ 'args' : ['build']
+                         \ }
+             \ }
+    else
+        return {}
+    endif
+endfunction
+call SpaceVim#plugins#tasks#reg_provider(funcref('s:make_tasks'))
+```
 
 #### Custom tasks
 


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [ ] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [ ] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Some tasks can be automatically detected by task provider. For example,
a Task Provider could check if there is a specific build file, such as `package.json`,
and create npm tasks. 

To build a task provider, you need to use Bootstrap function. The task provider should be a vim function.
and return a task object. 

here is an example for building task provider.

```vim
function! s:make_tasks() abort
    if filereadable('Makefile')
        let subcmd = filter(readfile('Makefile', ''), "v:val=~#'^.PHONY'")
        if !empty(subcmd)
            let commands = split(subcmd[0])[1:]
            let conf = {}
            for cmd in commands
                call extend(conf, {
                            \ cmd : {
                            \ 'command': 'make',
                            \ 'args' : [cmd],
                            \ 'isDetected' : 1,
                            \ 'detectedName' : 'make:'
                            \ }
                            \ })
            endfor
            return conf
        else
            return {}
        endif
    else
        return {}
    endif
endfunction
call SpaceVim#plugins#tasks#reg_provider(funcref('s:make_tasks'))
```

with above configuration, you will see following tasks in SpaceVim repo:

![task-make](https://user-images.githubusercontent.com/13142418/75105016-084cac80-564b-11ea-9fe6-75d86a0dbb9b.png)


