### PR TITLE
fix (layer): Remove error when file name contains curly brace

### DIFF
--- a/autoload/SpaceVim/api/vim/statusline.vim
+++ b/autoload/SpaceVim/api/vim/statusline.vim
@@ -25,7 +25,8 @@ let s:self.__bufnr = -1
 function! s:self.len(sec) abort
   let str = matchstr(a:sec, '%{.*}')
   if !empty(str)
-    return len(a:sec) - len(str) + len(eval(str[2:-2])) + 4
+    let pos = match(str, '}')
+    return len(a:sec) - len(str) + len(eval(str[2:pos-1])) + 4
   else
     return len(a:sec) + 4
   endif


### PR DESCRIPTION
eval() in the len() function now evals from the 3rd character to the character before the first right hand curly brace

Regarding issue #3976

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [yes] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [yes] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [yes] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?
This is fully elaborated in the issue https://github.com/SpaceVim/SpaceVim/issues/3976

Working with files that contain a curly braces lead to errors when: opening said file, closing said file, switching buffers from or to said file, saving said file. 

The code previously used an eval() which goes from str[2:-2], but with a file name containing a right curly brace, `sec` is contains both the command `%{ command }` and the ~`315 bytes the{file}.php`. Perhaps the issue is in the code that calls statusline.vim s:self.len(sec)... But this seems to be working.
