### PR TITLE
fzf.vim :: FzfFiles :: Allow fzf custom options

### DIFF
--- a/autoload/SpaceVim/layers/fzf.vim
+++ b/autoload/SpaceVim/layers/fzf.vim
@@ -204,7 +204,7 @@ endfunction
 command! FzfFiles call <SID>files()
 function! s:files() abort
   let s:source = 'files'
-  call fzf#run(s:wrap('files', {'sink': 'e', 'options': '--reverse', 'down' : '40%'}))
+  call fzf#run(s:wrap('files', {'sink': 'e', 'options': '--reverse' . ' ' . get(g:, 'fzf_files_options', ''), 'down' : '40%'}))
 endfunction
 
 let s:source = ''


### PR DESCRIPTION
# PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [X] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [X] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Allow using a global variable `fzf_files_options` to include additional fzf options when executing, for example, `:FzfFiles` by triggering `CTRL-p`.

Example of global variable: `let g:fzf_files_options = '--exact --inline-info --preview-window right:65%:noborder --preview "bat --style=changes,numbers,snip --wrap=never {}"'`