### PR TITLE
Fix lua api

### DIFF
--- a/autoload/SpaceVim/api/notification.vim
+++ b/autoload/SpaceVim/api/notification.vim
@@ -116,8 +116,6 @@ function! s:self.redraw_windows() abort
     return
   endif
   let self.notification_width = max(map(deepcopy(self.message), 'strwidth(v:val)'))
-  call self.__buffer.buf_set_lines(self.border.bufnr, 0 , -1, 0, self.draw_border(self.title, self.notification_width, len(self.message)))
-  call self.__buffer.buf_set_lines(self.bufnr, 0 , -1, 0, self.message)
   let self.begin_row = 2
   for hashkey in keys(s:notifications)
     if hashkey !=# self.hashkey
@@ -170,6 +168,8 @@ function! s:self.redraw_windows() abort
           \ })
     let self.win_is_open = v:true
   endif
+  call self.__buffer.buf_set_lines(self.border.bufnr, 0 , -1, 0, self.draw_border(self.title, self.notification_width, len(self.message)))
+  call self.__buffer.buf_set_lines(self.bufnr, 0 , -1, 0, self.message)
 endfunction
 
 

--- a/autoload/SpaceVim/api/vim/buffer.vim
+++ b/autoload/SpaceVim/api/vim/buffer.vim
@@ -66,7 +66,7 @@ function! s:self.bufadd(name) abort
   elseif has('lua') && empty(a:name)
     let nr = float2nr(luaeval('vim.open().number'))
     call setbufvar(nr, '&buflisted', 0)
-    return 0
+    return nr
   elseif empty(a:name)
     " create an no-named buffer
     noautocmd 1new

--- a/autoload/SpaceVim/api/vim/buffer.vim
+++ b/autoload/SpaceVim/api/vim/buffer.vim
@@ -168,9 +168,9 @@ function! s:self.buf_set_lines(buffer, start, end, strict_indexing, replacement)
   endif
   let ma = getbufvar(a:buffer, '&ma')
   call setbufvar(a:buffer,'&ma', 1)
-  if exists('*nvim_buf_set_lines')
+  if exists('*nvim_buf_set_lines') && 0
     call nvim_buf_set_lines(a:buffer, a:start, a:end, a:strict_indexing, a:replacement)
-  elseif exists('*deletebufline') && exists('*bufload')
+  elseif exists('*deletebufline') && exists('*bufload') && 0
     " patch-8.1.0039 deletebufline()
     " patch-8.1.0037 appendbufline()
     " patch-8.0.1039 setbufline()
@@ -204,7 +204,7 @@ function! s:self.buf_set_lines(buffer, start, end, strict_indexing, replacement)
     elseif a:start <= 0 && a:end > a:start && a:end < 0 && lct + a:start >= 0
       call self.buf_set_lines(a:buffer, lct + a:start + 1, lct + a:end + 2, a:strict_indexing, a:replacement)
     endif
-  elseif has('python')
+  elseif has('python') && 0
 py << EOF
 import vim
 import string
@@ -218,7 +218,7 @@ if end_line < 0:
 lines = vim.eval("a:replacement")
 vim.buffers[bufnr][start_line:end_line] = lines
 EOF
-  elseif has('python3')
+  elseif has('python3') && 0
 py3 << EOF
 import vim
 import string

--- a/autoload/SpaceVim/api/vim/buffer.vim
+++ b/autoload/SpaceVim/api/vim/buffer.vim
@@ -168,9 +168,9 @@ function! s:self.buf_set_lines(buffer, start, end, strict_indexing, replacement)
   endif
   let ma = getbufvar(a:buffer, '&ma')
   call setbufvar(a:buffer,'&ma', 1)
-  if exists('*nvim_buf_set_lines') && 0
+  if exists('*nvim_buf_set_lines')
     call nvim_buf_set_lines(a:buffer, a:start, a:end, a:strict_indexing, a:replacement)
-  elseif exists('*deletebufline') && exists('*bufload') && 0
+  elseif exists('*deletebufline') && exists('*bufload')
     " patch-8.1.0039 deletebufline()
     " patch-8.1.0037 appendbufline()
     " patch-8.0.1039 setbufline()
@@ -204,7 +204,7 @@ function! s:self.buf_set_lines(buffer, start, end, strict_indexing, replacement)
     elseif a:start <= 0 && a:end > a:start && a:end < 0 && lct + a:start >= 0
       call self.buf_set_lines(a:buffer, lct + a:start + 1, lct + a:end + 2, a:strict_indexing, a:replacement)
     endif
-  elseif has('python') && 0
+  elseif has('python')
 py << EOF
 import vim
 import string
@@ -218,7 +218,7 @@ if end_line < 0:
 lines = vim.eval("a:replacement")
 vim.buffers[bufnr][start_line:end_line] = lines
 EOF
-  elseif has('python3') && 0
+  elseif has('python3')
 py3 << EOF
 import vim
 import string


### PR DESCRIPTION
reproduce step:

1. switch to  branch `wsdjeg/lua_buf_api`
2. run `call SpaceVim#api#import('notification').notification('sssssssssssssssssss', 'WarningMsg')`

instead of show notification, the first line of current buffer will be changed, this only happened in gvim with `+lua` feature. I am not sure if this is a bug of vim's lua mode.