### PR TITLE
Fix typo in ruby.md

### DIFF
--- a/docs/layers/lang/ruby.md
+++ b/docs/layers/lang/ruby.md
@@ -53,7 +53,7 @@ gem install rubocop
 
   ```toml
   [[layers]]
-    name = "lang#python"
+    name = "lang#ruby"
     ruby_file_head = [
         '#!/usr/bin/ruby -w',
         '# -*- coding: utf-8 -*-',


### PR DESCRIPTION
under layer options it should read name = "lang#ruby" instead of name =  "lang#python"

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]


under layers, under ruby, under layer options

 it should read name = "lang#ruby" instead of name =  "lang#python"
