### PR TITLE
Fix: fix the pattern of Chinese Number and add a parameter for ‘substitute'.

### DIFF
--- a/autoload/SpaceVim/layers/chinese.vim
+++ b/autoload/SpaceVim/layers/chinese.vim
@@ -59,10 +59,10 @@ endfunction
 
 function! s:ConvertChineseNumberUnderCursorToDigit() abort
   let cword = expand('<cword>')
-  let ChineseNumberPattern = "[〇一二三四五六七八九零壹贰叁肆伍陆柒捌玖貮两点]\+"
+  let ChineseNumberPattern = '[〇一二三四五六七八九十百千万亿兆零壹贰叁肆伍陆柒捌玖拾佰仟萬億貮两点]\+'
   while cword =~ ChineseNumberPattern
     let matchword = matchstr(cword, ChineseNumberPattern)
-    let cword = substitute(cword, matchword, s:Chinese2Digit(matchword))
+    let cword = substitute(cword, matchword, s:Chinese2Digit(matchword), "")
   endwhile
   if !empty(cword)
     let save_register = @k


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Fix the pattern of Chinese Number and add a parameter for the function substitute. But there is still an error to solove.

"Vim(let):E716: Key not present in Directory: "<80>".
