### PR TITLE
Add: new configuration options for go layer to take advantage of gopls features

### DIFF
--- a/autoload/SpaceVim/layers/lang/go.vim
+++ b/autoload/SpaceVim/layers/lang/go.vim
@@ -40,6 +40,10 @@
 " <
 
 
+let s:go_fmt_command = 'gofmt'
+let s:go_imports_autosave = 0
+let s:go_imports_mode = 'goimports'
+
 function! SpaceVim#layers#lang#go#plugins() abort
   let plugins = [['fatih/vim-go', { 'on_ft' : 'go', 'loadconf_before' : 1}]]
   if has('nvim') && g:spacevim_autocomplete_method ==# 'deoplete'
@@ -55,7 +59,9 @@ function! SpaceVim#layers#lang#go#config() abort
   let g:go_highlight_structs = 1
   let g:go_highlight_operators = 1
   let g:go_highlight_build_constraints = 1
-  let g:go_fmt_command = 'goimports'
+  let g:go_imports_mode = s:go_imports_mode
+  let g:go_fmt_command = s:go_fmt_command
+  let g:go_imports_autosave = s:go_imports_autosave
   let g:syntastic_go_checkers = ['golint', 'govet']
   let g:syntastic_mode_map = { 'mode': 'active', 'passive_filetypes': ['go'] }
   let g:neomake_go_gometalinter_args = ['--disable-all']
@@ -70,6 +76,12 @@ function! SpaceVim#layers#lang#go#config() abort
   endif
   call SpaceVim#mapping#space#regesit_lang_mappings('go', function('s:language_specified_mappings'))
   call SpaceVim#plugins#runner#reg_runner('go', 'go run %s')
+endfunction
+
+function! SpaceVim#layers#lang#go#set_variable(var) abort
+  let s:go_fmt_command = get(a:var, 'go_fmt_command', s:go_fmt_command)
+  let s:go_imports_autosave = get(a:var, 'go_imports_autosave', s:go_imports_autosave)
+  let s:go_imports_mode = get(a:var, 'go_imports_mode', s:go_imports_mode)
 endfunction
 
 function! s:go_to_def() abort


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

For `gopls` users `vim-go` plugin offers some options to use it for formatting and imports processing:
https://github.com/fatih/vim-go/blob/master/doc/vim-go.txt#L1352

This PR adds new configuration options to `go` layer and preserves the default behaviour. New configuration options are:

- `go_fmt_command`
- `go_imports_autosave`
- `go_imports_mode`

Example config that I use:

```
[[layers]]
name = "lang#go"
go_fmt_command = 'gopls'
go_imports_mode = 'gopls'
go_imports_autosave = 1
```