### PR TITLE
fix(flygrep): use current directory when none specified for ripgrep.

### DIFF
--- a/autoload/SpaceVim/plugins/flygrep.vim
+++ b/autoload/SpaceVim/plugins/flygrep.vim
@@ -127,7 +127,7 @@ function! s:get_search_cmd(expr) abort
     if s:grep_exe ==# 'rg' || s:grep_exe ==# 'ag' || s:grep_exe ==# 'pt'
       let cmd += ['.']
     endif
-    " let cmd += s:grep_ropt
+    let cmd += s:grep_ropt
   endif
   " let cmd = map(cmd, 'shellescape(v:val)')
   " if has('win32')

--- a/autoload/SpaceVim/plugins/flygrep.vim
+++ b/autoload/SpaceVim/plugins/flygrep.vim
@@ -123,11 +123,11 @@ function! s:get_search_cmd(expr) abort
     " if grep dir is empty, grep files is empty, which means searhing in
     " current directory.
     let cmd += [a:expr] 
-    " in window, when using rg, ag, need to add '.' at the end.
-    if s:SYS.isWindows && (s:grep_exe ==# 'rg' || s:grep_exe ==# 'ag' || s:grep_exe ==# 'pt' )
+    " when using rg, ag, need to add '.' at the end.
+    if s:grep_exe ==# 'rg' || s:grep_exe ==# 'ag' || s:grep_exe ==# 'pt'
       let cmd += ['.']
     endif
-    let cmd += s:grep_ropt
+    " let cmd += s:grep_ropt
   endif
   " let cmd = map(cmd, 'shellescape(v:val)')
   " if has('win32')


### PR DESCRIPTION

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

With Ripgrep's breaking change, `flygrep` won't provide search results unless a directory is specified as it expects input from `stdin`
See https://github.com/BurntSushi/ripgrep/issues/1892 
The suffix was already applied for windows systems and should be applied for other systems too.
The expected behavior is maintained for `ag` (tested on OS X)
