### PR TITLE
Add: <leader>0 tabs to 10, <leader><Shift>{1:9, 0} tabs {11:20}

### DIFF
--- a/autoload/SpaceVim/layers/core/tabline.vim
+++ b/autoload/SpaceVim/layers/core/tabline.vim
@@ -447,8 +447,29 @@ function! SpaceVim#layers#core#tabline#config() abort
     autocmd!
     autocmd ColorScheme * call SpaceVim#layers#core#tabline#def_colors()
   augroup END
-  for i in range(1, 9)
-    exe "call SpaceVim#mapping#def('nmap <silent>', '<leader>" . i
+  
+  
+  let shift_keys = {
+   \  '1': '!',
+   \  '2': '@',
+   \  '3': '#',
+   \  '4': '$',
+   \  '5': '%',
+   \  '6': '^',
+   \  '7': '&',
+   \  '8': '*',
+   \  '9': '(',
+   \  '0': ')'
+   \}
+
+  for i in range(1, 20)
+    let key = i % 10
+
+    if i > 10
+      let key = shift_keys[string(key)]
+    endif
+
+    exe "call SpaceVim#mapping#def('nmap <silent>', '<leader>" . key
           \ . "', ':call SpaceVim#layers#core#tabline#jump("
           \ . i . ")<cr>', 'Switch to airline tab " . i
           \ . "', '', 'tabline index " . i . "')"


### PR DESCRIPTION
### PR Prelude

<details><summary>Prelude</summary>

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

</details>

### Why this change is necessary and useful?

Previously, the leader key only bound 1->9 for tabline shortcuts. 

This was useful behaviour, but made navigation beyond 10 tabs impractical. 

Now 

- `<leader><S>`+`{1..9}` tabs to `11..19`. 
- `<leader>0` tabs to `10`,
- `<leader><S>`+`0` tabs to `20`


