### PR TITLE
fix gtags completion and list project files

### DIFF
--- a/autoload/SpaceVim/layers/gtags.vim
+++ b/autoload/SpaceVim/layers/gtags.vim
@@ -26,7 +26,7 @@ function! SpaceVim#layers#gtags#config() abort
   let g:_spacevim_mappings_space.m.g = {'name' : '+gtags'}
   call SpaceVim#mapping#space#def('nnoremap', ['m', 'g', 'c'], 'GtagsGenerate!', 'create-a-gtags-database', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['m', 'g', 'u'], 'GtagsGenerate', 'update-tag-database', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['m', 'g', 'p'], 'Gtags -p', 'list-all-file-in-GTAGS', 1)
+  call SpaceVim#mapping#space#def('nnoremap', ['m', 'g', 'p'], 'Gtags -P', 'list-all-file-in-GTAGS', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['m', 'g', 'd'], 'exe "Gtags -d " . expand("<cword>")', 'find-definitions', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['m', 'g', 'r'], 'exe "Gtags -r " . expand("<cword>")', 'find-references', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['m', 'g', 's'], 'exe "Gtags -s " . expand("<cword>")', 'find-cursor-symbol', 1)

--- a/bundle/gtags.vim/autoload/gtags.vim
+++ b/bundle/gtags.vim/autoload/gtags.vim
@@ -302,7 +302,11 @@ function! s:ExecLoad(option, long_option, pattern) abort
   " Parse the output of 'global -x or -t' and show in the quickfix window.
   let l:efm_org = &efm
   let &efm = g:Gtags_Efm
-  cexpr! l:result
+  if l:result =~# '\n.'
+    cgetexpr l:result
+  else
+    cexpr! l:result
+  endif
   let &efm = l:efm_org
 endfunction
 

--- a/bundle/gtags.vim/autoload/gtags.vim
+++ b/bundle/gtags.vim/autoload/gtags.vim
@@ -266,7 +266,6 @@ function! s:ExecLoad(option, long_option, pattern) abort
     let $GTAGSDBPATH = ''
   endif
 
-  e
   if v:shell_error != 0
     if v:shell_error == 2
       call s:Error('invalid arguments. (gtags.vim requires GLOBAL 5.7 or later)')
@@ -357,7 +356,7 @@ function! gtags#global(line) abort
     if l:option =~# 'f'
       let l:line = input('Gtags for file: ', expand('%'), 'file')
     else
-      let l:line = input('Gtags for pattern: ', expand('<cword>'), 'custom,GtagsCandidateCore')
+      let l:line = input('Gtags for pattern: ', expand('<cword>'), 'custom,gtags#complete')
     endif
     let l:pattern = s:Extract(l:line, 'pattern')
     if l:pattern ==# ''


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

1. completion function in gtags.vim is wrong, fixed.
2. should use ``Gtags -P`` instead of ``Gtags -p`` to list project files
3. there's a ``e`` in ``gtags.vim``, maybe typo?
4. only jump to result when there's only one search result
5. completion should also set ``$GTAGSDBPATH``
