### PR TITLE
Fix: comment invert yank doesn't work in visual mode

### DIFF
--- a/autoload/SpaceVim/layers/core.vim
+++ b/autoload/SpaceVim/layers/core.vim
@@ -733,11 +733,10 @@ function! s:comment_invert_yank(visual) range abort
   if a:visual
     normal! gvy
     normal! gv
-    exe 'normal' "\<Plug>NERDCommenterInvert"
   else
     normal! yy
-    call feedkeys("\<Plug>NERDCommenterInvert")
   endif
+  call feedkeys("\<Plug>NERDCommenterInvert")
 endfunction
 
 function! s:better_easymotion_overwin_line(is_visual) abort

--- a/autoload/SpaceVim/layers/core.vim
+++ b/autoload/SpaceVim/layers/core.vim
@@ -288,7 +288,8 @@ function! SpaceVim#layers#core#config() abort
   " Toggles the comment state of the selected line(s). If the topmost selected
   " line is commented, all selected lines are uncommented and vice versa.
   nnoremap <silent> <Plug>CommentToLine :call <SID>comment_to_line(0)<Cr>
-  nnoremap <silent> <Plug>CommenterInvertYank :call <SID>comment_invert_yank()<Cr>
+  nnoremap <silent> <Plug>CommenterInvertYank :call <SID>comment_invert_yank(0)<Cr>
+  vnoremap <silent> <Plug>CommenterInvertYank :call <SID>comment_invert_yank(1)<Cr>
   nnoremap <silent> <Plug>CommentToLineInvert :call <SID>comment_to_line(1)<Cr>
   nnoremap <silent> <Plug>CommentParagraphs :call <SID>comment_paragraphs(0)<Cr>
   nnoremap <silent> <Plug>CommentParagraphsInvert :call <SID>comment_paragraphs(1)<Cr>
@@ -728,13 +729,15 @@ function! s:comment_to_line(invert) abort
   endif
 endfunction
 
-function! s:comment_invert_yank() abort
-  if mode() ==# 'n'
+function! s:comment_invert_yank(visual) range abort
+  if a:visual
+    normal! gvy
+    normal! gv
+    exe 'normal' "\<Plug>NERDCommenterInvert"
+  else
     normal! yy
-  elseif mode() ==? 'v'
-    normal! y
+    call feedkeys("\<Plug>NERDCommenterInvert")
   endif
-  call feedkeys("\<Plug>NERDCommenterInvert")
 endfunction
 
 function! s:better_easymotion_overwin_line(is_visual) abort


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Currently [SPC]cy binding (yank and toggle comment) doesn't work in visual mode.I fix it.