### PR TITLE
Ignore .git for rg searches

### DIFF
--- a/autoload/SpaceVim/plugins/searcher.vim
+++ b/autoload/SpaceVim/plugins/searcher.vim
@@ -55,7 +55,7 @@ function! s:get_search_cmd(exe, expr) abort
   if a:exe ==# 'grep'
     return ['grep', '-inHR', '--exclude-dir', '.git', a:expr, '.']
   elseif a:exe ==# 'rg'
-    return ['rg', '--hidden', '--no-heading', '--color=never', '--with-filename', '--line-number', a:expr, '.']
+    return ['rg', '-g!.git', '--hidden', '--no-heading', '--color=never', '--with-filename', '--line-number', a:expr, '.']
   else
     return [a:exe, a:expr]
   endif


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

`SPC s g j` search ignores .git while `SPC s r j` does not. This configures rg-based search to work as grep search does (see https://github.com/SpaceVim/SpaceVim/blob/751725315fe5f8147fd391fcd629dc06c52aa0af/autoload/SpaceVim/plugins/searcher.vim#L56)
