### PR TITLE
docs: mention SPC == space

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -160,7 +160,7 @@ To get more screenshots, see: [issue #415](https://github.com/SpaceVim/SpaceVim/
 
 SpaceVim defines a wide variety of transient states (temporary overlay maps)
 where it makes sense. This prevents one from doing repetitive and tedious
-presses on the SPC key.
+presses on the `SPC` (space) key.
 
 When a transient state is active, a documentation is displayed in the
 transient state buffer. Additional information may as well be displayed in it.


### PR DESCRIPTION
I went 'gonna try a new editor', got lead to SpaceVim.
From the quick start, I was led to https://spacevim.org/use-vim-as-a-go-ide/
> Press `SPC f v d`
Besides no mnemonic given (feels like typing a password), what the hell is `SPC`?

Having some (ex: tiling WMs) background knowledge and common sense,
  `SPC` is probably a special modifier key. Special.
I didn't think to go to the config to check, didn't come to my head.
(well, opening the config was a challenge in the first place)

In the same minute, I also ctrl-f-ed all three pages: quick-start, go, docs.
Nothing.

Tried `:SPC`, `:SPC f v d`
> Ambiguous use of user-defined command
uhh

Overall, it took ~80s of confusion for it to click, that SPC is space.. in SpaceVim.