### PR TITLE
Fix job.send can handle multi-line string

### DIFF
--- a/autoload/SpaceVim/api/job.vim
+++ b/autoload/SpaceVim/api/job.vim
@@ -275,7 +275,7 @@ function! s:self.send(id, data) abort dict
   if self.nvim_job
     if has_key(self.jobs, a:id)
       if type(a:data) == type('')
-        call jobsend(a:id, [a:data, ''])
+        call jobsend(a:id, a:data . "\n")
       else
         call jobsend(a:id, a:data)
       endif

--- a/autoload/SpaceVim/plugins/repl.vim
+++ b/autoload/SpaceVim/plugins/repl.vim
@@ -63,7 +63,7 @@ function! SpaceVim#plugins#repl#send(type, ...) abort
     elseif a:type ==# 'raw'
       let context = get(a:000, 0, '')
       if !empty(context) && s:VIM.is_string(context)
-        call s:JOB.send(s:job_id, [context] + [''])
+        call s:JOB.send(s:job_id, context)
       endif
     elseif a:type ==# 'buffer'
       call s:JOB.send(s:job_id, getline(1, '$') + [''])


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

close #3887

Because ``job.send()`` will append a ``\n`` for neovim and vim, so it's unnecessary to append one in ``repl#send()``.

If we don't want to limit the argument type of ``repl#send('raw')``, the type check can be omitted too.
