### PR TITLE
Fix: missing plugin dependency in lang#go layer #3444

### DIFF
--- a/autoload/SpaceVim/layers/lang/go.vim
+++ b/autoload/SpaceVim/layers/lang/go.vim
@@ -41,7 +41,9 @@
 
 
 function! SpaceVim#layers#lang#go#plugins() abort
-  let plugins = [['fatih/vim-go', { 'on_ft' : 'go', 'loadconf_before' : 1}]]
+  let plugins = [
+        \['fatih/vim-go', { 'on_ft' : 'go', 'loadconf_before' : 1}],
+        \['kien/ctrlp.vim']]
   if has('nvim') && g:spacevim_autocomplete_method ==# 'deoplete'
     call add(plugins, ['zchee/deoplete-go', {'on_ft' : 'go', 'build': 'make'}])
   endif


### PR DESCRIPTION
### PR Prelude

- [X] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [X] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

This change is necessary and useful to lang#go layer to be usable by every new user.
It fixes #3444 .

### Feature request & Open to suggestions
As my level with vim script is really basic I leave one feature I judge important for user concerns that is letting the user choose either ctrlp.vim or fzf.vim within layer options