### PR TITLE
fix syntax highlight about icase in flygrep window

### DIFF
--- a/autoload/SpaceVim/plugins/flygrep.vim
+++ b/autoload/SpaceVim/plugins/flygrep.vim
@@ -146,7 +146,8 @@ function! s:expr_to_pattern(expr) abort
   if s:grep_mode ==# 'expr'
     let items = split(a:expr)
     let pattern = join(items, '.*')
-    let pattern = s:filename_pattern . '.*\zs' . s:REGEX.parser(pattern, 0)
+    let ignorecase = &ignorecase ? '\c' : '\C'
+    let pattern = s:filename_pattern . '.*\zs' . ignorecase . s:REGEX.parser(pattern, 0)
     call s:LOGGER.info('matchadd pattern: ' . pattern)
     return pattern
   else


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?
When we `set ignorecase` in vim/neovim and type lowercase `todo` to search, flygrep will search for both `todo` and `TODO`, but do not highlight `TODO` with uppercase. I have changed the regex for group `FlyGrepPattern` by adding prefix `'\c'` to sovle this problem.
[Please explain **in detail** why the changes in this PR are needed.]
