### PR TITLE
Add: enhancement lang#java gradle run command (added)

### DIFF
--- a/autoload/SpaceVim/layers/lang/java.vim
+++ b/autoload/SpaceVim/layers/lang/java.vim
@@ -62,6 +62,7 @@
 "   -------------------------------------------------------------
 "   normal    SPC l g b     run gradle clean build
 "   normal    SPC l g B     run gradle build
+"   normal    SPC l g r     run gradle run 
 "   normal    SPC l g t     run gradle test
 "
 "   Jump key bindings:
@@ -248,7 +249,10 @@ function! s:language_specified_mappings() abort
   call SpaceVim#mapping#space#langSPC('nnoremap', ['l','g', 't'], 'call call('
         \ . string(function('s:execCMD')) . ', ["gradle test"])',
         \ 'Run gradle test', 1)
-  
+  call SpaceVim#mapping#space#langSPC('nnoremap', ['l','g', 'r'], 'call call('
+        \ . string(function('s:execCMD')) . ', ["gradle run"])',
+        \ 'Run gradle run', 1)
+
   " REPL
   let g:_spacevim_mappings_space.l.s = {'name' : '+Send'}
   call SpaceVim#mapping#space#langSPC('nmap', ['l','s', 'i'],

--- a/doc/SpaceVim.txt
+++ b/doc/SpaceVim.txt
@@ -2271,6 +2271,7 @@ MAPPINGS
   -------------------------------------------------------------
   normal    SPC l g b     run gradle clean build
   normal    SPC l g B     run gradle build
+  normal    SPC l g r     run gradle run 
   normal    SPC l g t     run gradle test
 
   Jump key bindings:


### PR DESCRIPTION
:enhancement:
this makes easy to execute the gradle run task.

normal    SPC l g r     run gradle run

 Changes to be committed:
	modified:   autoload/SpaceVim/layers/lang/java.vim
	modified:   doc/SpaceVim.txt

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [ x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [ x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [ x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]
gradle run command will generate build and execute the java binary. 
it's currently missing on lang#java#gradle plugin.

this will greatly help to use when java with gradle project.