### PR TITLE
fixed initial runtimepath when home path contains a space under Windows

### DIFF
--- a/config/main.vim
+++ b/config/main.vim
@@ -38,7 +38,7 @@ if has('win16') || has('win32') || has('win64')
     " ref: https://superuser.com/questions/524669/checking-where-a-symbolic-link-points-at-in-windows-7
     silent let rst = system(cmd)
     if !v:shell_error
-      let dir = split(rst)[-1][1:-2]
+      let dir = split(rst, '\[\|\]')[-2]
       return dir
     endif
     return a:path


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [X] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [X] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

fixed initial runtimepath when home path contains a space under Windows
