### PR TITLE
Change how highlight syntax IDs are looked up.

### DIFF
--- a/autoload/SpaceVim/api/vim/highlight.vim
+++ b/autoload/SpaceVim/api/vim/highlight.vim
@@ -21,8 +21,8 @@ let s:self = {}
 " reverse: if reverse
 
 function! s:self.group2dict(name) abort
-    let id = index(map(range(1999), "synIDattr(v:val, 'name')"), a:name)
-    if id == -1
+    let id = hlID(a:name)
+    if id == 0
         return {
                     \ 'name' : '',
                     \ 'ctermbg' : '',

--- a/test/api/vim/highlight.vader
+++ b/test/api/vim/highlight.vader
@@ -2,6 +2,19 @@ Execute ( SpaceVim api: vim#highlight ):
   let hi = SpaceVim#api#import('vim#highlight')
   set termguicolors
   highlight TestAPIVimHighlight ctermfg=11 guifg=#89DDFF guibg=#212121
-  AssertEqual hi.group2dict('TestAPIVimHighlight').guibg, '#212121'
-  AssertEqual hi.group2dict('TestAPIVimHighlight').guifg, '#89ddff'
-  AssertEqual hi.group2dict('TestAPIVimHighlight').ctermfg, '11'
+
+  let test_api_hi = hi.group2dict('TestAPIVimHighlight')
+  AssertEqual test_api_hi.guibg, '#212121'
+  AssertEqual test_api_hi.guifg, '#89ddff'
+  AssertEqual test_api_hi.ctermfg, '11'
+
+  let unknown_hi = hi.group2dict('UnknownHighlightGroup')
+  AssertEqual unknown_hi.name, ''
+  AssertEqual unknown_hi.ctermbg, ''
+  AssertEqual unknown_hi.ctermfg, ''
+  AssertEqual unknown_hi.bold, ''
+  AssertEqual unknown_hi.italic, ''
+  AssertEqual unknown_hi.reverse, ''
+  AssertEqual unknown_hi.underline, ''
+  AssertEqual unknown_hi.guibg, ''
+  AssertEqual unknown_hi.guifg, ''


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

There is a function called hlID that can be used to look up the syntax ID directly. On my laptop, this saves a bit over 100ms during start up when loading the tabline and the statusline.