### PR TITLE
Change: Update lang#html layer to install emmet for ERB

### DIFF
--- a/autoload/SpaceVim/layers/lang/html.vim
+++ b/autoload/SpaceVim/layers/lang/html.vim
@@ -59,7 +59,7 @@ function! SpaceVim#layers#lang#html#config() abort
   let g:user_emmet_leader_key = s:user_emmet_leader_key
   augroup spacevim_lang_html
     autocmd!
-    autocmd FileType html,css,scss,sass,less,javascript,jsp,vue,eex,php call s:install_emmet()
+    autocmd FileType html,css,scss,sass,less,javascript,jsp,vue,eex,php,erb call s:install_emmet()
     autocmd Filetype html setlocal omnifunc=htmlcomplete#CompleteTags
     autocmd FileType css setlocal omnifunc=csscomplete#CompleteCSS
   augroup END


### PR DESCRIPTION
### PR Prelude

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Ruby projects (mostly Rails) use the ERB extension in their HTML files. 

Given view files are named like `some_template.html.erb` the emmet plugin was not being installed.
