### PR TITLE
Fix CtrlP that uses grep for OSX

### DIFF
--- a/config/plugins/ctrlp.vim
+++ b/config/plugins/ctrlp.vim
@@ -35,9 +35,12 @@ elseif executable('ag') && !exists('g:ctrlp_user_command')
 elseif s:SYS.isWindows
   let g:ctrlp_user_command =
     \ 'dir %s /-n /b /s /a-d | findstr /v /l ".jpg \\tmp\\"' " Windows
+elseif s:SYS.isOSX
+  let g:ctrlp_user_command =
+    \ 'find %s -type f | grep --invert-match --extended-regexp "\.jpg$|/tmp/"' " MacOSX
 else
   let g:ctrlp_user_command =
-    \ 'find %s -type f | grep -v -P "\.jpg$|/tmp/"'          " MacOSX/Linux
+    \ 'find %s -type f | grep -v -P "\.jpg$|/tmp/"'          " Linux
 endif
 if !exists('g:ctrlp_match_func') && (has('python') || has('python3'))
   let g:ctrlp_match_func = { 'match': 'pymatcher#PyMatch'  }


### PR DESCRIPTION
Grep doesn't have the -P option in macOS

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Fixes bug when using CtrlP in SpaceVim on macOS. grep on macOS doesn't have the `-P, --perl-regexp` option.
