### PR TITLE
fix Leaderf neoyank.

### DIFF
--- a/autoload/SpaceVim/layers/core/statusline.vim
+++ b/autoload/SpaceVim/layers/core/statusline.vim
@@ -568,6 +568,7 @@ function! SpaceVim#layers#core#statusline#init() abort
   augroup END
 endfunction
 
+nnoremap <silent><c-l> <c-l>:let &l:statusline = SpaceVim#layers#core#statusline#get(1)<cr>
 let s:colors_template = SpaceVim#mapping#guide#theme#gruvbox#palette()
 
 function! SpaceVim#layers#core#statusline#def_colors() abort

--- a/autoload/SpaceVim/layers/leaderf.vim
+++ b/autoload/SpaceVim/layers/leaderf.vim
@@ -355,6 +355,7 @@ endfunction
 
 func! s:neoyank(...)
   let yank = []
+  call neoyank#update()
   for text in neoyank#_get_yank_histories()['"']
     call add(yank, '": ' . join(split(text[0], "\n"), '\n'))
   endfor

--- a/config/plugins_before/ultisnips.vim
+++ b/config/plugins_before/ultisnips.vim
@@ -3,4 +3,4 @@ let g:UltiSnipsEditSplit = 'vertical'
 let g:UltiSnipsExpandTrigger = get(g:, 'UltiSnipsExpandTrigger', '<C-j>')
 let g:UltiSnipsJumpBackwardTrigger = get(g:, 'UltiSnipsJumpBackwardTrigger', '<C-j>')
 let g:UltiSnipsJumpForwardTrigger = get(g:, 'UltiSnipsJumpForwardTrigger', '<C-j>')
-let g:UltiSnipsSnippetsDir = '~/.SpaceVim.d/UltiSnips'
+let g:UltiSnipsSnippetDirectories=[$HOME.'/.SpaceVim.d/UltiSnips']


### PR DESCRIPTION
And provide `nnoremap <C-L>` to refresh statusline.
And fix dirctory name of Ultisnips.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?
* `neoyank#update()` need to be called  before execute `Leaderf neoyank`
* `<C-L>` will refresh statusline. Some shortcut in neovim will trigger `WinLeave` but not `WinEnter`.
    In fact, you just want to type `<C-W>o` to close other windows. Then, statusline has been changed becase `WinLeave`
* the right dir variable is `UltiSnipsSnippetDirectories` , not `UltiSnipsSnippetsDir`
