### PR TITLE
Add: random-candidates for colorscheme layer

### DIFF
--- a/autoload/SpaceVim/layers/colorscheme.vim
+++ b/autoload/SpaceVim/layers/colorscheme.vim
@@ -95,7 +95,8 @@ function! SpaceVim#layers#colorscheme#config() abort
       let conf = s:JSON.json_decode(join(readfile(expand(g:spacevim_data_dir.'/SpaceVim/colorscheme_frequence.json'), ''), ''))
       if s:random_frequency !=# '' && !empty(conf)
         let ctime = localtime()
-        if ctime - get(conf, 'last', 0) >= get(s:time,  get(conf, 'fequecnce', ''), 0)
+        if index(s:random_candidates, get(conf, 'theme', '')) == -1 ||
+              \ ctime - get(conf, 'last', 0) >= get(s:time,  get(conf, 'fequecnce', ''), 0)
           let id = s:NUMBER.random(0, len(s:random_candidates))
           let g:spacevim_colorscheme = s:random_candidates[id]
           call s:update_conf()

--- a/autoload/SpaceVim/layers/colorscheme.vim
+++ b/autoload/SpaceVim/layers/colorscheme.vim
@@ -66,6 +66,7 @@ let s:cs = [
 let s:NUMBER = SpaceVim#api#import('data#number')
 
 let s:time = {
+      \ 'everytime' : 1,
       \ 'daily' : 1 * 24 * 60 * 60 * 1000,
       \ 'hourly' : 1 * 60 * 60 * 1000,
       \ 'weekly' : 7 * 24 * 60 * 60 * 1000,
@@ -78,6 +79,7 @@ endfor
 unlet s:n
 
 let s:random_colorscheme = 0
+let s:random_candidates = s:cs
 let s:random_frequency = ''
 let s:bright_statusline = 0
 
@@ -94,15 +96,15 @@ function! SpaceVim#layers#colorscheme#config() abort
       if s:random_frequency !=# '' && !empty(conf)
         let ctime = localtime()
         if ctime - get(conf, 'last', 0) >= get(s:time,  get(conf, 'fequecnce', ''), 0)
-          let id = s:NUMBER.random(0, len(s:cs))
-          let g:spacevim_colorscheme = s:cs[id]
+          let id = s:NUMBER.random(0, len(s:random_candidates))
+          let g:spacevim_colorscheme = s:random_candidates[id]
           call s:update_conf()
         else
           let g:spacevim_colorscheme = conf.theme
         endif
       else
-        let id = s:NUMBER.random(0, len(s:cs))
-        let g:spacevim_colorscheme = s:cs[id]
+        let id = s:NUMBER.random(0, len(s:random_candidates))
+        let g:spacevim_colorscheme = s:random_candidates[id]
       endif
     else
       if s:random_frequency !=# ''
@@ -127,6 +129,7 @@ endfunction
 
 function! SpaceVim#layers#colorscheme#set_variable(var) abort
   let s:random_colorscheme = get(a:var, 'random_theme', get(a:var, 'random-theme', 0))
+  let s:random_candidates = get(a:var, 'random_candidates', get(a:var, 'random-candidates', s:cs))
   let s:random_frequency = get(a:var, 'frequency', 'hourly')
   let s:bright_statusline = get(a:var, 'bright_statusline', 0)
 endfunction


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Maybe a user (like me) doesn't like all the colorschme in colorscheme layer. They should be allowed to set candidates for random choosing. Now they can choose colorscheme like this:

```
[[layers]]
name = "colorscheme"
random_theme = 1
random_candidates = ["molokai", "onedark", "gruvbox", "srcery", "jellybeans", "hybrid", "SpaceVim"]                                                                                                                                   frequency = "everytime"
```

BTW, I add a frequency option "everytime", which means colorscheme will be randomly choosed everytime vim starts.