### PR TITLE
Fix gitstatus not shown in defx

### DIFF
--- a/config/plugins/defx.vim
+++ b/config/plugins/defx.vim
@@ -18,7 +18,7 @@ function! s:setcolum() abort
   if g:spacevim_enable_vimfiler_filetypeicon && !g:spacevim_enable_vimfiler_gitstatus
     return 'indent:icons:filename:type'
   elseif !g:spacevim_enable_vimfiler_filetypeicon && g:spacevim_enable_vimfiler_gitstatus
-    return 'indent:icons:filename:type'
+    return 'indent:git:filename:type'
   elseif g:spacevim_enable_vimfiler_filetypeicon && g:spacevim_enable_vimfiler_gitstatus
     return 'indent:git:icons:filename:type'
   else


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [X] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?
When ```g:spacevim_enable_vimfiler_filetypeicon``` is ```false``` and ```g:spacevim_enable_vimfiler_gitstatus``` is ```true```, the icons are shown instead of the gitstatus. You expect to see gitstatus and no icons, but you will see icons and no gitstatus. This is not the correct behaviour. Changed icons to git in order to fix it.