### PR TITLE
Add shortcut to use NERDCommenterAltDelims

### DIFF
--- a/autoload/SpaceVim/layers/core.vim
+++ b/autoload/SpaceVim/layers/core.vim
@@ -291,6 +291,7 @@ function! SpaceVim#layers#core#config() abort
   nnoremap <silent> <Plug>CommentToLineInvert :call <SID>comment_to_line(1)<Cr>
   nnoremap <silent> <Plug>CommentParagraphs :call <SID>comment_paragraphs(0)<Cr>
   nnoremap <silent> <Plug>CommentParagraphsInvert :call <SID>comment_paragraphs(1)<Cr>
+  call SpaceVim#mapping#space#def('nmap', ['c', 'a'], '<Plug>NERDCommenterAltDelims', 'switch-to-alternative-delims', 0, 1)
   call SpaceVim#mapping#space#def('nmap', ['c', 'l'], '<Plug>NERDCommenterInvert', 'toggle-comment-lines', 0, 1)
   call SpaceVim#mapping#space#def('nmap', ['c', 'L'], '<Plug>NERDCommenterComment', 'comment-lines', 0, 1)
   call SpaceVim#mapping#space#def('nmap', ['c', 'u'], '<Plug>NERDCommenterUncomment', 'uncomment-lines', 0, 1)

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -956,6 +956,7 @@ Comments are handled by [nerdcommenter](https://github.com/scrooloose/nerdcommen
 | Key Bindings | Descriptions                                            |
 | ------------ | ------------------------------------------------------- |
 | `SPC ;`      | comment operator                                        |
+| `SPC c a`    | switch to the alternative set of delimiters             |
 | `SPC c h`    | hide/show comments                                      |
 | `SPC c l`    | toggle comment lines                                    |
 | `SPC c L`    | comment lines                                           |


### PR DESCRIPTION
### PR Prelude

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

NERDCommenter supports using "alternative" delimiters for comments, via the NERDCommenterAltDelims function. This functionality is currently not available via spacevim's shortcuts. This PR adds a new `SPC c a` shortcut that invokes NERDCommenterAltDelims and it allows to switch to alternative delimiters.