### PR TITLE
fix(ctrlp): invocation of printf() had the wrong number of arguments

### DIFF
--- a/autoload/SpaceVim/layers/ctrlp.vim
+++ b/autoload/SpaceVim/layers/ctrlp.vim
@@ -50,7 +50,7 @@ function! SpaceVim#layers#ctrlp#config() abort
         \ ],
         \ 1)
   " @fixme SPC h SPC make vim flick
-  exe printf('nmap %sh%s [SPC]h[SPC]', g:spacevim_default_custom_leader)
+  exe printf('nmap %sh%s [SPC]h[SPC]', g:spacevim_default_custom_leader, g:spacevim_default_custom_leader)
 
   let lnum = expand('<slnum>') + s:lnum - 1
   call SpaceVim#mapping#space#def('nnoremap', ['b', 'b'], 'CtrlPBuffer',


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

After #2792, I saw the following error message on starting vim:

```
Error detected while processing function SpaceVim#end[96]..SpaceVim#plugins#load[4]..<SNR>83_load_plugins[16]..<SN
R>83_loadLayerConfig[2]..SpaceVim#layers#ctrlp#config:
line   26:
E766: Insufficient arguments for printf()
Error detected while processing function SpaceVim#end[96]..SpaceVim#plugins#load[4]..<SNR>83_load_plugins:
line   16:
E170: Missing :endfor
Error detected while processing function SpaceVim#end[96]..SpaceVim#plugins#load:
line    4:
E171: Missing :endif
Press ENTER or type command to continue
```

Since the invocation of `printf()` [here](https://github.com/wsdjeg/SpaceVim/blob/1d46a80ec60b78fac274115f9df9f869f96ce922/autoload/SpaceVim/layers/ctrlp.vim#L53) has two `%s`, `printf()` needs three arguments.