### PR TITLE
Move split policies to settings

### DIFF
--- a/autoload/SpaceVim/default.vim
+++ b/autoload/SpaceVim/default.vim
@@ -138,6 +138,10 @@ function! SpaceVim#default#options() abort
 
   set foldtext=SpaceVim#default#Customfoldtext()
 
+  " Split windows below and right by default. Set this here rather than
+  " forcing it in keybindings, so that the user can override the policy.
+  set splitbelow splitright
+
 endfunction
 "}}}
 

--- a/autoload/SpaceVim/mapping/space.vim
+++ b/autoload/SpaceVim/mapping/space.vim
@@ -230,7 +230,7 @@ function! SpaceVim#mapping#space#init() abort
         \ ]
         \ , 1)
   let s:lnum = expand('<slnum>') + s:funcbeginline
-  call SpaceVim#mapping#space#def('nnoremap', ['w', '/'], 'belowright vsplit | wincmd w',
+  call SpaceVim#mapping#space#def('nnoremap', ['w', '/'], 'vsplit | wincmd w',
         \ ['split-windows-right',
         \ [
         \ '[SPC w /] is to split windows on the right',
@@ -240,7 +240,7 @@ function! SpaceVim#mapping#space#init() abort
         \ ]
         \ , 1)
   let s:lnum = expand('<slnum>') + s:funcbeginline
-  call SpaceVim#mapping#space#def('nnoremap', ['w', 'v'], 'belowright vsplit | wincmd w',
+  call SpaceVim#mapping#space#def('nnoremap', ['w', 'v'], 'vsplit | wincmd w',
         \ ['split-windows-right',
         \ [
         \ '[SPC w v] is to split windows on the right',
@@ -250,7 +250,7 @@ function! SpaceVim#mapping#space#init() abort
         \ ]
         \ , 1)
   let s:lnum = expand('<slnum>') + s:funcbeginline
-  call SpaceVim#mapping#space#def('nnoremap', ['w', '-'], 'bel split | wincmd w',
+  call SpaceVim#mapping#space#def('nnoremap', ['w', '-'], 'split | wincmd w',
         \ ['split-windows-below',
         \ [
         \ '[SPC w -] is to split windows below',
@@ -260,7 +260,7 @@ function! SpaceVim#mapping#space#init() abort
         \ ]
         \ , 1)
   let s:lnum = expand('<slnum>') + s:funcbeginline
-  call SpaceVim#mapping#space#def('nnoremap', ['w', 's'], 'bel split | wincmd w',
+  call SpaceVim#mapping#space#def('nnoremap', ['w', 's'], 'split | wincmd w',
         \ ['split-windows-below',
         \ [
         \ '[SPC w s] is to split windows below',
@@ -270,7 +270,7 @@ function! SpaceVim#mapping#space#init() abort
         \ ]
         \ , 1)
   let s:lnum = expand('<slnum>') + s:funcbeginline
-  call SpaceVim#mapping#space#def('nnoremap', ['w', 'S'], 'bel split',
+  call SpaceVim#mapping#space#def('nnoremap', ['w', 'S'], 'split',
         \ ['split-focus-windows-below',
         \ [
         \ '[SPC w S] is to split windows below and focus on new windows',
@@ -280,7 +280,7 @@ function! SpaceVim#mapping#space#init() abort
         \ ]
         \ , 1)
   let s:lnum = expand('<slnum>') + s:funcbeginline
-  call SpaceVim#mapping#space#def('nnoremap', ['w', '2'], 'silent only | vs | wincmd w',
+  call SpaceVim#mapping#space#def('nnoremap', ['w', '2'], 'silent only | vsplit | wincmd w',
         \ ['layout-double-columns',
         \ [
         \ '[SPC w 2] is to change current windows layout to double columns',
@@ -290,7 +290,7 @@ function! SpaceVim#mapping#space#init() abort
         \ ]
         \ , 1)
   let s:lnum = expand('<slnum>') + s:funcbeginline
-  call SpaceVim#mapping#space#def('nnoremap', ['w', '3'], 'silent only | vs | vs | wincmd H',
+  call SpaceVim#mapping#space#def('nnoremap', ['w', '3'], 'silent only | vsplit | vsplit | wincmd H',
         \ ['layout-three-columns',
         \ [
         \ '[SPC w 3] is to change current windows layout to three columns',
@@ -300,7 +300,7 @@ function! SpaceVim#mapping#space#init() abort
         \ ]
         \ , 1)
   call SpaceVim#mapping#space#def('nnoremap', ['w', 'V'],
-        \ 'bel vs', 'split-window-right-focus', 1)
+        \ 'vsplit', 'split-window-right-focus', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['w', '='],
         \ 'wincmd =', 'balance-windows', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['w', 'w'],


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

There's no need to force `belowright` in the key bindings when we could lean on the Vim setting instead. This change allows the user to override the policy to their preference in their bootstrap functions.