### PR TITLE
Allow to use prefix count to specify length of password.

### DIFF
--- a/autoload/SpaceVim/layers/edit.vim
+++ b/autoload/SpaceVim/layers/edit.vim
@@ -552,31 +552,31 @@ endfunction
 
 function! s:insert_simple_password() abort
   let save_register = @k
-  let @k = s:PASSWORD.generate_simple(8)
+  let @k = s:PASSWORD.generate_simple(v:count ? v:count : 8)
   normal! "kPl
   let @k = save_register
 endfunction
 function! s:insert_stronger_password() abort
   let save_register = @k
-  let @k = s:PASSWORD.generate_strong(12)
+  let @k = s:PASSWORD.generate_strong(v:count ? v:count : 12)
   normal! "kPl
   let @k = save_register
 endfunction
 function! s:insert_paranoid_password() abort
   let save_register = @k
-  let @k = s:PASSWORD.generate_paranoid(20)
+  let @k = s:PASSWORD.generate_paranoid(v:count ? v:count : 20)
   normal! "kPl
   let @k = save_register
 endfunction
 function! s:insert_numerical_password() abort
   let save_register = @k
-  let @k = s:PASSWORD.generate_numeric(4)
+  let @k = s:PASSWORD.generate_numeric(v:count ? v:count : 4)
   normal! "kPl
   let @k = save_register
 endfunction
 function! s:insert_phonetically_password() abort
   let save_register = @k
-  let @k = s:PASSWORD.generate_phonetic(8)
+  let @k = s:PASSWORD.generate_phonetic(v:count ? v:count : 8)
   normal! "kPl
   let @k = save_register
 endfunction

--- a/docs/cn/documentation.md
+++ b/docs/cn/documentation.md
@@ -899,6 +899,8 @@ call SpaceVim#custom#SPC('nnoremap', ['f', 't'], 'echom "hello world"', 'test cu
 | `SPC i U 4` | insert UUIDv4 (use universal argument to insert with CID format)      |
 | `SPC i U U` | insert UUIDv4 (use universal argument to insert with CID format)      |
 
+**提示：** 您可以使用前缀参数指定密码字符的数量，（例如，`10 SPC i p 1` 将生成 `10` 个简单密码字符）
+
 #### 增加或减小数字
 
 | 快捷键    | 功能描述                                 |

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -33,7 +33,7 @@ description: "General documentation about how to using SpaceVim, including the q
 - [General usage](#general-usage)
   - [Native functions](#native-functions)
   - [Visual mode key bindings](#visual-mode-key-bindings)
-  - [Command line mode key bindings](#command-line-mode-key-bidnings)
+  - [Command line mode key bindings](#command-line-mode-key-bindings)
   - [Mappings guide](#mappings-guide)
   - [Editing](#editing)
     - [Text manipulation commands](#text-manipulation-commands)
@@ -931,6 +931,8 @@ Text insertion commands (start with `i`):
 | `SPC i U 1`  | insert UUIDv1 (use universal argument to insert with CID format)      |
 | `SPC i U 4`  | insert UUIDv4 (use universal argument to insert with CID format)      |
 | `SPC i U U`  | insert UUIDv4 (use universal argument to insert with CID format)      |
+
+**Tips:** You can specify number of password characters using prefix argument, (i.e. `10 SPC i p 1` will generate 10 characters of simple password)
 
 #### Increase/Decrease numbers
 


### PR DESCRIPTION
In the password insertion functions it is now possible to use
count prefix to specify another password length instead of the default.

The defaults did not change and are used if v:count is 0.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

You can generate passwords with an arbitrary length.

Note: I added a tip into documentation as well, but as I currently can't speak Chinese, the cn version is Google Translator's output and needs improvement.
