### PR TITLE
fix gd jump for jedi and lsp on python.vim

### DIFF
--- a/autoload/SpaceVim/layers/lang/python.vim
+++ b/autoload/SpaceVim/layers/lang/python.vim
@@ -266,9 +266,9 @@ endf
 function! s:go_to_def() abort
   if SpaceVim#layers#lsp#check_filetype('python')
         \ || SpaceVim#layers#lsp#check_server('pyright')
-    call jedi#goto()
-  else
     call SpaceVim#lsp#go_to_def()
+  else
+    call jedi#goto()
   endif
 endfunction
 


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

make the jump to definition use lsp function while enable lsp for python.