### PR TITLE
Fix typo of lang#c layer in docs

### DIFF
--- a/docs/layers/lang/c.md
+++ b/docs/layers/lang/c.md
@@ -73,7 +73,7 @@ Here is an example how to use above options:
 [[layers]]
   name = "lang#c"
   clang_executable = "/usr/bin/clang"
-  clang_flag = ['-I/user/include']
+  clang_flag = ['-I/usr/include']
   [layer.clang_std]
     c = "c11"
     cpp = "c++1z"


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

`-I/user/include` is obviously a typo
