### PR TITLE
feat(core): Load local config after global config

### DIFF
--- a/autoload/SpaceVim/autocmds.vim
+++ b/autoload/SpaceVim/autocmds.vim
@@ -198,6 +198,12 @@ function! SpaceVim#autocmds#VimEnter() abort
     echom 'bootstrap_after function failed to execute. Check `SPC h L` for errors.'
     echohl None
   endif
+
+  if !filereadable('.SpaceVim.d/init.toml') && filereadable('.SpaceVim.d/init.vim')
+    call SpaceVim#logger#info('loading local conf: .SpaceVim.d/init.vim')
+    exe 'source .SpaceVim.d/init.vim'
+    call SpaceVim#logger#info('finished loading local conf')
+  endif
 endfunction
 
 function! s:disable_welcome() abort

--- a/autoload/SpaceVim/custom.vim
+++ b/autoload/SpaceVim/custom.vim
@@ -221,6 +221,8 @@ function! s:path_to_fname(path) abort
 endfunction
 
 function! SpaceVim#custom#load() abort
+  call SpaceVim#logger#info('start loading global config >>>')
+  call s:load_glob_conf()
   " if file .SpaceVim.d/init.toml exist
   if filereadable('.SpaceVim.d/init.toml')
     let local_dir = s:FILE.unify_path(
@@ -246,10 +248,6 @@ function! SpaceVim#custom#load() abort
       call writefile([s:JSON.json_encode(conf)], local_conf_cache)
       call s:apply(conf, 'local')
     endif
-    if g:spacevim_force_global_config
-      call SpaceVim#logger#info('force loading global config >>>')
-      call s:load_glob_conf()
-    endif
   elseif filereadable('.SpaceVim.d/init.vim')
     let local_dir = s:FILE.unify_path(
           \ s:CMP.resolve(fnamemodify('.SpaceVim.d/', ':p:h')))
@@ -257,15 +255,8 @@ function! SpaceVim#custom#load() abort
     let &rtp = local_dir . ',' . &rtp . ',' . local_dir . 'after'
     let local_conf = g:_spacevim_config_path
     call SpaceVim#logger#info('find local conf: ' . local_conf)
-    exe 'source .SpaceVim.d/init.vim'
-    if g:spacevim_force_global_config
-      call SpaceVim#logger#info('force loading global config >>>')
-      call s:load_glob_conf()
-    endif
   else
-    call SpaceVim#logger#info(
-          \ 'Can not find project local config, start loading global config')
-    call s:load_glob_conf()
+    call SpaceVim#logger#info('Could not find project local config')
   endif
 
 


### PR DESCRIPTION
            Loads the local `.SpaceVim.d/init.vim` file after all global
            configurations. Global configuration and `init.vim` is not
            loaded if `.SpaceVim.d/init.toml` is found locally. Makes
            `g:spacevim_force_global_config` obsolete.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Makes it easier to automatically load project specific configurations while inheriting the global configuration. `g:spacevim_force_global_config` is no longer used.

Assuming that there is a global configuration at `~/.SpaceVim.d/init.toml` with or without associated bootstrap functions. If `.SpaceVim.d/init.vim` is found in the project directory, it is loaded after the `bootstrap_after` function. If `.SpaceVim.d/init.toml` is found in the project directory, `init.vim` is ignored if it exists and the global configuration is not loaded.

It is currently still possible to use `force_global_config = true` in `./.SpaceVim.d/init.toml` to inherit the global configuration if the setting will not be removed. But it is ignored if set in `./.SpaceVim.d/init.vim`.