### PR TITLE
g++ should use -xc++ for C++

### DIFF
--- a/autoload/SpaceVim/layers/lang/c.vim
+++ b/autoload/SpaceVim/layers/lang/c.vim
@@ -153,7 +153,7 @@ function! SpaceVim#layers#lang#c#config() abort
   let runner2 = {
         \ 'exe' : 'g++',
         \ 'targetopt' : '-o',
-        \ 'opt' : ['-std=' . s:clang_std.cpp] + s:clang_flag + ['-xc', '-'],
+        \ 'opt' : ['-std=' . s:clang_std.cpp] + s:clang_flag + ['-xc++', '-'],
         \ 'usestdin' : 1,
         \ }
   call SpaceVim#plugins#runner#reg_runner('cpp', [runner2, '#TEMP#'])


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

There is a typo in the runner for ``C++``.  ``-xc++`` should be used instead of ``-xc`` for ``C++``.