### PR TITLE
Fix coffeescript api sys dependency

### DIFF
--- a/autoload/SpaceVim/layers/lang/coffeescript.vim
+++ b/autoload/SpaceVim/layers/lang/coffeescript.vim
@@ -38,9 +38,9 @@ if exists('s:coffee_interpreter')
   finish
 endif
 
-let s:coffee_interpreter = 'coffee' . (s:SYS.isWindows ? '.CMD' : '')
-
 let s:SYS = SpaceVim#api#import('system')
+
+let s:coffee_interpreter = 'coffee' . (s:SYS.isWindows ? '.CMD' : '')
 
 function! SpaceVim#layers#lang#coffeescript#plugins() abort
   let plugins = []


### PR DESCRIPTION
Adding the lang#coffeescript layer throws an error.

Last commit broke this layer as the `s:SYS` is called before the `#api#import` code.

Swapped the two lines to fix the problem.
