### PR TITLE
add tagbar documentation for markdonw layer

### DIFF
--- a/docs/layers/lang/markdown.md
+++ b/docs/layers/lang/markdown.md
@@ -89,5 +89,5 @@ If you don't want to install php, you can use [mdctags](https://github.com/wsdje
 | ------------ | ------------- | ------------------------------------------------------ |
 | `SPC b f`    | Normal        | Format current buffer                                  |
 | `SPC l k`    | Normal/Visual | Add URL link for word under cursor or slected word     |
-| `SPC l k`    | Normal/Visual | Add picture link for word under cursor or slected word |
+| `SPC l K`    | Normal/Visual | Add picture link for word under cursor or slected word |
 | `SPC l p`    | Normal        | Real-time markdown preview                             |

--- a/docs/layers/lang/markdown.md
+++ b/docs/layers/lang/markdown.md
@@ -77,6 +77,12 @@ Enable/Disable wcwidth for detecting the length of a table cell, default is 0. T
 
 Bullet marker to use for list items (`'-'`, `'*'`, or `'+'`, default: `'-'`).
 
+## Tagbar
+
+To have a table of the headings in the tagbar (toggled by [F2]), make sure php is in your `$PATH` (you can test this in SpaceVim : `:!php --version` should print something about php).
+
+If you don't want to install php, you can use [mdctags](https://github.com/wsdjeg/mdctags.rs) as an alternative.
+
 ## Key bindings
 
 | Key bindings | mode          | Descriptions                                           |


### PR DESCRIPTION
 tagbar-markdown need php to work.

mdctags don't. (maybe it should be the default plugin used for that ?)

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [V] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [V] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [V] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]

Document little annoying things save times :-)