### PR TITLE
Add: lang/layer/go `GoFmt` shortcut

### DIFF
--- a/autoload/SpaceVim/layers/lang/go.vim
+++ b/autoload/SpaceVim/layers/lang/go.vim
@@ -95,6 +95,9 @@ function! s:language_specified_mappings() abort
   call SpaceVim#mapping#space#langSPC('nmap', ['l','e'],
         \ '<Plug>(go-rename)',
         \ 'go rename', 0)
+  call SpaceVim#mapping#space#langSPC('nmap', ['l','f'],
+        \ ':GoFmt',
+        \ 'format current file', 1)
   call SpaceVim#mapping#space#langSPC('nmap', ['l','g'],
         \ '<Plug>(go-def)',
         \ 'go def', 0)

--- a/docs/cn/layers/lang/go.md
+++ b/docs/cn/layers/lang/go.md
@@ -53,6 +53,7 @@ go get -u github.com/jstemmer/gotags
 | `SPC l d` | go doc                    |
 | `SPC l D` | go doc vertical           |
 | `SPC l e` | go rename                 |
+| `SPC l f` | go format current file    |
 | `SPC l g` | go definition             |
 | `SPC l G` | go generate               |
 | `SPC l h` | go info                   |
@@ -63,7 +64,7 @@ go get -u github.com/jstemmer/gotags
 | `SPC l l` | list declarations in file |
 | `SPC l m` | format improts            |
 | `SPC l M` | add import                |
-| `SPC l r` | go run              |
+| `SPC l r` | go run                    |
 | `SPC l s` | fill struct               |
 | `SPC l t` | go test                   |
 | `SPC l v` | freevars                  |

--- a/docs/layers/lang/go.md
+++ b/docs/layers/lang/go.md
@@ -54,6 +54,7 @@ go get -u github.com/jstemmer/gotags
 | `SPC l d`    | go doc                    |
 | `SPC l D`    | go doc vertical           |
 | `SPC l e`    | go rename                 |
+| `SPC l f`    | go format current file    |
 | `SPC l g`    | go definition             |
 | `SPC l G`    | go generate               |
 | `SPC l h`    | go info                   |


### PR DESCRIPTION
### PR Prelude

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

currently, we only got `GoImports` cmd to format imports without `GoFmt` cmd to format the current Go file.
