### PR TITLE
Doc: add documentation for expand-region key bindings

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -39,6 +39,7 @@ description: "General documentation about how to using SpaceVim, including the q
     - [Code indentation](#code-indentation)
     - [Text manipulation commands](#text-manipulation-commands)
     - [Text insertion commands](#text-insertion-commands)
+    - [Expand regions of text](#expand-regions-of-text)
     - [Increase/Decrease numbers](#increasedecrease-numbers)
     - [Copy and paste](#copy-and-paste)
     - [Commenting](#commenting)
@@ -1063,6 +1064,15 @@ Text insertion commands (start with `i`):
 | `SPC i U U`  | insert UUIDv4 (use universal argument to insert with CID format)      |
 
 **Tips:** You can specify number of password characters using prefix argument, (i.e. `10 SPC i p 1` will generate 10 characters of simple password)
+
+#### Expand regions of text
+
+Key bindings available in visual mode:
+
+| Key bindings | Descriptions                                                          |
+| ------------ | --------------------------------------------------------------------- |
+| `v`          | expand visual selection of text to larger region                      |
+| `V`          | shrink visual selection of text to smaller region                     |
 
 #### Increase/Decrease numbers
 


### PR DESCRIPTION
### PR Prelude

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Found missing expand region key bindings documentation. I think it's relevant to document it.