### PR TITLE
fix some issues on windows

### DIFF
--- a/config/main.vim
+++ b/config/main.vim
@@ -41,9 +41,9 @@ else
     return resolve(a:path)
   endfunction
 endif
-let g:_spacevim_root_dir = escape(fnamemodify(s:resolve(fnamemodify(expand('<sfile>'),
+let g:_spacevim_root_dir = fnamemodify(s:resolve(fnamemodify(expand('<sfile>'),
       \ ':p:h:h:gs?\\?'.((has('win16') || has('win32')
-      \ || has('win64'))?'\':'/') . '?')), ':p:gs?[\\/]?/?'), ' ')
+      \ || has('win64'))?'\':'/') . '?')), ':p:gs?[\\/]?/?')
 lockvar g:_spacevim_root_dir
 if has('nvim')
   let s:qtdir = split(&rtp, ',')[-1]

--- a/docs/install.cmd
+++ b/docs/install.cmd
@@ -80,7 +80,7 @@ if (!(Test-Path "$HOME\.SpaceVim")) {
 echo ""
 
 if (!(Test-Path "$HOME\vimfiles")) {
-    cmd /c mklink $HOME\vimfiles $repo_path
+    cmd /c mklink /D $HOME\vimfiles $repo_path
 } else {
     echo "[OK] vimfiles already exists"
 	sleep 1
@@ -88,7 +88,7 @@ if (!(Test-Path "$HOME\vimfiles")) {
 echo ""
 
 if (!(Test-Path "$HOME\AppData\Local\nvim")) {
-  cmd /c mklink "$HOME\AppData\Local\nvim" $repo_path
+  cmd /c mklink /D "$HOME\AppData\Local\nvim" $repo_path
 } else {
     echo "[OK] $HOME\AppData\Local\nvim already exists"
 	sleep 1


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [X ] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [X ] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [X ] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?
This fixes two windows issues. First it makes install.cmd use mklink /D instead of mklink, in order to properly create a directory symlink (note it's not /J because there seems to be some code that greps for SYMLINK in the output of dir, and I didn't want to break it)

Second it no longer escapes spaces in g:_spacevim_root_dir. I have a space in my home directory and I was getting `C:/Users/Charles\ Barto/vimfiles/\mode\basic.toml, in SpaceVim#custom#autoconfig which isn't a valid path.
[Please explain **in detail** why the changes in this PR are needed.]
