### PR TITLE
Fix typo in documentation.

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -912,7 +912,7 @@ Text related commands (start with `x`):
 | `SPC x c`     | count the number of chars/words/lines in the selection region      |
 | `SPC x d w`   | delete trailing whitespaces                                        |
 | `SPC x d SPC` | Delete all spaces and tabs around point, leaving one space         |
-| `SPC x g l`   | set lanuages used by translate commands (TODO)                     |
+| `SPC x g l`   | set languages used by translate commands (TODO)                    |
 | `SPC x g t`   | translate current word using Google Translate                      |
 | `SPC x g T`   | reverse source and target languages (TODO)                         |
 | `SPC x i c`   | change symbol style to `lowerCamelCase`                            |


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

This fixes a minor typo in the documentation.
