### PR TITLE
fix(lsp): specify cmd for typescriptreact

### DIFF
--- a/autoload/SpaceVim/layers/lsp.vim
+++ b/autoload/SpaceVim/layers/lsp.vim
@@ -150,6 +150,7 @@ let s:lsp_servers = {
       \ 'scala' : ['metals-vim'],
       \ 'sh' : ['bash-language-server', 'start'],
       \ 'typescript' : ['typescript-language-server', '--stdio'],
+      \ 'typescriptreact' : ['typescript-language-server', '--stdio'],
       \ 'vue' : ['vls']
       \ }
 

--- a/docs/layers/language-server-protocol.md
+++ b/docs/layers/language-server-protocol.md
@@ -152,31 +152,32 @@ To enable lsp support for a specified filetype, you may need to load this layer 
 
 default language server commands:
 
-| language     | server command                                                                                                                                                                                   |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ada`        | `['ada_language_server']`                                                                                                                                                                        |
-| `c`          | `['clangd']`                                                                                                                                                                                     |
-| `cpp`        | `['clangd']`                                                                                                                                                                                     |
-| `crystal`    | `['scry']`                                                                                                                                                                                       |
-| `css`        | `['css-languageserver', '--stdio']`                                                                                                                                                              |
-| `dart`       | `['dart_language_server']`                                                                                                                                                                       |
-| `elm`        | `['elm-language-server']`                                                                                                                                                                        |
-| `go`         | `['gopls']`                                                                                                                                                            |
-| `haskell`    | `['hie', '--lsp']`                                                                                                                                                                               |
-| `html`       | `['html-languageserver', '--stdio']`                                                                                                                                                             |
-| `javascript` | `['javascript-typescript-stdio']`                                                                                                                                                                |
-| `julia`      | `['julia', '--startup-file=no', '--history-file=no', '-e', 'using LanguageServer; server = LanguageServer.LanguageServerInstance(STDIN, STDOUT, false); server.runlinter = true; run(server);']` |
-| `objc`       | `['clangd']`                                                                                                                                                                                     |
-| `objcpp`     | `['clangd']`                                                                                                                                                                                     |
-| `php`        | `['php', 'path/to/bin/php-language-server.php']`                                                                                                                                                 |
-| `purescript` | `['purescript-language-server', '--stdio']`                                                                                                                                                      |
-| `python`     | `['pyls']`                                                                                                                                                                                       |
-| `ruby`       | `['solargraph', 'stdio']`                                                                                                                                                                        |
-| `reason`     | `['ocaml-language-server']`                                                                                                                                                                      |
-| `rust`       | `['rustup', 'run', 'nightly', 'rls']`                                                                                                                                                            |
-| `sh`         | `['bash-language-server', 'start']`                                                                                                                                                              |
-| `typescript` | `['typescript-language-server', '--stdio']`                                                                                                                                                      |
-| `vue`        | `['vls']`                                                                                                                                                                                        |
+| language          | server command                                                                                                                                                                                   |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ada`             | `['ada_language_server']`                                                                                                                                                                        |
+| `c`               | `['clangd']`                                                                                                                                                                                     |
+| `cpp`             | `['clangd']`                                                                                                                                                                                     |
+| `crystal`         | `['scry']`                                                                                                                                                                                       |
+| `css`             | `['css-languageserver', '--stdio']`                                                                                                                                                              |
+| `dart`            | `['dart_language_server']`                                                                                                                                                                       |
+| `elm`             | `['elm-language-server']`                                                                                                                                                                        |
+| `go`              | `['gopls']`                                                                                                                                                                                      |
+| `haskell`         | `['hie', '--lsp']`                                                                                                                                                                               |
+| `html`            | `['html-languageserver', '--stdio']`                                                                                                                                                             |
+| `javascript`      | `['javascript-typescript-stdio']`                                                                                                                                                                |
+| `julia`           | `['julia', '--startup-file=no', '--history-file=no', '-e', 'using LanguageServer; server = LanguageServer.LanguageServerInstance(STDIN, STDOUT, false); server.runlinter = true; run(server);']` |
+| `objc`            | `['clangd']`                                                                                                                                                                                     |
+| `objcpp`          | `['clangd']`                                                                                                                                                                                     |
+| `php`             | `['php', 'path/to/bin/php-language-server.php']`                                                                                                                                                 |
+| `purescript`      | `['purescript-language-server', '--stdio']`                                                                                                                                                      |
+| `python`          | `['pyls']`                                                                                                                                                                                       |
+| `ruby`            | `['solargraph', 'stdio']`                                                                                                                                                                        |
+| `reason`          | `['ocaml-language-server']`                                                                                                                                                                      |
+| `rust`            | `['rustup', 'run', 'nightly', 'rls']`                                                                                                                                                            |
+| `sh`              | `['bash-language-server', 'start']`                                                                                                                                                              |
+| `typescript`      | `['typescript-language-server', '--stdio']`                                                                                                                                                      |
+| `typescriptreact` | `['typescript-language-server', '--stdio']`                                                                                                                                                      |
+| `vue`             | `['vls']`                                                                                                                                                                                        |
 
 To override the server command, you may need to use `override_cmd` option:
 


### PR DESCRIPTION
### PR Prelude

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

At the moment the lsp for tsx files is broken. This PR adds the LSP command for typescriptreact filetypes, which fixes the issue.
