### PR TITLE
Add: Respect $XDG_CACHE_HOME for the data/cache dir

### DIFF
--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -179,20 +179,41 @@ let g:spacevim_windows_leader          = 's'
 let g:spacevim_enable_insert_leader    = 1
 
 ""
+" @section data_dir, options-data_dir
+" @parentsection options
+" Set the cache directory of SpaceVim. Default is `$XDG_CACHE_HOME` 
+" or if not set `~/.cache¸.
+" >
+"   data_dir = "~/.cache"
+" <
+
+""
+" Set the cache directory of SpaceVim. Default is `$XDG_CACHE_HOME` 
+" or if not set `~/.cache¸.
+" >
+"   let g:spacevim_data_dir = '~/.cache'
+" <
+let g:spacevim_data_dir
+      \ = $XDG_CACHE_HOME != ''
+      \   ? $XDG_CACHE_HOME . SpaceVim#api#import('file').separator
+      \   : expand($HOME. join(['', '.cache', ''],
+      \     SpaceVim#api#import('file').separator))
+
+""
 " @section plugin_bundle_dir, options-plugin_bundle_dir
 " @parentsection options
-" Set the cache directory of plugins. Default is `~/.cache/vimfiles`.
+" Set the cache directory of plugins. Default is `$data_dir/vimfiles`.
 " >
 "   plugin_bundle_dir = "~/.cache/vimplugs"
 " <
 
 ""
-" Set the cache directory of plugins. Default is `~/.cache/vimfiles`.
+" Set the cache directory of plugins. Default is `$data_dir/vimfiles`.
 " >
-"   let g:spacevim_plugin_bundle_dir = '~/.cache/vimplugs'
+"   let g:spacevim_plugin_bundle_dir = g:spacevim_data_dir.'/vimplugs'
 " <
 let g:spacevim_plugin_bundle_dir
-      \ = $HOME. join(['', '.cache', 'vimfiles', ''],
+      \ = g:spacevim_data_dir . join(['vimfiles', ''],
       \ SpaceVim#api#import('file').separator)
 
 ""

--- a/autoload/SpaceVim/custom.vim
+++ b/autoload/SpaceVim/custom.vim
@@ -136,7 +136,7 @@ function! SpaceVim#custom#write(force) abort
 endfunction
 
 function! s:path_to_fname(path) abort
-  return expand('~/.cache/SpaceVim/conf/') . substitute(a:path, '[\\/:;.]', '_', 'g') . '.json'
+  return expand(g:spacevim_data_dir.'/SpaceVim/conf/') . substitute(a:path, '[\\/:;.]', '_', 'g') . '.json'
 endfunction
 
 function! SpaceVim#custom#load() abort
@@ -189,7 +189,7 @@ function! s:load_glob_conf() abort
   if filereadable(global_dir . 'init.toml')
     let g:_spacevim_global_config_path = global_dir . 'init.toml'
     let local_conf = global_dir . 'init.toml'
-    let local_conf_cache = s:FILE.unify_path(expand('~/.cache/SpaceVim/conf/init.json'))
+    let local_conf_cache = s:FILE.unify_path(expand(g:spacevim_data_dir.'/SpaceVim/conf/init.json'))
     let &rtp = global_dir . ',' . &rtp
     if getftime(local_conf) < getftime(local_conf_cache)
       let conf = s:JSON.json_decode(join(readfile(local_conf_cache, ''), ''))

--- a/autoload/SpaceVim/default.vim
+++ b/autoload/SpaceVim/default.vim
@@ -67,7 +67,7 @@ function! SpaceVim#default#options() abort
   set backup
   set undofile
   set undolevels=1000
-  let g:data_dir = $HOME . '/.cache/SpaceVim/'
+  let g:data_dir = g:spacevim_data_dir.'/SpaceVim/'
   let g:backup_dir = g:data_dir . 'backup'
   let g:swap_dir = g:data_dir . 'swap'
   let g:undo_dir = g:data_dir . 'undofile'
@@ -87,14 +87,14 @@ function! SpaceVim#default#options() abort
   if finddir(g:conf_dir) ==# ''
     silent call mkdir(g:conf_dir, 'p', 0700)
   endif
+  execute 'set undodir='.g:undo_dir
+  execute 'set backupdir='.g:backup_dir
+  execute 'set directory='.g:swap_dir
   unlet g:data_dir
   unlet g:backup_dir
   unlet g:swap_dir
   unlet g:undo_dir
   unlet g:conf_dir
-  set undodir=$HOME/.cache/SpaceVim/undofile
-  set backupdir=$HOME/.cache/SpaceVim/backup
-  set directory=$HOME/.cache/SpaceVim/swap
   " }}}
 
   set nowritebackup

--- a/autoload/SpaceVim/layers/colorscheme.vim
+++ b/autoload/SpaceVim/layers/colorscheme.vim
@@ -89,8 +89,8 @@ function! SpaceVim#layers#colorscheme#config() abort
     " {"fequecnce" : "dalily", "last" : 000000, 'theme' : 'one'}
     " FIXME: when global config cache is updated, check the cache also should
     " be updated
-    if filereadable(expand('~/.cache/SpaceVim/colorscheme_frequence.json'))
-      let conf = s:JSON.json_decode(join(readfile(expand('~/.cache/SpaceVim/colorscheme_frequence.json'), ''), ''))
+    if filereadable(expand(g:spacevim_data_dir.'/SpaceVim/colorscheme_frequence.json'))
+      let conf = s:JSON.json_decode(join(readfile(expand(g:spacevim_data_dir.'/SpaceVim/colorscheme_frequence.json'), ''), ''))
       if s:random_frequency !=# '' && !empty(conf)
         let ctime = localtime()
         if ctime - get(conf, 'last', 0) >= get(s:time,  get(conf, 'fequecnce', ''), 0)
@@ -121,7 +121,7 @@ function! s:update_conf() abort
         \ 'last' : localtime(),
         \ 'theme' : g:spacevim_colorscheme
         \ }
-  call writefile([s:JSON.json_encode(conf)], expand('~/.cache/SpaceVim/colorscheme_frequence.json'))
+  call writefile([s:JSON.json_encode(conf)], expand(g:spacevim_data_dir.'/SpaceVim/colorscheme_frequence.json'))
 endfunction
 
 

--- a/autoload/SpaceVim/plugins.vim
+++ b/autoload/SpaceVim/plugins.vim
@@ -164,12 +164,12 @@ function! s:install_manager() abort
           \ 'dein.vim'], s:Fsep)
   elseif g:spacevim_plugin_manager ==# 'vim-plug'
     "auto install vim-plug
-    if filereadable(expand('~/.cache/vim-plug/autoload/plug.vim'))
+    if filereadable(expand(g:spacevim_data_dir.'/vim-plug/autoload/plug.vim'))
       let g:_spacevim_vim_plug_installed = 1
     else
       if executable('curl')
         exec '!curl -fLo '
-              \ . '~/.cache/vim-plug/autoload/plug.vim'
+              \ . g:spacevim_data_dir.'/vim-plug/autoload/plug.vim'
               \ . ' --create-dirs '
               \ . 'https://raw.githubusercontent.com/'
               \ . 'junegunn/vim-plug/master/plug.vim'
@@ -180,7 +180,7 @@ function! s:install_manager() abort
         echohl None
       endif
     endif
-    exec 'set runtimepath+=~/.cache/vim-plug/'
+    exec 'set runtimepath+='g:spacevim_data_dir.'/vim-plug/'
   endif
 endf
 

--- a/autoload/SpaceVim/plugins/a.vim
+++ b/autoload/SpaceVim/plugins/a.vim
@@ -17,7 +17,7 @@ let s:CMP = SpaceVim#api#import('vim#compatible')
 let s:JSON = SpaceVim#api#import('data#json')
 let s:FILE = SpaceVim#api#import('file')
 let s:conf = '.project_alt.json'
-let s:cache_path = '~/.cache/SpaceVim/a.json'
+let s:cache_path = g:spacevim_data_dir.'/SpaceVim/a.json'
 
 
 " this is for saving the project configuration information. Use the path of

--- a/autoload/SpaceVim/plugins/flygrep.vim
+++ b/autoload/SpaceVim/plugins/flygrep.vim
@@ -35,8 +35,8 @@ let s:grep_timer_id = -1
 let s:preview_timer_id = -1
 let s:grepid = 0
 function! s:read_histroy() abort
-  if filereadable(expand('~/.cache/SpaceVim/flygrep_history'))
-    let _his = s:JSON.json_decode(join(readfile(expand('~/.cache/SpaceVim/flygrep_history'), ''), ''))
+  if filereadable(expand(g:spacevim_data_dir.'/SpaceVim/flygrep_history'))
+    let _his = s:JSON.json_decode(join(readfile(expand(g:spacevim_data_dir.'/SpaceVim/flygrep_history'), ''), ''))
     if type(_his) ==# type([])
       return _his
     else
@@ -51,10 +51,10 @@ function! s:update_history() abort
     call remove(s:grep_history, index(s:grep_history, s:grep_expr))
   endif
   call add(s:grep_history, s:grep_expr)
-  if !isdirectory(expand('~/.cache/SpaceVim'))
-    call mkdir(expand('~/.cache/SpaceVim'))
+  if !isdirectory(expand(g:spacevim_data_dir.'/SpaceVim'))
+    call mkdir(expand(g:spacevim_data_dir.'/SpaceVim'))
   endif
-  call writefile([s:JSON.json_encode(s:grep_history)], expand('~/.cache/SpaceVim/flygrep_history'))
+  call writefile([s:JSON.json_encode(s:grep_history)], expand(g:spacevim_data_dir.'/SpaceVim/flygrep_history'))
 endfunction
 let s:grep_history = s:read_histroy()
 let s:complete_input_history_num = [0,0]

--- a/autoload/SpaceVim/plugins/manager.vim
+++ b/autoload/SpaceVim/plugins/manager.vim
@@ -81,7 +81,7 @@ function! s:install_manager() abort
           \ 'dein.vim'], s:Fsep)
   elseif g:spacevim_plugin_manager ==# 'vim-plug'
     "auto install vim-plug
-    if filereadable(expand('~/.cache/vim-plug/autoload/plug.vim'))
+    if filereadable(expand(g:spacevim_data_dir.'/vim-plug/autoload/plug.vim'))
       let g:_spacevim_vim_plug_installed = 1
     else
       if s:need_cmd('curl')
@@ -89,14 +89,14 @@ function! s:install_manager() abort
         call s:VIM_CO.system([
               \ 'curl',
               \ '-fLo',
-              \ expand('~/.cache/vim-plug/autoload/plug.vim'),
+              \ expand(g:spacevim_data_dir.'/vim-plug/autoload/plug.vim'),
               \ '--create-dirs',
               \ 'https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
               \ ])
         let g:_spacevim_vim_plug_installed = 1
       endif
     endif
-    exec 'set runtimepath+=~/.cache/vim-plug/'
+    exec 'set runtimepath+='.g:spacevim_data_dir.'/vim-plug/'
   endif
 endf
 

--- a/autoload/SpaceVim/plugins/tabmanager.vim
+++ b/autoload/SpaceVim/plugins/tabmanager.vim
@@ -228,7 +228,7 @@ function! s:copy_tab() abort
   let s:copy_tab_name = gettabvar(cursor_tab, '_spacevim_tab_name', '')
   exe 'tabnext ' . cursor_tab
   let save_sessionopts = &sessionoptions
-  let tabsession = '~/.cache/SpaceVim/tabmanager_session.vim'
+  let tabsession = g:spacevim_data_dir.'/SpaceVim/tabmanager_session.vim'
   let &sessionoptions = 'winsize'
   exe 'mksession! ' . tabsession
   exe 'tabnext ' . current_tab
@@ -251,7 +251,7 @@ function! s:paste_tab() abort
   let current_tab = tabpagenr()
   let tabid = s:get_cursor_tabnr()
   silent! exe tabid . 'tabnew '
-  silent! exe 'so ~/.cache/SpaceVim/tabmanager_session.vim'
+  silent! exe 'so '.g:spacevim_data_dir.'/SpaceVim/tabmanager_session.vim'
   call settabvar(tabpagenr(),
         \ 'spacevim_tabman_expandable',
         \ s:copy_tab_expand_status)

--- a/config/functions.vim
+++ b/config/functions.vim
@@ -61,7 +61,7 @@ func! Show_Log_for_current_plugin()
         let @a = a_save
     endtry
     call unite#start([['output/shellcmd',
-                \ 'git --no-pager -C ~/.cache/vimfiles/repos/github.com/'
+                \ 'git --no-pager -C '.g:spacevim_data_dir.'/vimfiles/repos/github.com/'
                 \ . plug
                 \ . ' log -n 15 --oneline']], {'log': 1, 'wrap': 1,'start_insert':0})
     exe "nnoremap <buffer><CR> :call <SID>Opencommit('". plug ."', strpart(split(getline('.'),'[33m')[1],0,7))<CR>"

--- a/config/plugins/ctrlp.vim
+++ b/config/plugins/ctrlp.vim
@@ -18,7 +18,7 @@ let g:ctrlp_show_hidden = get(g:, 'ctrlp_show_hidden', 1)
 "for caching
 let g:ctrlp_use_caching = get(g:, 'ctrlp_use_caching', 500)
 let g:ctrlp_clear_cache_on_exit = get(g:, 'ctrlp_clear_cache_on_exit', 1)
-let g:ctrlp_cache_dir = get(g:, 'ctrlp_cache_dir', $HOME.'/.cache/ctrlp')
+let g:ctrlp_cache_dir = get(g:, 'ctrlp_cache_dir', g:spacevim_data_dir.'/ctrlp')
 "let g:ctrlp_map = ',,'
 "let g:ctrlp_open_multiple_files = 'v'
 "if you have install ag, the g:ctrlp_custom_ignore will not work

--- a/config/plugins/neocomplete.vim
+++ b/config/plugins/neocomplete.vim
@@ -1,5 +1,5 @@
 let g:neocomplete#data_directory= get(g:, 'neocomplete#data_directory',
-      \ '~/.cache/neocomplete')
+      \ g:spacevim_data_dir.'/neocomplete')
 let g:acp_enableAtStartup = get(g:, 'acp_enableAtStartup', 0)
 let g:neocomplete#enable_at_startup =
       \ get(g:, 'neocomplete#enable_at_startup', 1)

--- a/config/plugins/unite.vim
+++ b/config/plugins/unite.vim
@@ -37,7 +37,7 @@ let g:unite_source_file_rec_max_depth = get(g:,
       \ 'unite_source_file_rec_max_depth', 6)
 let g:unite_enable_ignore_case = get(g:, 'unite_enable_ignore_case', 1)
 let g:unite_enable_smart_case = get(g:, 'unite_enable_smart_case', 1)
-let g:unite_data_directory = get(g:, 'unite_data_directory','~/.cache/unite')
+let g:unite_data_directory = get(g:, 'unite_data_directory',g:spacevim_data_dir.'/unite')
 "let g:unite_enable_start_insert=1
 let g:unite_source_history_yank_enable = get(g:,
       \ 'unite_source_history_yank_enable', 1)

--- a/config/plugins/vim-gutentags.vim
+++ b/config/plugins/vim-gutentags.vim
@@ -1,2 +1,2 @@
-let g:gutentags_cache_dir = get(g:, 'gutentags_cache_dir', expand('~/.cache/tags'))
+let g:gutentags_cache_dir = get(g:, 'gutentags_cache_dir', expand(g:spacevim_data_dir.'/tags'))
 let g:gutentags_modules = get(g:, 'gutentags_modules', ['ctags', 'gtags_cscope'])


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

On my companies PC the home directory stays on a network drive and some times the network throughput getting low. Therefore the access to the `$HOME/.cache` dir is slow and neovim is getting slower. I want to be able to change the path, so the path can point to a local directory.

The path `$HOME/.cache` is now configurable through the `$XDG_CACHE_HOME` environment variable or could also be set with the variable `g:spacevim_data_dir`. If the later is used, there are some plugins which will still write to `$XDG_CACHE_HOME`.

Even so it adds a new option/functionality, the default behavior is not changed, because the environment variable `$XDG_CACHE_HOME` point normally to `$HOME/.cache`. If `$XDG_CACHE_HOME` is not set, it uses as default `$HOME/.cache`.