### PR TITLE
Fix: Allow :A to switch between *.h and {}.c

### DIFF
--- a/autoload/SpaceVim/plugins/a.vim
+++ b/autoload/SpaceVim/plugins/a.vim
@@ -190,7 +190,7 @@ else
     let s:project_config[a:alt_config_json.root] = {}
     " @question why need sory()
     " if we have two key docs/*.md and docs/cn/*.md
-    " with the first key, we can also find files in 
+    " with the first key, we can also find files in
     " docs/cn/ directory, for example docs/cn/index.md
     " and the alt file will be
     " docs/cn/cn/index.md. this should be overrided by login in
@@ -214,11 +214,11 @@ else
           endfor
         else
           for type in keys(a:alt_config_json.config[key])
-            let begin_end = split(key, '*')
-            if len(begin_end) == 2
+            let left_index = stridx(key, '*')
+            if left_index != -1 && left_index == strridx(key, '*')
               let s:project_config[a:alt_config_json.root][file][type] =
                     \ s:get_type_path(
-                    \ begin_end,
+                    \ key,
                     \ file,
                     \ a:alt_config_json.config[key][type]
                     \ )
@@ -232,8 +232,8 @@ else
   endfunction
 
   function! s:get_type_path(a, f, b) abort
-    let begin_len = strlen(a:a[0])
-    let end_len = strlen(a:a[1])
+    let begin_len = stridx(a:a, '*')
+    let end_len = strlen(a:a) - begin_len - 1
     return substitute(a:b, '{}', a:f[begin_len : (end_len+1) * -1], 'g')
   endfunction
 


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:


- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why is this change necessary and useful?

For C(PP) development it is often needed to switch between header (_.h_ or _.hpp_) files and matching source (_.c_ or _.cpp_) files. Luckily, SpaceVim is equipped with `:A` command which allows a more general switching between related files, so this can be achieved by providing a suitable `.project_alt.json` configuration file in the project root folder. An example configuration file is given on the [Use Vim as a C/C++ IDE](https://spacevim.org/use-vim-as-a-c-cpp-ide/) page (under 'alternate file jumping' section).

Unfortunately, this doesn't work out of the box. When trying to switch between for e.g. _a.h_ and _a.c_ files located in the project root folder, an error message ('failed to find alternate file!') is generated despite both files being present.

Upon inspection of the relevant plugin code (_a.vim_ file inside _autoload/pugins/_) a bug was identified. The original code checked for the presence of exactly one '*' character in the following way:
```
let begin_end = split(key, '\*')
if len(begin_end) == 2
```
This does not work if the key string is of the form `"\*.c"` as the `len(begin_end)` equals *1* in that case.

The solution implemented consists of checking if the indexes of the first occurrence of the '*' from the left and from the right match:
```
let left_index = stridx(key, '\*')
if left_index != -1 && left_index == strridx(key, '\*')
```
This change prompted further modification to the implementation of the function `s:get_type_path(a, f, b)` and its call.