### PR TITLE
use gopls in rename command for go

### DIFF
--- a/autoload/SpaceVim/layers/lang/go.vim
+++ b/autoload/SpaceVim/layers/lang/go.vim
@@ -60,6 +60,7 @@ function! SpaceVim#layers#lang#go#config() abort
   let g:syntastic_mode_map = { 'mode': 'active', 'passive_filetypes': ['go'] }
   let g:neomake_go_gometalinter_args = ['--disable-all']
   let g:go_snippet_engine = 'neosnippet'
+  let g:go_rename_command = 'gopls'
 
   if SpaceVim#layers#lsp#check_filetype('go')
     call SpaceVim#mapping#gd#add('go',


### PR DESCRIPTION
### PR Prelude

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps

### Why this change is necessary and useful?

Vim-go uses the deprecated gorename command that doesn't support Go modules. The latest release go gopls support renaming and is the new way forward.

See: 
* https://github.com/golang/go/issues/27571
* https://github.com/fatih/vim-go/issues/2366
