### PR TITLE
Fix clang_std option for c language layer

### DIFF
--- a/autoload/SpaceVim/layers/lang/c.vim
+++ b/autoload/SpaceVim/layers/lang/c.vim
@@ -46,7 +46,7 @@
 "     name = "lang#c"
 "     clang_executable = "/usr/bin/clang"
 "     clang_flag = ['-I/user/include']
-"     [layer.clang_std]
+"     [layers.clang_std]
 "       c = "c11"
 "       cpp = "c++1z"
 "       objc = "c11"
@@ -236,6 +236,8 @@ function! SpaceVim#layers#lang#c#set_variable(var) abort
   let s:clang_flag = get(a:var, 'clang_flag', s:clang_flag)
 
   let s:enable_clang_syntax = get(a:var, 'enable_clang_syntax_highlight', s:enable_clang_syntax)
+
+  call extend(s:clang_std, get(a:var, 'clang_std', {}))
 endfunction
 
 function! s:language_specified_mappings() abort


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

layers/lang/c.vim doesn't read ``clang_std`` from ``init.toml``.