### PR TITLE
todo manager: implement custom keywords

### DIFF
--- a/autoload/SpaceVim/plugins/todo.vim
+++ b/autoload/SpaceVim/plugins/todo.vim
@@ -67,18 +67,7 @@ function! s:update_todo_content() abort
   let argv = [s:grep_default_exe] + 
         \ s:grep_default_opt +
         \ s:grep_default_expr_opt
-  " @fixme expr for defferent tools
-  " when using rg, [join(s:labels, '|')]
-  " when using grep, [join(s:labels, '\|')]
-  if s:grep_default_exe ==# 'rg'
-    let argv += [join(s:labels, '|')]
-  elseif s:grep_default_exe ==# 'grep'
-    let argv += [join(s:labels, '\|')]
-  elseif s:grep_default_exe ==# 'findstr'
-    let argv += [join(s:labels, ' ')]
-  else
-    let argv += [join(s:labels, '|')]
-  endif
+  let argv += [s:join_labels()]
   if s:SYS.isWindows && (s:grep_default_exe ==# 'rg' || s:grep_default_exe ==# 'ag' || s:grep_default_exe ==# 'pt' )
     let argv += ['.']
   elseif s:SYS.isWindows && s:grep_default_exe ==# 'findstr'
@@ -101,8 +90,9 @@ function! s:stdout(id, data, event) abort
       let file = fnameescape(split(data, ':\d\+:')[0])
       let line = matchstr(data, ':\d\+:')[1:-2]
       let column = matchstr(data, '\(:\d\+\)\@<=:\d\+:')[1:-2]
-      let lebal = matchstr(data, join(s:labels, '\|'))
-      let title = get(split(data, lebal), 1, '')
+      let full_label = matchstr(data, s:join_labels_pattern())
+      let trimmed_label = substitute(full_label, '\W', '', 'g')
+      let title = get(split(data, full_label), 1, '')
       " @todo add time tag
       call add(s:todos, 
             \ {
@@ -110,7 +100,7 @@ function! s:stdout(id, data, event) abort
             \ 'line' : line,
             \ 'column' : column,
             \ 'title' : title,
-            \ 'lebal' : lebal,
+            \ 'label' : trimmed_label,
             \ }
             \ )
     endif
@@ -126,9 +116,9 @@ endfunction
 function! s:exit(id, data, event ) abort
   call s:LOG.info('exit code: ' . string(a:data))
   let s:todos = sort(s:todos, function('s:compare_todo'))
-  let label_w = max(map(deepcopy(s:todos), 'strlen(v:val.lebal)'))
+  let label_w = max(map(deepcopy(s:todos), 'strlen(v:val.label)'))
   let file_w = max(map(deepcopy(s:todos), 'strlen(v:val.file)'))
-  let expr = "v:val.lebal . repeat(' ', label_w - strlen(v:val.lebal)) . ' ' ."
+  let expr = "tolower(v:val.label) . repeat(' ', label_w - strlen(v:val.label)) . ' ' ."
         \ .  "SpaceVim#api#import('file').unify_path(v:val.file, ':.') . repeat(' ', file_w - strlen(v:val.file)) . ' ' ."
         \ .  'v:val.title'
   let lines = map(deepcopy(s:todos),expr)
@@ -136,8 +126,8 @@ function! s:exit(id, data, event ) abort
 endfunction
 
 function! s:compare_todo(a, b) abort
-  let a = index(s:labels, a:a.lebal)
-  let b = index(s:labels, a:b.lebal)
+  let a = index(s:labels, a:a.label)
+  let b = index(s:labels, a:b.label)
   return a == b ? 0 : a > b ? 1 : -1
 endfunction
 
@@ -153,6 +143,29 @@ function! s:open_todo() abort
   call cursor(todo.line, todo.column)
   noautocmd normal! :
 endfunction
+
+" @fixme expr for different tools
+" when using rg,   [join(s:labels, '|')]
+" when using grep, [join(s:labels, '\|')]
+function! s:join_labels()
+  if s:grep_default_exe ==# 'rg'
+    return join(s:labels, '|')
+  elseif s:grep_default_exe ==# 'grep'
+    return join(s:labels, '\|')
+  elseif s:grep_default_exe ==# 'findstr'
+    return join(s:labels, ' ')
+  else
+    return join(s:labels, '|')
+  endif
+endfunc
+
+function! s:join_labels_pattern ()
+  if exists('g:spacevim_todo_labels_pattern')
+    return g:spacevim_todo_labels_pattern
+  end
+  return join(s:labels, '\|')
+endfunc
+
 
 " @todo fuzzy find todo list
 " after open todo manager buffer, we should be able to fuzzy find the item we

--- a/autoload/SpaceVim/plugins/todo.vim
+++ b/autoload/SpaceVim/plugins/todo.vim
@@ -75,7 +75,6 @@ function! s:update_todo_content() abort
     let argv += ['*.*']
   endif
   let argv += s:grep_default_ropt
-  echom string(argv)
   call s:LOG.info('cmd: ' . string(argv))
   let jobid = s:JOB.start(argv, {
         \ 'on_stdout' : function('s:stdout'),

--- a/autoload/SpaceVim/plugins/todo.vim
+++ b/autoload/SpaceVim/plugins/todo.vim
@@ -75,6 +75,7 @@ function! s:update_todo_content() abort
     let argv += ['*.*']
   endif
   let argv += s:grep_default_ropt
+  echom string(argv)
   call s:LOG.info('cmd: ' . string(argv))
   let jobid = s:JOB.start(argv, {
         \ 'on_stdout' : function('s:stdout'),
@@ -165,7 +166,7 @@ function! s:get_labels_regex()
 endfunc
 
 function! s:get_labels_pattern ()
-  return join(map(copy(s:labels), "(v:val[0] =~ '\w' ? '\\<' : '') . v:val . '\\>:\\?'"), '\|')
+  return '\C' . join(map(copy(s:labels), "(v:val[0] =~ '\w' ? '\\<' : '') . v:val . '\\>:\\?'"), '\|')
 endfunc
 
 

--- a/autoload/SpaceVim/plugins/todo.vim
+++ b/autoload/SpaceVim/plugins/todo.vim
@@ -94,7 +94,6 @@ function! s:stdout(id, data, event) abort
       let full_label = matchstr(data, s:get_labels_pattern())
       let trimmed_label = substitute(full_label, '\W', '', 'g')
       let title = get(split(data, full_label), 1, '')
-      call add(g:data, data)
       " @todo add time tag
       call add(s:todos, 
             \ {

--- a/doc/SpaceVim.txt
+++ b/doc/SpaceVim.txt
@@ -1242,7 +1242,23 @@ Config the command line prompt for flygrep and denite etc.
 
                                                       *g:spacevim_todo_labels*
 Option for setting todo labels in current project.
+By default, it matches "@todo", "@question", "@fixme" and "@idea".
 
+                                              *g:spacevim_todo_labels_pattern*
+This option is used in conjunction with `g:spacevim_todo_labels` to configure
+custom todo patterns.
+
+The following configuration will match todos in the form "TODO", "FIXME" and
+"XXX".
+>
+  let g:spacevim_todo_labels = [
+    \ '\bFIXME\b',
+    \ '\bTODO\b',
+    \ '\bXXX\b',
+    \ ]
+
+  let g:spacevim_todo_labels_pattern = '\v\CTODO:?|FIXME:?|XXX:?'
+<
                                                   *g:spacevim_lint_on_the_fly*
 Enable/Disable lint on the fly feature of SpaceVim's maker. Default is 0.
 >

--- a/doc/SpaceVim.txt
+++ b/doc/SpaceVim.txt
@@ -1244,20 +1244,14 @@ Config the command line prompt for flygrep and denite etc.
 Option for setting todo labels in current project.
 By default, it matches "@todo", "@question", "@fixme" and "@idea".
 
-                                              *g:spacevim_todo_labels_pattern*
-This option is used in conjunction with `g:spacevim_todo_labels` to configure
-custom todo patterns.
-
 The following configuration will match todos in the form "TODO", "FIXME" and
 "XXX".
 >
   let g:spacevim_todo_labels = [
-    \ '\bFIXME\b',
-    \ '\bTODO\b',
-    \ '\bXXX\b',
+    \ 'FIXME',
+    \ 'TODO',
+    \ 'XXX',
     \ ]
-
-  let g:spacevim_todo_labels_pattern = '\v\CTODO:?|FIXME:?|XXX:?'
 <
                                                   *g:spacevim_lint_on_the_fly*
 Enable/Disable lint on the fly feature of SpaceVim's maker. Default is 0.

--- a/syntax/SpaceVimTodoManager.vim
+++ b/syntax/SpaceVimTodoManager.vim
@@ -4,10 +4,12 @@ endif
 let b:current_syntax = 'SpaceVimTodoManager'
 syntax case ignore
 
-syn match FileName /\(@[a-zA-Z]*\s\+\)\@<=[^ ]*/
+syn match FileName /\(^\S\+\s\+\)\@<=[^ ]*/
 syn match TODOTAG  /^\s*@[a-zA-Z]*/
+syn match TODOTAG  /^\s*@\?todo*/
 syn match TODOQUESTION  /^\s*@ques[a-z]*/
-syn match TODOFIXME  /^\s*@fixm[a-z]*/
+syn match TODOFIXME  /^\s*@\?fixm[a-z]*/
+syn match TODOFIXME  /^\s*@\?xxx*/
 " syn match TODOCHECKBOX /[\d\+/\d\+\]/
 syn match TODOINDEX /^\s\+\d\+\.\s/
 syn match TODOCHECKBOXPANDING /\s\+√\s\+/


### PR DESCRIPTION
Fixes https://github.com/SpaceVim/SpaceVim/issues/3466

To supply custom search keywords, the user must set two options:
 - `spacevim_todo_labels`: the labels as will be searched by the external tool (grep, ripgrep, ...)
 - `spacevim_todo_labels_pattern`: the *vim* pattern to match the labels inside a string

The second option is required in case the first one contains special regex stuff that isn't handled by vim's patterns. The example below shows how to configure it to match the keywords "TODO" & friends as they usually appear in source code.

![Screenshot from 2020-10-14 21-26-23](https://user-images.githubusercontent.com/1423607/96062592-11052380-0e64-11eb-8286-52ed29ec67fb.png)

Notes:
 - Untested because I don't use SpaceVim but tested [this one](https://github.com/wsdjeg/vim-todo/pull/3).
 - IMHO the default behavior should be to include "TODO" etc. "@todo" can be included as well even if its usage is limited. Let me know what you think.