### PR TITLE
Fully automate dev setup with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,4 @@
+image: gitpod/workspace-full
+
+tasks:
+  - init: make

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/SpaceVim/SpaceVim)
+
 [![SpaceVim](https://spacevim.org/logo.png)](https://spacevim.org)
 
 [Wiki](https://github.com/SpaceVim/SpaceVim/wiki) \|


### PR DESCRIPTION
This commit implements a fully-automated development setup using Gitpod.io, an
online IDE for GitLab, GitHub, and Bitbucket that enables Dev-Environments-As-Code.
This PR makes it easy for anyone to get a ready-to-code workspace for any branch,
issue or pull request almost instantly with a single click.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Adding the ability to quickly and easily start and enter a GitPod container from the project page dramatically decreases the project's barrier-to-entry. 

With this configuration included, one only has to visit the project page and click the button to have a fully provisioned development environment with the repository checked out, no downloads or setup required. Without this PR, individual developers would need to create their own GitPod configuration, and in fact, I made these commits to my fork as a part of setting up my GitPod container; I'm just trying to save future developers the same effort :)

While there are multiple solutions such as this, including GitHub's Codespaces, I believe GitPod is currently the best choice here. Codespaces is neither finished nor widely available, and even those with access can only have two created at a time. Other than GitHub Codespaces, GitPod is the most commonly implemented solution of this nature, from what I have seen.