### PR TITLE
Update gtags install guide

### DIFF
--- a/docs/cn/layers/gtags.md
+++ b/docs/cn/layers/gtags.md
@@ -68,26 +68,25 @@ sudo apt-get install exuberant-ctags python-pygments
 **ArchLinux**
 
 ```sh
-sudo pacman -S ctags python-pygments
+sudo pacman -S ctags global python-pygments
 ```
 
 **编译安装**
 
-下载最新的 tar.gz 文件，执行如下命令：
+下载最新的 [tar.gz](http://tamacom.com/global/global-6.6.5.tar.gz) 文件，执行如下命令：
 
 ```sh
-tar xvf global-6.5.3.tar.gz
-cd global-6.5.3
+tar xvf global-6.5.5.tar.gz
+cd global-6.5.5
 ./configure --with-exuberant-ctags=/usr/bin/ctags
 make
 sudo make install
 ```
 
-To be able to use pygments and ctags, you need to copy the sample gtags.conf either to /etc/gtags.conf or
-如果需要启用 pygments 和 ctags，需要复制示例 gtags.conf 至 `/etc/gtags.conf` 或者 `$HOME/.globalrc`。例如：
+如果需要启用 pygments 和 ctags，需要复制示例 gtags.conf.in 至 `/etc/gtags.conf` 或者 `$HOME/.globalrc`。例如：
 
 ```sh
-cp gtags.conf ~/.globalrc
+cp gtags.conf.in ~/.globalrc
 ```
 
 此外，启动 shell 时需要设置环境变量 `GTAGSLABEL`，通常需要修改 `.profile` 文件。


### PR DESCRIPTION
ArchLinux needs to install global. `gtags.conf` is [dead](http://cvs.savannah.gnu.org/viewvc/global/global/), and the newer one is `gtags.conf.in`. #1687

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [√] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [√] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [√] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]
