### PR TITLE
Fix make error for missing lib folder

### DIFF
--- a/bundle/vimproc.vim/.gitignore
+++ b/bundle/vimproc.vim/.gitignore
@@ -1,4 +1,5 @@
 lib/*
+!lib/.gitkeep
 doc/tags
 *.obj
 *.o


### PR DESCRIPTION
#3021 # PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

The repo `vimproc.vim` has a wrong setting in .gitignore file, which
should track `lib/.gitkeep` file rather than ignore the whole lib
folder.

I have a similar pull request to fix root issue,
https://github.com/Shougo/vimproc.vim/pull/301

Without folder `lib`, you will get error message when starting SpaceVim
![image](https://user-images.githubusercontent.com/90078/85367116-37bce880-b55b-11ea-943e-516229ddeb8e.png)

Here is the error message when I run `make` as the document said:
```
# bright @ shacng035wqrt in ~/.SpaceVim/bundle/vimproc.vim on git:master o [13:25:35]
$ make
make -f make_unix.mak
make[1]: Entering directory '/home/bright/.SpaceVim/bundle/vimproc.vim'
cc -W -O2 -Wall -Wno-unused -Wno-unused-parameter -std=gnu99 -pedantic -shared -fPIC  -o lib/vimproc_linux64.so src/proc.c -lutil
/usr/bin/ld: cannot open output file lib/vimproc_linux64.so: No such file or directory
collect2: error: ld returned 1 exit status
make[1]: *** [make_unix.mak:17: lib/vimproc_linux64.so] Error 1
make[1]: Leaving directory '/home/bright/.SpaceVim/bundle/vimproc.vim'
make: *** [Makefile:66: all] Error 2
```

