### PR TITLE
fixed tagbar from finding and using bash.exe under windows

### DIFF
--- a/bundle/tagbar/autoload/tagbar.vim
+++ b/bundle/tagbar/autoload/tagbar.vim
@@ -2661,7 +2661,7 @@ function! s:ExecuteCtags(ctags_cmd) abort
         set noshellslash
     endif
 
-    if executable('bash') && has('nvim')
+    if executable('/bin/bash') && has('nvim')
         let shell_save = &shell
         let shellcmdflag_save = &shellcmdflag
         set shell=bash

--- a/config/main.vim
+++ b/config/main.vim
@@ -38,7 +38,7 @@ if has('win16') || has('win32') || has('win64')
     " ref: https://superuser.com/questions/524669/checking-where-a-symbolic-link-points-at-in-windows-7
     silent let rst = system(cmd)
     if !v:shell_error
-      let dir = split(rst)[-1][1:-2]
+      let dir = split(rst, '\[\|\]')[-2]
       return dir
     endif
     return a:path


### PR DESCRIPTION

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [X] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Under Windows and NVim, executable('bash') was finding bash.exe (probably WSL's), but the command "ctags --version" was not found (event though exuberant ctags is installed in WSL)… maybe bash was looking for an executable named "ctags --version" with the space part of its name…

I just thought /bin/bash would find bash without .exe (under Linux systems)

But I'm not sure if the original intent was to run bash under Windows and NVim if available
