### PR TITLE
Print error if user's bootstrap was unsuccessful

### DIFF
--- a/autoload/SpaceVim/autocmds.vim
+++ b/autoload/SpaceVim/autocmds.vim
@@ -171,11 +171,24 @@ function! SpaceVim#autocmds#VimEnter() abort
   if !empty(get(g:, '_spacevim_bootstrap_after', ''))
     try
       call call(g:_spacevim_bootstrap_after, [])
+      let g:_spacevim_bootstrap_after_success = 1
     catch
       call SpaceVim#logger#error('failed to call bootstrap_after function: ' . g:_spacevim_bootstrap_after)
       call SpaceVim#logger#error('       exception: ' . v:exception)
       call SpaceVim#logger#error('       throwpoint: ' . v:throwpoint)
+      let g:_spacevim_bootstrap_after_success = 0
     endtry
+  endif
+
+  if !get(g:, '_spacevim_bootstrap_before_success', 1)
+    echohl Error
+    echom 'bootstrap_before function failed to execute. Check `SPC h L` for errors.'
+    echohl None
+  endif
+  if !get(g:, '_spacevim_bootstrap_after_success', 1)
+    echohl Error
+    echom 'bootstrap_after function failed to execute. Check `SPC h L` for errors.'
+    echohl None
   endif
 endfunction
 

--- a/autoload/SpaceVim/custom.vim
+++ b/autoload/SpaceVim/custom.vim
@@ -160,10 +160,12 @@ function! SpaceVim#custom#apply(config, type) abort
     if !empty(bootstrap_before)
       try
         call call(bootstrap_before, [])
+        let g:_spacevim_bootstrap_before_success = 1
       catch
         call SpaceVim#logger#error('failed to call bootstrap_before function: ' . bootstrap_before)
         call SpaceVim#logger#error('       exception: ' . v:exception)
         call SpaceVim#logger#error('       throwpoint: ' . v:throwpoint)
+        let g:_spacevim_bootstrap_before_success = 0
       endtry
     endif
   endif


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Resolves #4079.

### Implementation

I've used `echom` to display the messages instead of `echoerr`. The second could potentially block neovim-qt.
The message is short, user is redirected to `SPC h L` where more info can be found.