### PR TITLE
Fix tabline switching previous tab

### DIFF
--- a/autoload/SpaceVim/default.vim
+++ b/autoload/SpaceVim/default.vim
@@ -264,7 +264,7 @@ function! SpaceVim#default#keyBindings() abort
   " Tabs
   nnoremap <silent>g0 :<C-u>tabfirst<CR>
   nnoremap <silent>g$ :<C-u>tablast<CR>
-  nnoremap <silent><expr> gr tabpagenr('#') > 0 ? ':exe "tabnext " . tabpagenr("#")<cr>' : ''
+  nnoremap <silent><expr> gr tabpagenr('$') > 0 ? ':exe "tabprevious "<cr>' : ''
 
   " Remove spaces at the end of lines
   nnoremap <silent> ,<Space> :<C-u>silent! keeppatterns %substitute/\s\+$//e<CR>


### PR DESCRIPTION
:bug:
1. gr command
fixed error
E15: Invalid expression: #

vim function tabpagner is only return current tab number
and last tab number (tab total count)
so tabpagner('#') is getting error
also fix tabprevious refereces logic.

Changes to be committed:
modified:autoload/SpaceVim/default.vim

-- above comment has been modified since #3693 already provides most of the tabline issues.
but it's still not address issues on "gr" previous tab

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]
as mention earlier comment when I navigate keep getting errors and the fix is corrected on core/tabline code.
no document change required.