### PR TITLE
Some fixes for FlyGrep

### DIFF
--- a/.ci/detach_plugin.sh
+++ b/.ci/detach_plugin.sh
@@ -82,21 +82,21 @@ main () {
 ""
 " FlyGrep will start to searching code after a delay, the default value is
 " 500ms.
-let g:FlyGrep_input_delay = 500
+let g:FlyGrep_input_delay = get(g:, 'FlyGrep_input_delay', 500)
 
 ""
 " A list of searching tools will be userd.
-let g:FlyGrep_search_tools = ['ag', 'rg', 'grep', 'pt', 'ack']
+let g:FlyGrep_search_tools = get(g:, 'FlyGrep_search_tools', ['ag', 'rg', 'grep', 'pt', 'ack'])
 
-let g:spacevim_data_dir = '~/.cache'
+let g:spacevim_data_dir = get(g:, 'spacevim_data_dir', '~/.cache')
 
 ""
 " Enable FlyGrep statusline
-let g:FlyGrep_enable_statusline = 1
+let g:FlyGrep_enable_statusline = get(g:, 'FlyGrep_enable_statusline', 1)
 
 ""
 " Set FlyGrep default command prompt
-let g:spacevim_commandline_prompt = '➭'
+let g:spacevim_commandline_prompt = get(g:, 'spacevim_commandline_prompt', '➭')
 
 command! -nargs=0 FlyGrep call FlyGrep#open({})
 EOT

--- a/.ci/detach_plugin.sh
+++ b/.ci/detach_plugin.sh
@@ -38,7 +38,12 @@ main () {
             _detect autoload/SpaceVim/api/vim/buffer.vim
             _detect autoload/SpaceVim/api/vim/regex.vim
             _detect autoload/SpaceVim/api/vim/compatible.vim
+            _detect autoload/SpaceVim/api/vim/floating.vim
+            _detect autoload/SpaceVim/api/vim/highlight.vim
+            _detect autoload/SpaceVim/api/vim/statusline.vim
+            _detect autoload/SpaceVim/api/vim/window.vim
             _detect autoload/SpaceVim/api/neovim/floating.vim
+            _detect autoload/SpaceVim/api/data/dict.vim
             _detect autoload/SpaceVim/api/data/list.vim
             _detect autoload/SpaceVim/api/data/json.vim
             _detect autoload/SpaceVim/api/prompt.vim

--- a/autoload/SpaceVim/api/vim/statusline.vim
+++ b/autoload/SpaceVim/api/vim/statusline.vim
@@ -167,11 +167,13 @@ endfunction
 
 if s:self.__floating.exists()
   function! s:self.close_float() abort
-    call self.__floating.win_close(self.__winid, 1)
+    if get(self, '__winid', -1) != -1
+      call self.__floating.win_close(self.__winid, 1)
+    endif
   endfunction
 else
   function! s:self.close_float() abort
-    if has_key(self, '__winid') && win_id2tabwin(self.__winid)[0] == tabpagenr()
+    if get(self, '__winid', -1) != -1 && win_id2tabwin(self.__winid)[0] == tabpagenr()
       noautocmd execute win_id2win(self.__winid).'wincmd w'
       noautocmd close
     endif

--- a/autoload/SpaceVim/plugins/flygrep.vim
+++ b/autoload/SpaceVim/plugins/flygrep.vim
@@ -913,6 +913,10 @@ endfunction
 " }}}
 
 function! s:update_statusline() abort
+  if !g:FlyGrep_enable_statusline
+    return
+  endif
+
   if s:SL.support_float() && win_id2tabwin(s:flygrep_win_id)[0] ==# tabpagenr() && s:Window.is_float(win_id2win(s:flygrep_win_id))
     noautocmd call s:SL.open_float([
           \ ['FlyGrep ', 'SpaceVim_statusline_a_bold'],


### PR DESCRIPTION
### PR Prelude

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

FlyGrep currently doesn't get all of the API files that it uses copied over and also overwrites user config settings.

It also doesn't respect g:FlyGrep_enable_statusline.
In making FlyGrep respect g:FlyGrep_enable_statusline, I also modified statusline.vim's close_float to only attempt to close the float if it opened one (self.__winid isn't -1) to avoid errors.

