### PR TITLE
preserve g:indentLine_fileTypeExclude setting in layers/ui.vim

### DIFF
--- a/autoload/SpaceVim/layers/ui.vim
+++ b/autoload/SpaceVim/layers/ui.vim
@@ -46,7 +46,8 @@ function! SpaceVim#layers#ui#config() abort
   let g:indentLine_concealcursor = 'niv'
   let g:indentLine_conceallevel = 2
   let g:indentLine_enabled = s:enable_indentline
-  let g:indentLine_fileTypeExclude = ['help', 'man', 'startify', 'vimfiler', 'json']
+  let g:indentLine_fileTypeExclude = get(g:, 'indentLine_fileTypeExclude', [])
+  let g:indentLine_fileTypeExclude += ['help', 'man', 'startify', 'vimfiler', 'json']
   let g:better_whitespace_filetypes_blacklist = ['diff', 'gitcommit', 'unite',
         \ 'qf', 'help', 'markdown', 'leaderGuide',
         \ 'startify'


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]

``indentLine`` conflicts with jez/vim-better-sml plugins, which also use conceal.  ``indentLine`` has an option ``g:indentLine_fileTypeExclude`` to disable it for specified filetypes, but it's overwritten in ``layers/ui.vim``.  I have try adding 'sml' to this option in bootstrap_after, but sadly it doesn't work.

So, I want ``layers/ui.vim`` preserve original option value instead of replacing it.