### PR TITLE
disable colors for ipython repl

### DIFF
--- a/autoload/SpaceVim/layers/lang/python.vim
+++ b/autoload/SpaceVim/layers/lang/python.vim
@@ -85,7 +85,7 @@ function! SpaceVim#layers#lang#python#config() abort
   call SpaceVim#mapping#space#regesit_lang_mappings('python', function('s:language_specified_mappings'))
   call SpaceVim#layers#edit#add_ft_head_tamplate('python', s:python_file_head)
   if executable('ipython')
-    call SpaceVim#plugins#repl#reg('python', 'ipython --no-term-title')
+    call SpaceVim#plugins#repl#reg('python', 'ipython --no-term-title --colors=NoColor')
   elseif executable('python')
     call SpaceVim#plugins#repl#reg('python', ['python', '-i'])
   endif

--- a/autoload/SpaceVim/plugins/repl.vim
+++ b/autoload/SpaceVim/plugins/repl.vim
@@ -56,7 +56,7 @@ function! SpaceVim#plugins#repl#send(type, ...) abort
   if !exists('s:job_id')
     echom('Please start REPL via the key binding "SPC l s i" first.')
   elseif s:job_id == 0
-    echom('please retart the REPL')
+    echom('please restart the REPL')
   else
     if a:type ==# 'line'
       call s:JOB.send(s:job_id, [getline('.'), ''])


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Currently the ipython repl will output the raw ascii escape sequences for example when some code execution fails.
This behavior could be prevented by disabling the colorized output of the repl by providing --colors=NoColor cmdline parameter.

Before:
![before](https://user-images.githubusercontent.com/16268238/111168334-43958280-85a2-11eb-8b97-e75b9a9c758c.png)

After:
![after](https://user-images.githubusercontent.com/16268238/111168360-4bedbd80-85a2-11eb-859f-92d749d4858c.png)