### PR TITLE
Fix layer lang::markdown install

### DIFF
--- a/autoload/SpaceVim/layers/lang/markdown.vim
+++ b/autoload/SpaceVim/layers/lang/markdown.vim
@@ -52,10 +52,10 @@ function! SpaceVim#layers#lang#markdown#plugins() abort
   call add(plugins, ['iamcco/mathjax-support-for-mkdp',{ 'on_ft' : 'markdown'}])
   call add(plugins, ['lvht/tagbar-markdown',{'merged' : 0}])
   " check node package managers to ensure building of 2 plugins below
-  if executable('npm')
-    let s:node_pkgm = 'npm'
-  elseif executable('yarn')
+  if executable('yarn')
     let s:node_pkgm = 'yarn'
+  elseif executable('npm')
+    let s:node_pkgm = 'npm'
   else
     let s:node_pkgm = ''
     call SpaceVim#logger#error('npm or yarn is required to build iamcco/markdown-preview and neoclide/vim-node-rpc')


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]

Recently, I found the layer lang::markdown always build failed. 
<img width="910" alt="Screen Shot 2021-07-06 at 17 26 55" src="https://user-images.githubusercontent.com/16577489/124577023-792ae800-de7f-11eb-93a1-0b4de43e37ec.png">
The reason is some dependencies of the npm packages are conflict, with npm install, it will faill,  but success with yarn install. So I change the order of s:node_pkgm, make yarn to be prioritized. Hope the npm package can fix the issue.
<img width="942" alt="Screen Shot 2021-07-06 at 17 28 49" src="https://user-images.githubusercontent.com/16577489/124577222-a4153c00-de7f-11eb-8131-4e50500a74e9.png">
