### PR TITLE
update default go-lsp to gopls

### DIFF
--- a/autoload/SpaceVim/layers/lang/go.vim
+++ b/autoload/SpaceVim/layers/lang/go.vim
@@ -55,7 +55,7 @@ function! SpaceVim#layers#lang#go#config() abort
   let g:go_highlight_structs = 1
   let g:go_highlight_operators = 1
   let g:go_highlight_build_constraints = 1
-  let g:go_fmt_command = 'goimports'
+  let g:go_fmt_command = 'gopls'
   let g:syntastic_go_checkers = ['golint', 'govet']
   let g:syntastic_mode_map = { 'mode': 'active', 'passive_filetypes': ['go'] }
   let g:neomake_go_gometalinter_args = ['--disable-all']

--- a/autoload/SpaceVim/layers/lsp.vim
+++ b/autoload/SpaceVim/layers/lsp.vim
@@ -128,7 +128,7 @@ let s:lsp_servers = {
       \ 'css' : ['css-languageserver', '--stdio'],
       \ 'dart' : ['dart_language_server'],
       \ 'dockerfile' : ['docker-langserver', '--stdio'],
-      \ 'go' : ['go-langserver', '-mode', 'stdio'],
+      \ 'go' : ['gopls'],
       \ 'haskell' : ['hie-wrapper', '--lsp'],
       \ 'html' : ['html-languageserver', '--stdio'],
       \ 'javascript' : ['javascript-typescript-stdio'],

--- a/docs/cn/layers/language-server-protocol.md
+++ b/docs/cn/layers/language-server-protocol.md
@@ -135,7 +135,7 @@ gem install solargraph
 | `crystal`    | `['scry']`                                                                                                                                                                                       |
 | `css`        | `['css-languageserver', '--stdio']`                                                                                                                                                              |
 | `dart`       | `['dart_language_server']`                                                                                                                                                                       |
-| `go`         | `['go-langserver', '-mode', 'stdio']`                                                                                                                                                            |
+| `go`         | `['gopls']`                                                                                                                                                            |
 | `haskell`    | `['hie', '--lsp']`                                                                                                                                                                               |
 | `html`       | `['html-languageserver', '--stdio']`                                                                                                                                                             |
 | `javascript` | `['javascript-typescript-stdio']`                                                                                                                                                                |

--- a/docs/layers/language-server-protocol.md
+++ b/docs/layers/language-server-protocol.md
@@ -161,7 +161,7 @@ default language server commands:
 | `css`        | `['css-languageserver', '--stdio']`                                                                                                                                                              |
 | `dart`       | `['dart_language_server']`                                                                                                                                                                       |
 | `elm`        | `['elm-language-server']`                                                                                                                                                                        |
-| `go`         | `['go-langserver', '-mode', 'stdio']`                                                                                                                                                            |
+| `go`         | `['gopls']`                                                                                                                                                            |
 | `haskell`    | `['hie', '--lsp']`                                                                                                                                                                               |
 | `html`       | `['html-languageserver', '--stdio']`                                                                                                                                                             |
 | `javascript` | `['javascript-typescript-stdio']`                                                                                                                                                                |


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

gopls is the default go-lsp for a while now, go-langserver wasn't updated since 2020 May.