### PR TITLE
feat(layer): Add cargo-clippy to Rust layer

### DIFF
--- a/autoload/SpaceVim/layers/lang/rust.vim
+++ b/autoload/SpaceVim/layers/lang/rust.vim
@@ -182,6 +182,9 @@ function! s:language_specified_mappings() abort
   call SpaceVim#mapping#space#langSPC('nnoremap', ['l','c', 't'], 'call call('
         \ . string(function('s:execCMD')) . ', ["cargo test"])',
         \ 'cargo-test', 1)
+  call SpaceVim#mapping#space#langSPC('nnoremap', ['l','c', 'l'], 'call call('
+        \ . string(function('s:execCMD')) . ', ["cargo clippy"])',
+        \ 'cargo-clippy', 1)
   call SpaceVim#mapping#space#langSPC('nnoremap', ['l','c', 'u'], 'call call('
         \ . string(function('s:execCMD')) . ', ["cargo update"])',
         \ 'update-external-dependencies', 1)

--- a/autoload/SpaceVim/layers/lang/rust.vim
+++ b/autoload/SpaceVim/layers/lang/rust.vim
@@ -70,6 +70,7 @@
 "   SPC l c B   cargo-bench
 "   SPC l c D   cargo-docs
 "   SPC l c r   cargo-run
+"   SPC l c l   cargo-clippy
 " <
 "
 " This layer also provides REPL support for rust, the key bindings are:

--- a/docs/layers/lang/rust.md
+++ b/docs/layers/lang/rust.md
@@ -77,6 +77,7 @@ To use this configuration layer, update your custom configuration file with:
 | `SPC l c B`     | Run `cargo bench`                  |
 | `SPC l c D`     | Run `cargo doc`                    |
 | `SPC l c r`     | Run `cargo run`                    |
+| `SPC l c l`     | Run `cargo clippy`                 |
 
 **Note:** `SPC l g` and `SPC l v` will not be available if the `lsp` layer is not enabled.
 


### PR DESCRIPTION
             Adds `SPC l c l` binding to run cargo clippy.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Adds the language specific keybind `SPC l c l` for Rust to run linter `cargo clippy`.