### PR TITLE
Add: typescriptreact syntax highlighting support

### DIFF
--- a/autoload/SpaceVim/layers/lang/typescript.vim
+++ b/autoload/SpaceVim/layers/lang/typescript.vim
@@ -26,6 +26,7 @@
 function! SpaceVim#layers#lang#typescript#plugins() abort
   let plugins = []
   call add(plugins, ['leafgarland/typescript-vim'])
+  call add(plugins, ['peitalin/vim-jsx-typescript'])
   call add(plugins, ['heavenshell/vim-jsdoc', { 'on_cmd': 'JsDoc' }])
   if !SpaceVim#layers#lsp#check_filetype('typescript')
     if has('nvim')


### PR DESCRIPTION
Note that this changes the `ft` from "typescriptreact" to "typscript.tsx"

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

I was confused why .tsx files were not highlighting. I saw a number of issues related to this that were closed with little or no resolution (#3210 #3221 #3261). This was the simplest working PR I could come up with, though I am not sure what side effects it might contain.