### PR TITLE
3421 Extend permalink clipboard copy support

### DIFF
--- a/autoload/SpaceVim/util.vim
+++ b/autoload/SpaceVim/util.vim
@@ -150,13 +150,15 @@ fu! SpaceVim#util#CopyToClipboard(...) abort
         if len(remotes) > 0
           let remote = remotes[0]
           if stridx(remote, '@') > -1
-            let repo_url = 'https://github.com/'. split(split(remote,' ')[0],':')[1]
+            let repo_url = split(split(remote, '@')[1], ':')[0]
+            let repo_url = 'https://'. repo_url. '/'. split(split(remote,' ')[0],':')[1]
             let repo_url = strpart(repo_url, 0, len(repo_url) - 4)
           else
             let repo_url = split(remote,' ')[0]
             let repo_url = strpart(repo_url, stridx(repo_url, 'http'),len(repo_url) - 4 - stridx(repo_url, 'http'))
           endif
-          let f_url =repo_url. '/blob/'. branch[:-2] . '/'. strpart(expand('%:p'), len(repo_home) + 1, len(expand('%:p')))
+          let head_sha = systemlist('git rev-parse HEAD')[0] 
+          let f_url =repo_url. '/blob/'. head_sha. '/'. strpart(expand('%:p'), len(repo_home) + 1, len(expand('%:p')))
           if s:SYSTEM.isWindows
             let f_url = substitute(f_url, '\', '/', 'g')
           endif


### PR DESCRIPTION
Resolves #3421 

Now supports non-standard ssh remotes (ie - not github.com)

Also, now by default copies the permalink WRT the current head's SHA,
 as opposed to to name of the current branch- For example:

https://github.com/SpaceVim/SpaceVim/blob/13b28149d8d4a4b96ed59c5da6592f7296b5c4b0/autoload/SpaceVim/util.vim#L143-L206

As opposed to:

https://github.com/SpaceVim/SpaceVim/blob/master/autoload/SpaceVim/util.vim#L143-L206

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

I wanted to be able to copy links to code from my enterprise server. 
I also wanted them to be permalinks, that embed well in GitHub threads, and also are tied to a specific point at the commit history, rather than the head of a branch