### PR TITLE
use `go install` replace `go get`

### DIFF
--- a/docs/layers/lang/go.md
+++ b/docs/layers/lang/go.md
@@ -32,7 +32,7 @@ After the installation, run `:GoInstallBinaries` inside vim.
 To enable tagbar support, you need to install [gotags](https://github.com/jstemmer/gotags):
 
 ```sh
-go get -u github.com/jstemmer/gotags
+go install github.com/jstemmer/gotags@latest
 ```
 
 ## Features


### PR DESCRIPTION
Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.

