### PR TITLE
fix(vim-jsx-typescript): remove blank line that was throwing an error

### DIFF
--- a/bundle/vim-jsx-typescript/ftdetect/typescript.vim
+++ b/bundle/vim-jsx-typescript/ftdetect/typescript.vim
@@ -2,5 +2,4 @@
 " Vim ftdetect file
 " Language: TSX (Typescript)
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
 autocmd BufNewFile,BufRead *.tsx setf typescriptreact


### PR DESCRIPTION
Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]

see https://github.com/SpaceVim/SpaceVim/commit/6e25213d3ef55043de5b0379e09e3d1515ed1480#r44754382
for an example of the error message introduced by #3993, this PR eliminates
that error message.