### PR TITLE
Add `silent_format` to format layer

### DIFF
--- a/autoload/SpaceVim/layers/format.vim
+++ b/autoload/SpaceVim/layers/format.vim
@@ -30,6 +30,7 @@ if exists('s:format_on_save')
 else
   let s:format_method = 'neoformat'
   let s:format_on_save = 0
+  let s:silent_format = 0
   let s:format_ft = []
 endif
 
@@ -62,17 +63,22 @@ function! SpaceVim#layers#format#config() abort
   endif
   augroup spacevim_layer_format
     autocmd!
-    autocmd BufWritePre * call s:format()
+    if s:silent_format
+      autocmd BufWritePre * silent! call s:format()
+    else
+      autocmd BufWritePre * call s:format()
+    endif
   augroup END
 endfunction
 
 function! SpaceVim#layers#format#set_variable(var) abort
   let s:format_method = get(a:var, 'format_method', s:format_method)
   let s:format_on_save = get(a:var, 'format_on_save', s:format_on_save)
+  let s:silent_format = get(a:var, 'silent_format', s:silent_format)
 endfunction
 
 function! SpaceVim#layers#format#get_options() abort
-  return ['format_method', 'format_on_save']
+  return ['format_method', 'format_on_save', 'silent_format']
 endfunction
 
 function! SpaceVim#layers#format#add_filetype(ft) abort

--- a/autoload/SpaceVim/layers/format.vim
+++ b/autoload/SpaceVim/layers/format.vim
@@ -17,6 +17,7 @@
 " 1. `format_on_save`: disabled by default.
 " 2. `format_method`: set the format plugin, default plugin is `neoformat`.
 " You can also use `vim-codefmt`.
+" 3. `silent_format`: Runs the formatter without any messages.
 "
 " @subsection key bindings
 " >

--- a/docs/layers/format.md
+++ b/docs/layers/format.md
@@ -70,6 +70,15 @@ This layer is enabled by default. If you want to disable it, add the following t
     format_on_save = false
   ```
 
+- **`silent_format`**: Setting this to true will run the formatter silently without any messages. Default is
+disabled.
+
+  ```toml
+  [[layers]]
+    name = "format"
+    silent_format = true
+  ```
+
 ### Global options
 
 neoformat is a formatting framework, all of it's options can be used in bootstrap function. You can read


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

When running the formatter, a message is shown that can be a minor inconvenience to some people, especially with format on save enabled.

![image](https://user-images.githubusercontent.com/34889224/153000614-52f707ac-aea8-4c29-a79f-80f22d8ea552.png)

This change adds `silent_format` which can be used to hide these messages by making the following changes to the `init.toml`.

```toml
[[layers]]
  name = "format"
  silent_format = true
```