### PR TITLE
fix simple typo

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -37,7 +37,7 @@ By default SpaceVim enables these layers:
 - `core#tabline`
 
 To enable a specific layer you need to edit SpaceVim's custom configuration files.
-The key binding for opening the configuration files.s `SPC f v d`.
+The key binding for opening the configuration files is `SPC f v d`.
 
 The following example shows how to load `shell` layer with some specified options:
 
@@ -79,7 +79,7 @@ Some layers are enabled by default. The following example shows how to disable `
 | [ctrlp](ctrlp/)                                       | This layers provide a heavily customized ctrlp centric work-flow                                                                                                    |
 | [ctrlspace](ctrlspace/)                               | This layer provides a customized CtrlSpace centric workflow                                                                                                         |
 | [debug](debug/)                                       | This layer provides debug workflow support in SpaceVim                                                                                                              |
-| [default](default/)                                   | SpaceVim's default layer contains no plugins, but It provides some better default config for SpaceVim.                                                              |
+| [default](default/)                                   | SpaceVim's default layer contains no plugins, but it provides some better default config for SpaceVim.                                                              |
 | [denite](denite/)                                     | This layers provide's a heavily customized Denite centric workflow                                                                                                  |
 | [edit](edit/)                                         | Improve code edit experience in SpaceVim, provides more text objects.                                                                                               |
 | [floobits](floobits/)                                 | This layer adds support for the peer programming tool floobits to SpaceVim.                                                                                         |
@@ -98,7 +98,7 @@ Some layers are enabled by default. The following example shows how to disable `
 | [lang#autohotkey](lang/autohotkey/)                   | This layer adds AutohotKey language support to SpaceVim.                                                                                                            |
 | [lang#batch](lang/batch/)                             | This layer is for DOS batch file development, provides syntax highlighting, code runner and repl support for batch files.                                           |
 | [lang#c](lang/c/)                                     | C/C++/Object-C language support for SpaceVim, including code completion, jump to definition, and quick runner.                                                      |
-| [lang#chapel](lang/chapel/)                           | This layer is for chapel development. provides syntax checking, code runner and repl support for chapel files.                                                      |
+| [lang#chapel](lang/chapel/)                           | This layer is for chapel development, provides syntax checking, code runner and repl support for chapel files.                                                      |
 | [lang#clojure](lang/clojure/)                         | This layer is for Clojure development, provides autocompletion, syntax checking, code format for Clojure files.                                                     |
 | [lang#coffeescript](lang/coffeescript/)               | This layer is for CoffeeScript development, provides autocompletion, syntax checking, code format for CoffeeScript files.                                           |
 | [lang#crystal](lang/crystal/)                         | This layer is for crystal development, provides syntax checking, code runner and repl support for crystal files.                                                    |


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?
> The key binding for opening the configuration files.s SPC f v d.

Changed to:
> The key binding for opening the configuration files is SPC f v d.

A small suggestion is to also add a hint to tell user to turn `modifiable` on before the command?
```
:set ma
# short for:
:set modifiable
``` 
