### PR TITLE
Add new filemanager variant 'coc-explorer'

### DIFF
--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -772,11 +772,11 @@ let g:spacevim_colorscheme_default     = 'desert'
 " @section filemanager, options-filemanager
 " @parentsection options
 " The default file manager of SpaceVim. Default is 'vimfiler'.
-" you can also use nerdtree or defx
+" you can also use nerdtree, defx or coc-explorer
 
 ""
 " The default file manager of SpaceVim. Default is 'vimfiler'.
-" you can also use nerdtree or defx
+" you can also use nerdtree, defx or coc-explorer
 let g:spacevim_filemanager             = 'vimfiler'
 ""
 " @section filetree_direction, options-filetree_direction

--- a/autoload/SpaceVim/layers/core.vim
+++ b/autoload/SpaceVim/layers/core.vim
@@ -221,6 +221,13 @@ function! SpaceVim#layers#core#config() abort
     call SpaceVim#mapping#space#def('nnoremap', ['f', 'T'], 'Defx -no-toggle', 'show-file-tree', 1)
     call SpaceVim#mapping#space#def('nnoremap', ['f', 'o'], "Defx  -no-toggle -search=`expand('%:p')` `stridx(expand('%:p'), getcwd()) < 0? expand('%:p:h'): getcwd()`", 'open-file-tree', 1)
     call SpaceVim#mapping#space#def('nnoremap', ['b', 't'], 'exe "Defx -no-toggle " . fnameescape(expand("%:p:h"))', 'show-file-tree-at-buffer-dir', 1)
+  elseif g:spacevim_filemanager ==# 'coc-explorer'
+    call SpaceVim#mapping#space#def('nnoremap', ['f', 't'], 'CocCommand explorer --toggle', 'toggle-file-tree', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['f', 'T'], 'CocCommand explorer --no-toggle', 'show-file-tree', 1)
+    " TODO what is the difference betwee `leader b t` and `leader f o`
+    " TODO check is eplorer --reavel success, then if not open new tree
+    call SpaceVim#mapping#space#def('nnoremap', ['f', 'o'], 'exe "CocCommand explorer --no-toggle " . fnameescape(expand("%:p:h"))', 'open-file-tree', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['b', 't'], 'exe "CocCommand explorer --no-toggle " . fnameescape(expand("%:p:h"))', 'show-file-tree-at-buffer-dir', 1)
   endif
   call SpaceVim#mapping#space#def('nnoremap', ['f', 'y'], 'call SpaceVim#util#CopyToClipboard()', 'show-and-copy-buffer-filename', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['f', 'Y'], 'call SpaceVim#util#CopyToClipboard(1)', 'show-and-copy-buffer-filename', 1)
@@ -874,6 +881,14 @@ function! s:explore_current_dir(cur) abort
       exe 'e ' . getcwd() 
     else
       NERDTreeCWD
+    endif
+  elseif g:spacevim_filemanager ==# 'coc-explorer'
+    if !a:cur
+      let g:_spacevim_autoclose_filetree = 0
+      CocCommand explorer -no-toggle `getcwd()`
+      let g:_spacevim_autoclose_filetree = 1
+    else
+      CocCommand explorer -no-toggle
     endif
   elseif g:spacevim_filemanager ==# 'defx'
     if !a:cur

--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -452,6 +452,9 @@ function! SpaceVim#layers#core#statusline#get(...) abort
   elseif &filetype ==# 'nerdtree'
     return '%#SpaceVim_statusline_ia#' . s:winnr(1) . '%#SpaceVim_statusline_ia_SpaceVim_statusline_b#' . s:lsep
           \ . '%#SpaceVim_statusline_b# Nerdtree %#SpaceVim_statusline_b_SpaceVim_statusline_c#' . s:lsep . ' '
+  elseif &filetype ==# 'coc-explorer'
+    return '%#SpaceVim_statusline_ia#' . s:winnr(1) . '%#SpaceVim_statusline_ia_SpaceVim_statusline_b#' . s:lsep
+          \ . '%#SpaceVim_statusline_b# Coc-Explorer %#SpaceVim_statusline_b_SpaceVim_statusline_c#' . s:lsep . ' '
   elseif &filetype ==# 'Mundo'
     return '%#SpaceVim_statusline_ia#' . s:winnr(1) . '%#SpaceVim_statusline_ia_SpaceVim_statusline_b#' . s:lsep
           \ . '%#SpaceVim_statusline_b# Mundo %#SpaceVim_statusline_b_SpaceVim_statusline_c#' . s:lsep . ' '

--- a/autoload/SpaceVim/plugins/projectmanager.vim
+++ b/autoload/SpaceVim/plugins/projectmanager.vim
@@ -126,6 +126,8 @@ function! SpaceVim#plugins#projectmanager#open(project) abort
     Startify | NERDTree
   elseif g:spacevim_filemanager ==# 'defx'
     Startify | Defx
+  elseif g:spacevim_filemanager ==# 'coc-explorer'
+    Startify | CocCommand explorer 
   endif
 endfunction
 

--- a/autoload/SpaceVim/plugins/windisk.vim
+++ b/autoload/SpaceVim/plugins/windisk.vim
@@ -70,6 +70,8 @@ function! s:open_disk(d) abort
   if g:spacevim_filemanager ==# 'vimfiler'
     exe 'VimFiler -no-toggle ' . disk
   elseif g:spacevim_filemanager ==# 'nerdtree'
+  elseif g:spacevim_filemanager ==# 'coc-explorer'
+    exe 'CocCommand explorer ' . disk
   elseif g:spacevim_filemanager ==# 'defx'
     exe 'Defx -no-toggle -no-resume ' . disk
   endif

--- a/doc/SpaceVim.txt
+++ b/doc/SpaceVim.txt
@@ -454,7 +454,7 @@ to disable this key binding, set this option to empty string.
 FILEMANAGER                                     *SpaceVim-options-filemanager*
 
 The default file manager of SpaceVim. Default is 'vimfiler'. you can also use
-nerdtree or defx
+nerdtree, defx or coc-explorer
 
 ==============================================================================
 FILETREE_DIRECTION                       *SpaceVim-options-filetree_direction*
@@ -1086,7 +1086,7 @@ installed.
 
                                                       *g:spacevim_filemanager*
 The default file manager of SpaceVim. Default is 'vimfiler'. you can also use
-nerdtree or defx
+nerdtree, defx or coc-explorer
 
                                                *g:spacevim_filetree_direction*
 Config the direction of file tree. Default is 'right'. you can also set to

--- a/docs/cn/documentation.md
+++ b/docs/cn/documentation.md
@@ -720,6 +720,7 @@ SpaceVim 使用 vimfiler 作为默认的文件树插件，默认的快捷键是 
     # 文件树插件可选值包括：
     # - vimfiler （默认）
     # - nerdtree
+    # - coc-explorer
     # - defx
     filemanager = "defx"
 ```

--- a/docs/cn/layers/core.md
+++ b/docs/cn/layers/core.md
@@ -16,10 +16,11 @@ lang: zh
 
 nerdtree 或者 vimfiler，默认为 vimfiler，由 `filemanager` 选项控制。
 
-如果需要使用 nerdtree 作为文件树插件，可以添加：
+如果需要使用 nerdtree, coc-explorer 作为文件树插件，可以添加：
 
 ```toml
 [options]
+  #filemanager = "coc-explorer"
   filemanager = "nerdtree"
 ```
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -769,6 +769,7 @@ To change the filemanager plugin:
     # - vimfiler (default)
     # - nerdtree
     # - defx
+    # - coc-explorer
     filemanager = "defx"
 ```
 
@@ -1177,7 +1178,7 @@ can be get by `<Leader> q r`, if you want to disable this feature, you can use `
 | Key Bindings | Descriptions                     |
 | ------------ | -------------------------------- |
 | `<F2>`       | Toggle tagbar                    |
-| `<F3>`       | Toggle Vimfiler                  |
+| `<F3>`       | Toggle Vimfiler/ coc-explorer    |
 | `Ctrl-Down`  | Move to split below (`Ctrl-w j`) |
 | `Ctrl-Up`    | Move to upper split (`Ctrl-w k`) |
 | `Ctrl-Left`  | Move to left split (`Ctrl-w h`)  |

--- a/docs/layers/core.md
+++ b/docs/layers/core.md
@@ -24,10 +24,11 @@ This is core layer of SpaceVim, and it is loaded by default.
 
 
 The filetree plugin is included in core layer, by default `vimfiler` is used as filetree manager.
-To use nerdtree or defx, please add following snippet into your configuration file.
+To use nerdtree, defx or coc-explorer, please add following snippet into your configuration file.
 
 ```toml
 [options]
+  # filemanager = "coc-explorer"
   filemanager = "nerdtree"
 ```
 


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

I think the coc-explorer filemanager is mature enough for my need and got many feature that vimfiler or nerdtree doesnt seem to have. Also it integrate very well with other coc plugin.

### Todo
- [ ] [config/plugins/coc-explorer.vim](https://github.com/SpaceVim/SpaceVim/blob/77f496f29d5a2f346493dbf25ea489f9a06accb1/config/plugins/nerdtree.vim) file with maybe similar functions than nerdtree ? 
- [ ] auto install
- [ ] It seems there is an nerdtree [integration](https://github.com/SpaceVim/SpaceVim/blob/77f496f29d5a2f346493dbf25ea489f9a06accb1/config/plugins/ctrlp.vim#L46) with ctrlp, can it be replicated with coc-explorer 
- [ ] handle hidden file option
- [ ] handle position of the filetree
- [x] assign bindings
- [x] update doc
- [ ] what is the difference between `leader f o` and `leader b t` ?
- [ ] create .vader test file