### PR TITLE
Fixed typescript installation issue

### DIFF
--- a/docs/layers/lang/typescript.md
+++ b/docs/layers/lang/typescript.md
@@ -28,12 +28,18 @@ To use this configuration layer, update your custom configuration file with:
 [[layers]]
   name = "lang#typescript"
 ```
+and also use npm to install neovim using:
+```bash
+npm install -g neovim
+```
+then in SpaceVim run `:UpdateRemotePlugin`
 
 To generate doc of typescript file, you need to install [lehre](https://www.npmjs.com/package/lehre)
 
 ```
 yarn add -D lehre
 ```
+
 
 ## Layer options
 


### PR DESCRIPTION
Spacevim's typescript support does not install properly w/o installing npm neovim plugin first on a system level.

### PR Prelude

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

The Spacevim's documentation doesn't mention anything about installing neovim. However, the nvim-typescript does mention it on their readme. It would be a better user experience if the documentation was also placed into the SpaceVim's documentation so that new users don't mistake this issue as a bug. 


