### PR TITLE
Improve project root detection

### DIFF
--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -1018,6 +1018,9 @@ let g:spacevim_project_rooter_patterns = ['.git/', '_darcs/', '.hg/', '.bzr/', '
 ""
 " Enable/Disable changing directory automatically. Enabled by default.
 let g:spacevim_project_rooter_automatically = 1
+""
+" Enable/Disable finding outermost directory for project root detection.
+let g:spacevim_project_rooter_outermost = 1
 
 ""
 " Config the command line prompt for flygrep and denite etc.

--- a/autoload/SpaceVim/plugins/projectmanager.vim
+++ b/autoload/SpaceVim/plugins/projectmanager.vim
@@ -19,7 +19,7 @@ let s:FILE = SpaceVim#api#import('file')
 
 function! s:update_rooter_patterns() abort
   let s:project_rooter_patterns = filter(copy(g:spacevim_project_rooter_patterns), 'v:val !~# "^!"')
-  let s:project_rooter_ignores = filter(copy(g:spacevim_project_rooter_patterns), 'v:val ~=# "^!"')
+  let s:project_rooter_ignores = filter(copy(g:spacevim_project_rooter_patterns), 'v:val =~# "^!"')
 endfunction
 
 function! s:is_ignored_dir(dir) abort
@@ -207,7 +207,7 @@ function! s:sort_dirs(dirs) abort
 endfunction
 
 function! s:compare(d1, d2) abort
-  return len(split(a:d1, '/')) - len(split(a:d2, '/'))
+  return len(split(a:d2, '/')) - len(split(a:d1, '/'))
 endfunction
 
 let s:FILE = SpaceVim#api#import('file')

--- a/autoload/SpaceVim/plugins/projectmanager.vim
+++ b/autoload/SpaceVim/plugins/projectmanager.vim
@@ -17,10 +17,19 @@
 let s:BUFFER = SpaceVim#api#import('vim#buffer')
 let s:FILE = SpaceVim#api#import('file')
 
+function! s:update_rooter_patterns() abort
+  let s:project_rooter_patterns = filter(copy(g:spacevim_project_rooter_patterns), 'v:val !~# "^!"')
+  let s:project_rooter_ignores = filter(copy(g:spacevim_project_rooter_patterns), 'v:val ~=# "^!"')
+endfunction
+
+function! s:is_ignored_dir(dir) abort
+  return len(filter(copy(s:project_rooter_ignores), 'a:dir =~# v:val')) > 0
+endfunction
 
 
 call add(g:spacevim_project_rooter_patterns, '.SpaceVim.d/')
 let s:spacevim_project_rooter_patterns = copy(g:spacevim_project_rooter_patterns)
+call s:update_rooter_patterns()
 
 let s:project_paths = {}
 
@@ -105,6 +114,7 @@ function! SpaceVim#plugins#projectmanager#current_root() abort
   if join(g:spacevim_project_rooter_patterns, ':') !=# join(s:spacevim_project_rooter_patterns, ':')
     call setbufvar('%', 'rootDir', '')
     let s:spacevim_project_rooter_patterns = copy(g:spacevim_project_rooter_patterns)
+    call s:update_rooter_patterns()
   endif
   let rootdir = getbufvar('%', 'rootDir', '')
   if empty(rootdir)
@@ -161,7 +171,7 @@ function! s:find_root_directory() abort
   let fd = expand('%:p')
   let dirs = []
   call SpaceVim#logger#info('Start to find root for: ' . s:FILE.unify_path(fd))
-  for pattern in g:spacevim_project_rooter_patterns
+  for pattern in s:project_rooter_patterns
     if stridx(pattern, '/') != -1
       let dir = SpaceVim#util#findDirInParent(pattern, fd)
     else
@@ -171,6 +181,7 @@ function! s:find_root_directory() abort
     if ( ftype ==# 'dir' || ftype ==# 'file' ) 
           \ && dir !=# expand('~/.SpaceVim.d/')
           \ && dir !=# expand('~/.Rprofile')
+          \ && !s:is_ignored_dir(dir)
       let dir = s:FILE.unify_path(fnamemodify(dir, ':p'))
       if ftype ==# 'dir'
         let dir = fnamemodify(dir, ':h:h')

--- a/autoload/SpaceVim/plugins/projectmanager.vim
+++ b/autoload/SpaceVim/plugins/projectmanager.vim
@@ -207,7 +207,11 @@ function! s:sort_dirs(dirs) abort
 endfunction
 
 function! s:compare(d1, d2) abort
-  return len(split(a:d2, '/')) - len(split(a:d1, '/'))
+  if g:spacevim_project_rooter_outermost
+    return len(split(a:d2, '/')) - len(split(a:d1, '/'))
+  else
+    return len(split(a:d1, '/')) - len(split(a:d2, '/'))
+  endif
 endfunction
 
 let s:FILE = SpaceVim#api#import('file')

--- a/autoload/SpaceVim/plugins/projectmanager.vim
+++ b/autoload/SpaceVim/plugins/projectmanager.vim
@@ -19,7 +19,7 @@ let s:FILE = SpaceVim#api#import('file')
 
 function! s:update_rooter_patterns() abort
   let s:project_rooter_patterns = filter(copy(g:spacevim_project_rooter_patterns), 'v:val !~# "^!"')
-  let s:project_rooter_ignores = filter(copy(g:spacevim_project_rooter_patterns), 'v:val =~# "^!"')
+  let s:project_rooter_ignores = map(filter(copy(g:spacevim_project_rooter_patterns), 'v:val =~# "^!"'), 'v:val[1:]')
 endfunction
 
 function! s:is_ignored_dir(dir) abort

--- a/doc/SpaceVim.txt
+++ b/doc/SpaceVim.txt
@@ -1135,6 +1135,9 @@ Set the project rooter patterns, by default it is `['.git/', '_darcs/',
                                      *g:spacevim_project_rooter_automatically*
 Enable/Disable changing directory automatically. Enabled by default.
 
+                                         *g:spacevim_project_rooter_outermost*
+Enable/Disable finding outermost directory for project root detection.
+
                                                *g:spacevim_commandline_prompt*
 Config the command line prompt for flygrep and denite etc.
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1680,7 +1680,30 @@ which will tell you the functional of all mappings starting with `z`.
 
 ### Managing projects
 
-SpaceVim will find the root of the project when a `.git` directory or a `.project_alt.json` file is encountered in the file tree.
+SpaceVim will detect the root directory of the project based on `project_rooter_patterns` option, default is:
+
+```toml
+[options]
+    project_rooter_patterns = ['.git/', '_darcs/', '.hg/', '.bzr/', '.svn/']
+```
+
+The project manager will find outermost directory by default, to find nearest directory,
+you need to change `project_rooter_outermost` to `false`.
+
+```toml
+[options]
+    project_rooter_patterns = ['.git/', '_darcs/', '.hg/', '.bzr/', '.svn/']
+    project_rooter_outermost = false
+```
+
+when using nearest directory, something we want to ignore some directory,
+for example ignore `node_packages/` directory.
+
+```toml
+[options]
+    project_rooter_patterns = ['.git/', '_darcs/', '.hg/', '.bzr/', '.svn/', '!node_packages/']
+    project_rooter_outermost = false
+```
 
 Project manager commands start with `p`:
 


### PR DESCRIPTION
close #3332 #3510 
ref #3031 #3316 #3319 #3321

In #3316 we change the project rooter detection from nerstest dir to outermost directory, this make some users confuse. so I just open another PR (#3609), In this PR, we will add following feature:

1. add option for using nerstest dir or outermost dir
2. add ignore patterns 

```toml
[options]
    project_rooter_patterns = ['.git/', '_darcs/', '.hg/', '.bzr/', '.svn/', '!packages/']
```

The history of spacevim project manager

* 19f23394 - (HEAD -> project_root_ignore, wsdjeg/project_root_ignore) Update (Shidong Wang 22 minutes ago)
* 6b8babd5 - Improve project root detection (Shidong Wang 24 minutes ago)
* d90cf593 - Improve lang#r layer (#3322) (Wang Shidong 5 months ago)
* d1e6318a - Fix type (Shidong Wang 5 months ago)
* 6233e0ee - Fix root (#3321) (Wang Shidong 5 months ago)
* c50bc1ec - Improve project manager plugin (#3316) (Wang Shidong 5 months ago)
* 7de3d133 - fix completion for :OpenProject (#3146) (thawk 9 months ago)
* 33113950 - Update Copyright (#2878) (Wang Shidong 1 year, 1 month ago)
* 81b56a90 - Remove some code && fix windows support (#2874) (Wang Shidong 1 year, 1 month ago)
* e2cb874e - Fix project switch function (#2718) (Wang Shidong 1 year, 3 months ago)
* ec5b8d0a - fix vim script lint (#2519) (Wang Shidong 1 year, 5 months ago)
* 11941875 - [issue#2367]: clear rootDir cache after rooter pattern changed (#2370) (Dyno Fu 1 year, 6 months ago)
* c5205aa1 - only check option at the top level (Sarunas Valaskevicius 1 year, 7 months ago)
* 6210afd2 - remove debug output (Sarunas Valaskevicius 1 year, 7 months ago)
* ee7e5b6a - disable autochange dir - fix option (Sarunas Valaskevicius 1 year, 7 months ago)
* 34a3c4d6 - Update runtime log for startup (#2219) (Wang Shidong 1 year, 9 months ago)
* c4bbc664 - Close #2030 (#2186) (Wang Shidong 1 year, 9 months ago)
* adfffa44 - Fix: can't found file, just cant found directory (#1883) (s97712 2 years ago)
* 76ae6ccb - Select the configured projectmanager when opening a project (Cosmin Cojocar 2 years, 1 month ago)
* d300d1ed - Escape file name (#1795) (Wang Shidong 2 years, 1 month ago)
* a2400b7d - Relicense (#1406) (Wang Shidong 2 years, 5 months ago)
* 9b9915b6 - Fix funcref (wsdjeg 2 years, 5 months ago)
* 9f87d9ef - Fix project manager (wsdjeg 2 years, 6 months ago)
* 3f6d187d - Add support for file pattern (wsdjeg 2 years, 6 months ago)
* d1ce686e - Change root (wsdjeg 2 years, 6 months ago)
* 664fda4c - Done (wsdjeg 2 years, 6 months ago)
* 5daaa4b7 - Fix rooter (wsdjeg 2 years, 6 months ago)
* b9f36cbd - Fix project rooter (wsdjeg 2 years, 6 months ago)
* d98f1af1 - Add project rooter (wsdjeg 2 years, 6 months ago)
* 55bd243a - Fix win project manager (wsdjeg 2 years, 6 months ago)
* 3e50239a - Add .clang for project patterns (wsdjeg 2 years, 6 months ago)
* dbefd008 - Add callback for projectmanager (wsdjeg 2 years, 6 months ago)
* 861914d3 - Add key bindings for list projects (wsdjeg 2 years, 7 months ago)
* ea732fae - Kill all buffers (wsdjeg 2 years, 7 months ago)
* 34a8e229 - Fix SPC p k (wsdjeg 2 years, 7 months ago)
* 7468d6ec - Auto set project name (wsdjeg 2 years, 7 months ago)
* a5f34909 - Fix shell config (wsdjeg 2 years, 7 months ago)
* 4092951d - Add SPC p k to kill all project buffers (wsdjeg 2 years, 9 months ago)
* 4c061de7 - Add project manager (wsdjeg 2 years, 10 months ago)
