### PR TITLE
Change: enhancement usability shortcut for java gradle

### DIFF
--- a/autoload/SpaceVim/layers/lang/java.vim
+++ b/autoload/SpaceVim/layers/lang/java.vim
@@ -60,8 +60,8 @@
 "
 "   Mode      Key           Function
 "   -------------------------------------------------------------
-"   normal    SPC l g b     run gradle clean build
-"   normal    SPC l g B     run gradle build
+"   normal    SPC l g b     run gradle build
+"   normal    SPC l g B     run gradle clean build
 "   normal    SPC l g t     run gradle test
 "
 "   Jump key bindings:
@@ -239,10 +239,10 @@ function! s:language_specified_mappings() abort
 
   " Gradle
   let g:_spacevim_mappings_space.l.g = {'name' : '+Gradle'}
-  call SpaceVim#mapping#space#langSPC('nnoremap', ['l','g', 'b'], 'call call('
+  call SpaceVim#mapping#space#langSPC('nnoremap', ['l','g', 'B'], 'call call('
         \ . string(function('s:execCMD')) . ', ["gradle clean build"])',
         \ 'Run gradle clean build', 1)
-  call SpaceVim#mapping#space#langSPC('nnoremap', ['l','g', 'B'], 'call call('
+  call SpaceVim#mapping#space#langSPC('nnoremap', ['l','g', 'b'], 'call call('
         \ . string(function('s:execCMD')) . ', ["gradle build"])',
         \ 'Run gradle build', 1)
   call SpaceVim#mapping#space#langSPC('nnoremap', ['l','g', 't'], 'call call('

--- a/doc/SpaceVim.txt
+++ b/doc/SpaceVim.txt
@@ -2269,8 +2269,8 @@ MAPPINGS
 
   Mode      Key           Function
   -------------------------------------------------------------
-  normal    SPC l g b     run gradle clean build
-  normal    SPC l g B     run gradle build
+  normal    SPC l g b     run gradle build
+  normal    SPC l g B     run gradle clean build
   normal    SPC l g t     run gradle test
 
   Jump key bindings:


### PR DESCRIPTION
change [b] to build
change [B] to clean and build
specially gradle using cache to shorten build time that can be benefits
to use shortcut with 'b', because of it's more easy to access to the
user.
:enhancement:

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [ x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [ x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x ] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]


specially shortcut Gradle [b] build is more accessible and take great advantage to Gradle incremental build. 
and if big projects will save a lot of time. and just needed to build. 
otherwise, each time clean and build is quite time-consuming. 