### PR TITLE
Fix fzf mru, most recent should be first

### DIFF
--- a/autoload/SpaceVim/layers/fzf.vim
+++ b/autoload/SpaceVim/layers/fzf.vim
@@ -282,7 +282,7 @@ function! s:file_mru() abort
     return neomru#_gather_file_candidates()
   endfunction
   call fzf#run(s:wrap('mru', {
-        \ 'source':  reverse(<sid>mru_files()),
+        \ 'source':  <sid>mru_files(),
         \ 'sink':    function('s:open_file'),
         \ 'down' : '40%',
         \ }))


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

When using the fzf mru functionality (SPC f r), the most recent file was at the
END of the list rather than the FRONT. Note this is separate from fzf --reverse
which is purely presentational.