### PR TITLE
Fix: enable clean startup in VimR

### DIFF
--- a/autoload/SpaceVim/default.vim
+++ b/autoload/SpaceVim/default.vim
@@ -21,14 +21,22 @@ function! SpaceVim#default#options() abort
     set guioptions-=b " Hide bottom scrollbar
     set showtabline=0 " Hide tabline
     set guioptions-=e " Hide tab
-    if s:SYSTEM.isWindows
-      " please install the font in 'Dotfiles\font'
-      set guifont=DejaVu_Sans_Mono_for_Powerline:h11:cANSI:qDRAFT
-    elseif s:SYSTEM.isOSX
-      set guifont=DejaVu\ Sans\ Mono\ for\ Powerline:h11
-    else
-      set guifont=DejaVu\ Sans\ Mono\ for\ Powerline\ 11
-    endif
+    try
+      if s:SYSTEM.isWindows
+        " please install the font in 'Dotfiles\font'
+        set guifont=DejaVu_Sans_Mono_for_Powerline:h11:cANSI:qDRAFT
+      elseif s:SYSTEM.isOSX
+        set guifont=DejaVu\ Sans\ Mono\ for\ Powerline:h11
+      else
+        set guifont=DejaVu\ Sans\ Mono\ for\ Powerline\ 11
+      endif
+    catch /^Vim\%((\a\+)\)\=:E518/
+      if has('gui_vimr')
+        " VimR has disabled support for guifont
+      else
+        throw v:exception
+      endif
+    endtry
   endif
 
   " indent use backspace delete indent, eol use backspace delete line at

--- a/config/general.vim
+++ b/config/general.vim
@@ -29,5 +29,9 @@ if g:spacevim_hiddenfileinfo == 1 && has('patch-7.4.1570')
     set shortmess+=F
 endif
 if has('gui_running') && !empty(g:spacevim_guifont)
-  let &guifont = g:spacevim_guifont
+  if has('gui_vimr')
+    " VimR has removed support for guifont
+  else
+    let &guifont = g:spacevim_guifont
+  endif
 endif


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

This is a follow-on to #1651; I found that I was still seeing the error message
mentioned in that PR under VimR 0.32.0.  Fortunately VimR has a specific
feature `gui_vimr` to test against; recent builds of VimR do set `gui_running`,
so the fix from that previous PR no longer works.