### PR TITLE
Fix random theme functionality of the [colorscheme] layer

### DIFF
--- a/autoload/SpaceVim/layers/colorscheme.vim
+++ b/autoload/SpaceVim/layers/colorscheme.vim
@@ -87,18 +87,19 @@ function! SpaceVim#layers#colorscheme#config() abort
   if s:random_colorscheme
     let ctime = ''
     " Use local file's save time, the local file is
-    " ~/.cache/SpaceVim/colorscheme_frequence.json
-    " {"fequecnce" : "dalily", "last" : 000000, 'theme' : 'one'}
+    " ~/.cache/SpaceVim/colorscheme_frequency.json
+    " {"frequency" : "dalily", "last" : 000000, 'theme' : 'one'}
     " FIXME: when global config cache is updated, check the cache also should
     " be updated
-    if filereadable(expand(g:spacevim_data_dir.'/SpaceVim/colorscheme_frequence.json'))
-      let conf = s:JSON.json_decode(join(readfile(expand(g:spacevim_data_dir.'/SpaceVim/colorscheme_frequence.json'), ''), ''))
+    if filereadable(expand(g:spacevim_data_dir.'/SpaceVim/colorscheme_frequency.json'))
+      let conf = s:JSON.json_decode(join(readfile(expand(g:spacevim_data_dir.'/SpaceVim/colorscheme_frequency.json'), ''), ''))
       if s:random_frequency !=# '' && !empty(conf)
         let ctime = localtime()
         if index(s:random_candidates, get(conf, 'theme', '')) == -1 ||
-              \ ctime - get(conf, 'last', 0) >= get(s:time,  get(conf, 'fequecnce', ''), 0)
+              \ ctime - get(conf, 'last', 0) >= get(s:time,  get(conf, 'frequency', ''), 0)
           let id = s:NUMBER.random(0, len(s:random_candidates))
           let g:spacevim_colorscheme = s:random_candidates[id]
+          echom len(s:random_candidates)
           call s:update_conf()
         else
           let g:spacevim_colorscheme = conf.theme
@@ -120,11 +121,11 @@ endfunction
 
 function! s:update_conf() abort
   let conf = {
-        \ 'fequecnce' : s:random_frequency,
+        \ 'frequency' : s:random_frequency,
         \ 'last' : localtime(),
         \ 'theme' : g:spacevim_colorscheme
         \ }
-  call writefile([s:JSON.json_encode(conf)], expand(g:spacevim_data_dir.'/SpaceVim/colorscheme_frequence.json'))
+  call writefile([s:JSON.json_encode(conf)], expand(g:spacevim_data_dir.'/SpaceVim/colorscheme_frequency.json'))
 endfunction
 
 

--- a/autoload/SpaceVim/layers/colorscheme.vim
+++ b/autoload/SpaceVim/layers/colorscheme.vim
@@ -99,7 +99,6 @@ function! SpaceVim#layers#colorscheme#config() abort
               \ ctime - get(conf, 'last', 0) >= get(s:time,  get(conf, 'frequency', ''), 0)
           let id = s:NUMBER.random(0, len(s:random_candidates))
           let g:spacevim_colorscheme = s:random_candidates[id]
-          echom len(s:random_candidates)
           call s:update_conf()
         else
           let g:spacevim_colorscheme = conf.theme


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [X] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [X] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]

The random colorscheme functionality, uses a JSON key "frequency" according to [Documentation](https://spacevim.org/layers/colorscheme/#configuration).
However, in  https://github.com/SpaceVim/SpaceVim/blob/e780e6711260e51787475d91d81c99bc0e2b1649/autoload/SpaceVim/layers/colorscheme.vim#L99 and in
https://github.com/SpaceVim/SpaceVim/blob/e780e6711260e51787475d91d81c99bc0e2b1649/autoload/SpaceVim/layers/colorscheme.vim#L123
`frequency` or `frequence` is misspelled as `fequecnce`, causing the customized frequency not working.

And I noticed some inconsistency of using both "frequency" and "frequence", which is error-prone.

I fixed its functionality by changing all of them to "frequency".