### PR TITLE
Chore: Add compatibility with podman for build task.

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,2 +1,13 @@
+HAVE_DOCKER := $(shell which docker 2>/dev/null)
+HAVE_PODMAN := $(shell which podman 2>/dev/null)
+
 build:
-		docker build -t nvim -f Dockerfile.nvim-python3 .
+ifdef HAVE_DOCKER	
+	docker build -t nvim -f Dockerfile.nvim-python3 .
+else
+ifdef HAVE_PODMAN
+	podman build -t nvim -f Dockerfile.nvim-python3 .
+else
+	$(error "No docker or podman in $(PATH). Check if one was installed.")
+endif
+endif


### PR DESCRIPTION
Change in Makefile for build with docker or podman via one interface. Also add error if no docker or podman installed.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Users that uses podman cannot use old Makefile without changes. This simple update allow users use any engine.
[Please explain **in detail** why the changes in this PR are needed.]
