### PR TITLE
Doc: Fix typos

### DIFF
--- a/doc/SpaceVim.txt
+++ b/doc/SpaceVim.txt
@@ -216,8 +216,8 @@ will also be added to runtimepath.
 here is an example setting SpaceVim options:
 >
   [options]
-    enable-guicolors = true
-    max-column = 120
+    enable_guicolors = true
+    max_column = 120
 <
 
 ==============================================================================
@@ -238,7 +238,7 @@ Set the autocomplete engine of spacevim, the default logic is:
   endif
 <
 
-and you can alse set this option to coc, then coc.nvim will be used.
+and you can also set this option to coc, then coc.nvim will be used.
 
 ==============================================================================
 AUTOCOMPLETE_PARENS                     *SpaceVim-options-autocomplete_parens*


### PR DESCRIPTION
"enable-guicolors" should be "enable_guicolors".
"max-column" should be "max_column".
"alse" should be "also".

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]

Typos should be corrected :)
