### PR TITLE
Add: Support auto_completion_complete_with_key_sequence for coc completion

### DIFF
--- a/autoload/SpaceVim/layers/autocomplete.vim
+++ b/autoload/SpaceVim/layers/autocomplete.vim
@@ -75,9 +75,9 @@ function! SpaceVim#layers#autocomplete#plugins() abort
           \ }])
   elseif g:spacevim_autocomplete_method ==# 'coc'
     if executable('yarn')
-      call add(plugins, ['neoclide/coc.nvim',  {'merged': 0, 'build': 'yarn install --frozen-lockfile'}])
+      call add(plugins, ['neoclide/coc.nvim',  {'loadconf': 1, 'merged': 0, 'build': 'yarn install --frozen-lockfile'}])
     else
-      call add(plugins, ['neoclide/coc.nvim',  {'merged': 0, 'rev': 'release'}])
+      call add(plugins, ['neoclide/coc.nvim',  {'loadconf': 1, 'merged': 0, 'rev': 'release'}])
     endif
   elseif g:spacevim_autocomplete_method ==# 'deoplete'
     call add(plugins, [g:_spacevim_root_dir . 'bundle/deoplete.nvim', {

--- a/config/plugins/coc.vim
+++ b/config/plugins/coc.vim
@@ -1,0 +1,5 @@
+if !empty(g:_spacevim_key_sequence)
+      \ && g:_spacevim_key_sequence !=# 'nil'
+      \ && g:spacevim_escape_key_binding !=# g:_spacevim_key_sequence
+exe printf('imap <silent>%s <C-r>=coc#refresh()<CR>', g:_spacevim_key_sequence)
+endif


### PR DESCRIPTION
### PR Prelude

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

The `auto_completion_complete_with_key_sequence` option is not available for `neoclide/coc.nvim` which is used for lsp completion.

This commit adds support of this option for this completion engine.