### PR TITLE
Add split flygrep horizontally across vertical split

### DIFF
--- a/autoload/SpaceVim/plugins/flygrep.vim
+++ b/autoload/SpaceVim/plugins/flygrep.vim
@@ -838,7 +838,7 @@ function! SpaceVim#plugins#flygrep#open(argv) abort
           \ 'col': 0
           \ })
   else
-    noautocmd rightbelow split __flygrep__
+    noautocmd botright split __flygrep__
     let s:flygrep_win_id = win_getid()
   endif
   if exists('&winhighlight')


### PR DESCRIPTION
Hi There,

Thank you for working on SpaceVim! :)

This minuscule PR allow flygrep to split horizontally across vertical windows so can be consistent with the other plugin/panels and also because the flygrep output requires a lot of horizontal space