### PR TITLE
Update doc for key binding SPC f /

### DIFF
--- a/autoload/SpaceVim/plugins/find.vim
+++ b/autoload/SpaceVim/plugins/find.vim
@@ -150,7 +150,7 @@ function! s:find_on_exit(id, data, event) abort
 endfunction
 
 function! s:close_buffer() abort
-  exe 'bwipeout' s:find_argvs_buffer_id
+  exe 'noautocmd bwipeout' s:find_argvs_buffer_id
   noautocmd normal! :
 endfunction
 let s:MPT._onclose = function('s:close_buffer')

--- a/autoload/SpaceVim/plugins/find.vim
+++ b/autoload/SpaceVim/plugins/find.vim
@@ -142,7 +142,9 @@ endfunction
 function! s:find_on_exit(id, data, event) abort
   let files = map(filter(deepcopy(s:finded_files), '!empty(v:val)'), "{'filename' : v:val}")
   if !empty(files)
-    call setqflist(files, 'r', {'title' : 'SPC f /'})
+    call setqflist([], 'r', {'title' : ' SPC f /',
+          \ 'items' : files,
+          \ })
     copen
   else
     echo 'Can not find anything'

--- a/autoload/SpaceVim/plugins/find.vim
+++ b/autoload/SpaceVim/plugins/find.vim
@@ -125,6 +125,7 @@ function! s:start_find() abort
   endif
   let s:MPT._quit = 1
   call s:MPT._clear_prompt()
+  call s:close_buffer()
   let s:finded_files = []
   call s:JOB.start(cmd,
         \ {

--- a/autoload/SpaceVim/plugins/find.vim
+++ b/autoload/SpaceVim/plugins/find.vim
@@ -144,7 +144,7 @@ endfunction
 function! s:find_on_exit(id, data, event) abort
   let files = map(filter(deepcopy(s:finded_files), '!empty(v:val)'), "{'filename' : v:val}")
   if !empty(files)
-    call setqflist(files)
+    call setqflist(files, 'r', {'title' : 'SPC f /'})
     copen
   else
     echo 'Can not find anything'
@@ -154,6 +154,7 @@ endfunction
 function! s:close_buffer() abort
   noautocmd pclose
   noautocmd q
+  noautocmd normal! :
 endfunction
 let s:MPT._onclose = function('s:close_buffer')
 

--- a/autoload/SpaceVim/plugins/find.vim
+++ b/autoload/SpaceVim/plugins/find.vim
@@ -125,9 +125,6 @@ function! s:start_find() abort
   endif
   call s:MPT._clear_prompt()
   let s:MPT._quit = 1
-  let line = getline('.')
-  noautocmd q
-  redraw!
   let s:finded_files = []
   call s:JOB.start(cmd,
         \ {
@@ -152,8 +149,7 @@ function! s:find_on_exit(id, data, event) abort
 endfunction
 
 function! s:close_buffer() abort
-  noautocmd pclose
-  noautocmd q
+  exe 'bwipeout' s:find_argvs_buffer_id
   noautocmd normal! :
 endfunction
 let s:MPT._onclose = function('s:close_buffer')

--- a/autoload/SpaceVim/plugins/find.vim
+++ b/autoload/SpaceVim/plugins/find.vim
@@ -10,6 +10,7 @@
 scriptencoding utf-8
 let s:MPT = SpaceVim#api#import('prompt')
 let s:JOB = SpaceVim#api#import('job')
+let s:FILE = SpaceVim#api#import('file')
 " let s:SYS = SpaceVim#api#import('system')
 " let s:BUFFER = SpaceVim#api#import('vim#buffer')
 " let s:LIST = SpaceVim#api#import('data#list')
@@ -140,7 +141,7 @@ function! s:find_on_stdout(id, data, event) abort
 endfunction
 
 function! s:find_on_exit(id, data, event) abort
-  let files = map(filter(deepcopy(s:finded_files), '!empty(v:val)'), "{'filename' : v:val}")
+  let files = map(filter(deepcopy(s:finded_files), '!empty(v:val)'), "{'filename' : v:val, 'module' : s:FILE.unify_path(v:val, ':.')}")
   if !empty(files)
     call setqflist([], 'r', {'title' : ' SPC f /',
           \ 'items' : files,

--- a/autoload/SpaceVim/plugins/find.vim
+++ b/autoload/SpaceVim/plugins/find.vim
@@ -123,8 +123,8 @@ function! s:start_find() abort
   elseif s:current_tool ==# 'fd'
     let cmd = s:default_cmd[s:current_tool] . ' ' . s:MPT._prompt.begin . s:MPT._prompt.cursor . s:MPT._prompt.end
   endif
-  call s:MPT._clear_prompt()
   let s:MPT._quit = 1
+  call s:MPT._clear_prompt()
   let s:finded_files = []
   call s:JOB.start(cmd,
         \ {

--- a/autoload/SpaceVim/plugins/find.vim
+++ b/autoload/SpaceVim/plugins/find.vim
@@ -141,7 +141,8 @@ function! s:find_on_stdout(id, data, event) abort
 endfunction
 
 function! s:find_on_exit(id, data, event) abort
-  let files = map(filter(deepcopy(s:finded_files), '!empty(v:val)'), "{'filename' : v:val, 'module' : s:FILE.unify_path(v:val, ':.')}")
+  " let files = map(filter(deepcopy(s:finded_files), '!empty(v:val)'), "{'filename' : v:val, 'module' : s:FILE.unify_path(v:val, ':.')}")
+  let files = map(filter(deepcopy(s:finded_files), '!empty(v:val)'), "{'filename' : v:val}")
   if !empty(files)
     call setqflist([], 'r', {'title' : ' SPC f /',
           \ 'items' : files,

--- a/autoload/SpaceVim/plugins/find.vim
+++ b/autoload/SpaceVim/plugins/find.vim
@@ -17,8 +17,12 @@ let s:JOB = SpaceVim#api#import('job')
 
 
 let s:support_tools = ['find', 'fd']
+let s:default_cmd = {
+      \ 'find' : 'find -not -iwholename "*.git*" ',
+      \ 'fd' : 'fd',
+      \ }
 let s:current_tool = 'find'
-let s:MPT._prompt.mpt = ' ' . s:current_tool . ' '
+  let s:MPT._prompt.mpt = ' ' . s:default_cmd[s:current_tool] . ' '
 let s:options = {}
 let s:second_option = {}
 let s:options.find = {
@@ -115,9 +119,9 @@ let s:second_option.fd = {
 
 function! s:start_find() abort
   if s:current_tool ==# 'find'
-    let cmd = 'find -not -iwholename "*.git*" ' . s:MPT._prompt.begin . s:MPT._prompt.cursor . s:MPT._prompt.end
+    let cmd = s:default_cmd[s:current_tool] . ' ' . s:MPT._prompt.begin . s:MPT._prompt.cursor . s:MPT._prompt.end
   elseif s:current_tool ==# 'fd'
-    let cmd = 'fd ' . s:MPT._prompt.begin . s:MPT._prompt.cursor . s:MPT._prompt.end
+    let cmd = s:default_cmd[s:current_tool] . ' ' . s:MPT._prompt.begin . s:MPT._prompt.cursor . s:MPT._prompt.end
   endif
   call s:MPT._clear_prompt()
   let s:MPT._quit = 1
@@ -204,7 +208,7 @@ function! s:switch_tool() abort
   let s:MPT._prompt.begin = ''
   let s:MPT._prompt.cursor = ''
   let s:MPT._prompt.end = ''
-  let s:MPT._prompt.mpt = ' ' . s:current_tool . ' '
+  let s:MPT._prompt.mpt = ' ' . s:default_cmd[s:current_tool] . ' '
   redraw
   call s:MPT._build_prompt()
 endfunction
@@ -214,7 +218,7 @@ function! s:enter() abort
 endfunction
 
 function! s:handle_command_line(cmd) abort
-  normal! "_dG
+  noautocmd silent normal! "_dG
   if empty(s:MPT._prompt.begin)
     redraw
     call s:MPT._build_prompt()

--- a/docs/cn/documentation.md
+++ b/docs/cn/documentation.md
@@ -1234,6 +1234,11 @@ SpaceVim 选项 `window_leader` 的值来设为其它按键：
 | `SPC f d`            | Windows 下显示/隐藏磁盘管理器                          |
 | `SPC f y`            | 复制并显示当前文件的绝对路径                           |
 
+**注意：** 如果你使用的是 Window 系统，那么你需要额外 [findutils](https://www.gnu.org/software/findutils/)
+或者 [fd](https://github.com/sharkdp/fd)。
+如果是使用 [scoop](https://github.com/lukesampson/scoop) 安装的这些工具，系统默认的 `C:\WINDOWS\system32` 中的命令会覆盖掉用户定义的 `$PATH`，
+解决方案是将 `scoop` 默认的可执行文件所在的文件夹放置在系统环境变量 `$PATH` 内 `C:\WINDOWS\system32` 的前方。
+
 #### Vim 和 SpaceVim 相关文件
 
 SpaceVim 相关的快捷键均以 `SPC f v` 为前缀，这便于快速访问 SpaceVim 的配置文件：

--- a/docs/cn/documentation.md
+++ b/docs/cn/documentation.md
@@ -1237,7 +1237,7 @@ SpaceVim 选项 `window_leader` 的值来设为其它按键：
 **注意：** 如果你使用的是 Window 系统，那么你需要额外 [findutils](https://www.gnu.org/software/findutils/)
 或者 [fd](https://github.com/sharkdp/fd)。
 如果是使用 [scoop](https://github.com/lukesampson/scoop) 安装的这些工具，系统默认的 `C:\WINDOWS\system32` 中的命令会覆盖掉用户定义的 `$PATH`，
-解决方案是将 `scoop` 默认的可执行文件所在的文件夹放置在系统环境变量 `$PATH` 内 `C:\WINDOWS\system32` 的前方。
+解决方案是将 scoop 默认的可执行文件所在的文件夹放置在系统环境变量 `$PATH` 内 `C:\WINDOWS\system32` 的前方。
 
 #### Vim 和 SpaceVim 相关文件
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1290,7 +1290,7 @@ Files manipulation commands (start with f):
 | `SPC f y`    | show and copy current file absolute path in the cmdline   |
 
 **NOTE:** If you are using window, you need to install [findutils](https://www.gnu.org/software/findutils/) or [fd](https://github.com/sharkdp/fd).
-If you are using `scoop` to install packages, the commands in `C:\WINDOWS\system32` will override User path.
+If you are using [scoop](https://github.com/lukesampson/scoop) to install packages, the commands in `C:\WINDOWS\system32` will override User path.
 so you need to put the scoop binary PATH before all the windows `C:\WINDOWS\system32` PATH.
 
 #### Vim and SpaceVim files

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1289,6 +1289,10 @@ Files manipulation commands (start with f):
 | `SPC f d`    | toggle disk manager in Windows OS                         |
 | `SPC f y`    | show and copy current file absolute path in the cmdline   |
 
+**NOTE:** If you are using window, you need to install [findutils](https://www.gnu.org/software/findutils/) or [fd](https://github.com/sharkdp/fd).
+If you are using `scoop` to install packages, the commands in `C:\WINDOWS\system32` will override User path.
+so you need to put the scoop binary PATH before all the windows `C:\WINDOWS\system32` PATH.
+
 #### Vim and SpaceVim files
 
 Convenient key bindings are located under the prefix `SPC f v` to quickly navigate between Vim and SpaceVim specific files.


### PR DESCRIPTION
the key binding `SPC f /` is just to run `find` or `fd` command, but this is missing in doc, just updated the doc for it.

for windows users, the default find (`C:\WINDOWS\system32\find.EXE`) is not supported, you need to install [findutils](https://www.gnu.org/software/findutils/)

close #3821 