### PR TITLE
Add format_on_save toggle for javascript

### DIFF
--- a/autoload/SpaceVim/layers/lang/javascript.vim
+++ b/autoload/SpaceVim/layers/lang/javascript.vim
@@ -47,7 +47,7 @@
 " <
 "
 
-
+let s:format_on_save = 0
 
 function! SpaceVim#layers#lang#javascript#plugins() abort
   let plugins = [
@@ -86,6 +86,9 @@ let s:enable_flow_syntax = 0
 function! SpaceVim#layers#lang#javascript#set_variable(var) abort
   let s:auto_fix = get(a:var, 'auto_fix', 0)
   let s:enable_flow_syntax = get(a:var, 'enable_flow_syntax', 0)
+  let s:format_on_save = get(a:var,
+        \ 'format_on_save',
+        \ s:format_on_save)
 endfunction
 
 function! SpaceVim#layers#lang#javascript#config() abort
@@ -136,6 +139,14 @@ function! SpaceVim#layers#lang#javascript#config() abort
   " be flushed by sender.
   " Use node -i will show the output of repl command.
   call SpaceVim#plugins#repl#reg('javascript', ['node', '-i'])
+
+  " Format on save
+  if s:format_on_save
+    call SpaceVim#layers#format#add_filetype({
+          \ 'filetype' : 'javascript',
+          \ 'enable' : 1,
+          \ })
+  endif
 endfunction
 
 function! s:on_ft() abort

--- a/docs/layers/lang/javascript.md
+++ b/docs/layers/lang/javascript.md
@@ -53,6 +53,15 @@ auto_fix = true
 enable_flow_syntax = true
 ```
 
+`format_on_save`: Enable/disable file formatting when saving current javascript file. By default,
+it is disabled, to enable it:
+```toml
+[[layers]]
+    name = 'lang#javascript'
+    format_on_save = true
+  ```
+
+
 ## Key bindings
 
 ### Import key bindings


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]

I used python.vim as an example how `format_on_save` is handled and added it to javascript.