### PR TITLE
Add flygrep to open file on previous window

### DIFF
--- a/autoload/SpaceVim/plugins/flygrep.vim
+++ b/autoload/SpaceVim/plugins/flygrep.vim
@@ -497,6 +497,7 @@ function! s:open_item() abort
     endif
     let s:preview_able = 0
     noautocmd q
+    wincmd p
     call s:update_history()
     call s:BUFFER.open_pos('edit', filename, linenr, colum)
     noautocmd normal! :


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

When opening a file with _flygrep_ this open it on the default (first?) window and not on the previous one