### PR TITLE
FzfMru: remove the reverse line

### DIFF
--- a/autoload/SpaceVim/layers/fzf.vim
+++ b/autoload/SpaceVim/layers/fzf.vim
@@ -284,7 +284,6 @@ function! s:file_mru() abort
   call fzf#run(s:wrap('mru', {
         \ 'source':  reverse(<sid>mru_files()),
         \ 'sink':    function('s:open_file'),
-        \ 'options': '--reverse',
         \ 'down' : '40%',
         \ }))
 endfunction


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [X] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [X] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]
When fzf layer is enabled, `[SPC] f r` will open the most recent file list for selection. Currently, the code turns on the reverse option, but on the other hand, the source (i.e., the file list) is reversed as well. Basically, it is a double reverse.

The reverse option is removed to restore the expected behavior.