### PR TITLE
Add: Project-specific debugger configuration.

### DIFF
--- a/autoload/SpaceVim/layers/debug.vim
+++ b/autoload/SpaceVim/layers/debug.vim
@@ -38,15 +38,23 @@ function! SpaceVim#layers#debug#config() abort
 endfunction
 
 function! SpaceVim#layers#debug#launching(ft) abort
+  if exists('g:spacevim_debug_config')
+    let s:config = getcwd() . '/' . g:spacevim_debug_config
+  else
+    let s:config = getcwd() . '/.vim/debug.vim'
+  endif
+
   if a:ft ==# 'python'
     exe 'VBGstartPDB ' . bufname('%')
   elseif a:ft ==# 'ruby'
     exe 'VBGstartRDebug ' . bufname('%')
   elseif a:ft ==# 'powershell'
     exe 'VBGstartPowerShell ' . bufname('%')
+  elseif filereadable(s:config)
+    exe "source " . fnameescape(s:config)
   else
     echohl WarningMsg
-    echo 'read :h vebugger-launching'
+    echo 'No configuration file found, see :h vebugger-launching'
     echohl None
   endif
 endfunction

--- a/docs/layers/debug.md
+++ b/docs/layers/debug.md
@@ -27,6 +27,19 @@ To use this configuration layer, add following snippet to your custom configurat
   name = "debug"
 ```
 
+In order to configure which debugger needs to be started, a project should define a configuration
+file in the project root.
+
+By default, SpaceVim will look for `.vim/debug.vim`, though this can be overridden by setting
+`g:spacevim_debug_config` another relative file path.
+
+This configuration file should contain the command to start the debugger.
+
+Example `.vim/debug.vim` in a Rust project root:
+```vim
+call vebugger#gdb#start('target/debug/myapp', {'args': ['hello', 'world']})
+```
+
 ## Key bindings
 
 | Key Binding | Description                              |


### PR DESCRIPTION
_Support a project-specific debug configuration file to define the action to be performed when launching the debugger._

In the current implementation, there is no out-of-the-box support for launching a debugger, with the exception of powershell, ruby and python scripts.

This small PR introduces support for a simple Vim file which is sourced when the user launches the debugger (`[SPC] d l`).
This file - by default `.vim/debug.vim` (relative to the project root) should contain the launch command, e.g.:
```vim
call vebugger#gdb#start('target/debug/myapp', {'args': ['hello', 'world']})
```

Additionally, this PR makes the path to the Vim file configurable through the `g:spacevim_debug_config` variable. If it is set, the debug layer will read from the specified file instead.