### PR TITLE
:bug: cache init.toml based on filename if linked

### DIFF
--- a/autoload/SpaceVim/custom.vim
+++ b/autoload/SpaceVim/custom.vim
@@ -209,9 +209,9 @@ function! s:load_glob_conf() abort
   if filereadable(global_dir . 'init.toml')
     let g:_spacevim_global_config_path = global_dir . 'init.toml'
     let local_conf = global_dir . 'init.toml'
-    let local_conf_cache = s:FILE.unify_path(expand(g:spacevim_data_dir.'/SpaceVim/conf/init.json'))
+    let local_conf_cache = s:FILE.unify_path(expand(g:spacevim_data_dir.'/SpaceVim/conf/' . fnamemodify(resolve(local_conf), ':t:r') . '.json'))
     let &rtp = global_dir . ',' . &rtp
-    if getftime(local_conf) < getftime(local_conf_cache)
+    if getftime(resolve(local_conf)) < getftime(resolve(local_conf_cache))
       let conf = s:JSON.json_decode(join(readfile(local_conf_cache, ''), ''))
       call SpaceVim#custom#apply(conf, 'glob')
     else


### PR DESCRIPTION

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

This PR attempts to fix the following edgecase

If init.toml is a symlink to another file and that file timestamp is not
updated when the file is changed then the caching system breaks.

This happens in particular for users that rely on [NixOS](https://nixos.org/) or
[home-manager](https://github.com/rycee/home-manager) to
manage their vim configuration. This is because in Nix all files have
the same timestamp of the UNIX EPOCH. When generating a new
version of the file Nix will checksum the name (hence changing the name
the links point to) but the timestamp will ALWAYS be the same.


The approach I took is to cache using the filename behind the link (if a link exists). This way Nix users should be able to manage their `init.toml` using home-manager and nobody else should be affected.

Please let me know if this is an acceptable change and/or if there is a better approach I should take.


Thanks a lot!




