### PR TITLE
Fix smart close issue for Vim

### DIFF
--- a/autoload/SpaceVim/mapping.vim
+++ b/autoload/SpaceVim/mapping.vim
@@ -302,7 +302,7 @@ fu! SpaceVim#mapping#SmartClose() abort
         \ && exists('*popup_list')
         \ && exists('*popup_getoptions')
         \ && exists('*popup_getpos')
-    let popup_count =  len(
+    let win_count =  len(
           \ filter(
           \ map(
           \ filter(popup_list(), 'popup_getpos(v:val).visible'),


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]

In Vim, when use "q" for smart close window, it will return the error as below
```
Error detected while processing function SpaceVim#mapping#SmartClose:
line   19:
E121: Undefined variable: win_count
```