### PR TITLE
Fix layer/lang/go jump to definition issue

### DIFF
--- a/autoload/SpaceVim/layers/lang/go.vim
+++ b/autoload/SpaceVim/layers/lang/go.vim
@@ -72,7 +72,7 @@ function! SpaceVim#layers#lang#go#config() abort
 endfunction
 
 function! s:go_to_def() abort
-  call go#def#Jump('')
+  call go#def#Jump('', 0)
 endfunction
 
 function! s:language_specified_mappings() abort


### PR DESCRIPTION
### PR Prelude

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

fix `gd` for the Go layer according to the original vim plug https://github.com/fatih/vim-go/blob/master/ftplugin/go/commands.vim#L57. currently, the `gd` functionality of the Go layer is not working as expected.