### PR TITLE
Fix: Handle Vim without `language` command

### DIFF
--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -1554,6 +1554,8 @@ function! SpaceVim#begin() abort
     endif
   catch /^Vim\%((\a\+)\)\=:E197/
     call SpaceVim#logger#error('Can not set language to en_US.utf8')
+  catch /^Vim\%((\a\+)\)\=:E319/
+    call SpaceVim#logger#error('Can not set language to en_US.utf8, language not implemented in this Vim build')
   endtry
 
   " try to set encoding to utf-8


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

E319 means that Vim was built without the feature that supports a given
command (http://vimdoc.sourceforge.net/htmldoc/message.html#E319); if
Vim is built without language support, SpaceVim cannot successfully
load.  this change enables SpaceVim to recover from this error message
and continue loading.

see https://github.com/qvacua/vimr/issues/879 for an example of the
problem that this solves.
