### PR TITLE
Set `tabstop`, `softtabstop` and `shiftwidth` to the same value only if default_indent is positive

### DIFF
--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -1359,9 +1359,12 @@ function! SpaceVim#end() abort
   " tab options:
   set smarttab
   let &expandtab = g:spacevim_expand_tab
-  let &tabstop = g:spacevim_default_indent
-  let &softtabstop = g:spacevim_default_indent
-  let &shiftwidth = g:spacevim_default_indent
+  
+  if g:spacevim_default_indent > 0
+    let &tabstop = g:spacevim_default_indent
+    let &softtabstop = g:spacevim_default_indent
+    let &shiftwidth = g:spacevim_default_indent
+  endif
 
   let g:unite_source_menu_menus =
         \ get(g:,'unite_source_menu_menus',{})


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Sometimes `tapstop`, `softtabstop` and `shiftwidth` may need to be set separately to different values in a bootstrap function.

