### PR TITLE
Fix projectmanager from finding ~/SpaceVim.d in home directory on windows

### DIFF
--- a/autoload/SpaceVim/default.vim
+++ b/autoload/SpaceVim/default.vim
@@ -126,6 +126,11 @@ function! SpaceVim#default#options() abort
   set shortmess+=s
   " Do not wrap lone lines
   set nowrap
+  
+  " set shellslash for filename comparisons
+  if exists('+shellslash')
+    set shellslash
+  endif
 
   set foldtext=SpaceVim#default#Customfoldtext()
 

--- a/autoload/SpaceVim/plugins/projectmanager.vim
+++ b/autoload/SpaceVim/plugins/projectmanager.vim
@@ -169,8 +169,8 @@ function! s:find_root_directory() abort
     endif
     let ftype = getftype(dir)
     if ( ftype ==# 'dir' || ftype ==# 'file' ) 
-          \ && expand(dir) !=# expand('~/.SpaceVim.d/')
-          \ && expand(dir) !=# expand('~/.Rprofile')
+          \ && fnamemodify(dir, ':p') !=# fnamemodify('~/.SpaceVim.d/', ':p')
+          \ && fnamemodify(dir, ':p') !=# fnamemodify('~/.Rprofile', ':p')
       let dir = s:FILE.unify_path(fnamemodify(dir, ':p'))
       if ftype ==# 'dir'
         let dir = fnamemodify(dir, ':h:h')

--- a/autoload/SpaceVim/plugins/projectmanager.vim
+++ b/autoload/SpaceVim/plugins/projectmanager.vim
@@ -169,8 +169,8 @@ function! s:find_root_directory() abort
     endif
     let ftype = getftype(dir)
     if ( ftype ==# 'dir' || ftype ==# 'file' ) 
-          \ && dir !=# expand('~/.SpaceVim.d/')
-          \ && dir !=# expand('~/.Rprofile')
+          \ && expand(dir) !=# expand('~/.SpaceVim.d/')
+          \ && expand(dir) !=# expand('~/.Rprofile')
       let dir = s:FILE.unify_path(fnamemodify(dir, ':p'))
       if ftype ==# 'dir'
         let dir = fnamemodify(dir, ':h:h')


### PR DESCRIPTION
### Why this change is necessary and useful?
the project manager detects ~/SpaceVim.d in windows as a top level project. 

The current check for catching this is here:
https://github.com/SpaceVim/SpaceVim/blob/master/autoload/SpaceVim/plugins/projectmanager.vim#L172 

It compares the **strings** not the **paths** so on windows where paths use backslash, this comparison fails. 

I set the option **setslash** and also expand the path when comparing. 