### PR TITLE
Add vim ultest

### DIFF
--- a/autoload/SpaceVim/layers/test.vim
+++ b/autoload/SpaceVim/layers/test.vim
@@ -22,19 +22,48 @@
 "   normal    SPC k v     visits the last run test file
 " <
 
+let s:use_ultest = 0
+
 function! SpaceVim#layers#test#plugins() abort
-  return [
+  let l:plugins = [
         \ ['janko/vim-test'],
         \ ]
+
+  if s:use_ultest
+    let l:plugins += [['rcarriga/vim-ultest']]
+  endif
+
+  return l:plugins
 endfunction
 
 function! SpaceVim#layers#test#config() abort
   let g:_spacevim_mappings_space.k = get(g:_spacevim_mappings_space, 'k',  {'name' : '+Test'})
 
-  call SpaceVim#mapping#space#def('nnoremap', ['k', 'n'], 'TestNearest', 'nearest', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['k', 'f'], 'TestFile', 'file', 1)
+  if s:use_ultest
+    let g:ultest_use_pty = 1
+
+    call SpaceVim#mapping#space#def('nnoremap', ['k', 'n'], 'UltestNearest', 'nearest', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['k', 'f'], 'Ultest', 'file', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['k', 'l'], 'UltestLast', 'last', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['k', 'u'], 'UltestSummary!', 'jump-to-summary', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['k', 'U'], 'UltestSummary', 'open-summary', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['k', 'k'], 'UltestStopNearest', 'stop-nearest', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['k', 'K'], 'UltestStop', 'stop', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['k', 'a'], 'UltestAttach', 'attach', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['k', 'c'], 'UltestClear', 'clear', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['k', 'd'], 'UltestDebugNearest', 'debug-nearest', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['k', 'D'], 'UltestDebug', 'debug', 1)
+    call SpaceVim#mapping#space#def('nmap', ['k', 'j'], '<Plug>(ultest-next-fail)', 'jump-to-next-failed', 0)
+    call SpaceVim#mapping#space#def('nmap', ['k', 'k'], '<Plug>(ultest-prev-fail)', 'jump-to-prev-failed', 0)
+    call SpaceVim#mapping#space#def('nmap', ['k', 'o'], '<Plug>(ultest-output-show)', 'show-output', 0)
+    call SpaceVim#mapping#space#def('nmap', ['k', 'O'], '<Plug>(ultest-output-jump)', 'jump-to-output', 0)
+  else
+    call SpaceVim#mapping#space#def('nnoremap', ['k', 'n'], 'TestNearest', 'nearest', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['k', 'f'], 'TestFile', 'file', 1)
+    call SpaceVim#mapping#space#def('nnoremap', ['k', 'l'], 'TestLast', 'last', 1)
+  endif
+
   call SpaceVim#mapping#space#def('nnoremap', ['k', 's'], 'TestSuite', 'suite', 1)
-  call SpaceVim#mapping#space#def('nnoremap', ['k', 'l'], 'TestLast', 'last', 1)
   call SpaceVim#mapping#space#def('nnoremap', ['k', 'v'], 'TestVisit', 'visit', 1)
   let g:test#custom_strategies = {'spacevim': function('SpaceVim#plugins#runner#open')}
   let g:test#strategy = 'spacevim'
@@ -48,6 +77,8 @@ function! SpaceVim#layers#test#set_variable(var) abort
       execute 'let g:'.l:varname.' = '."'".l:override[l:option]."'"
     endfor
   endif
+
+  let s:use_ultest = get(a:var, 'use_ultest', s:use_ultest)
 endfunction
 
 function! SpaceVim#layers#test#health() abort

--- a/docs/layers/test.md
+++ b/docs/layers/test.md
@@ -48,6 +48,14 @@ let test#java#gradletest#executable = "./gradlew test"
 
 In essence, it replaces `_` with `#` and prepends `test#` to the keys inside `override_config`.
 
+To use ultest, set the configuration:
+
+```toml
+[[layers]]
+  name = "test"
+  use_ultest = true
+```
+
 ## Key bindings
 
 | Key Binding | Description                                                                                                                                                                                                                                                                             |
@@ -58,3 +66,19 @@ In essence, it replaces `_` with `#` and prepends `test#` to the keys inside `ov
 | `SPC k l`   | Runs the last test                                                                                                                                                                                                                                                                      |
 | `SPC k v`   | Visits the test file from which you last run your tests (useful when you're trying to make a test pass, and you dive deep into application code and close your test buffer to make more space, and once you've made it pass you want to go back to the test file to write more tests)   |
 
+**Additional bindings with ultest**
+
+| Key Binding | Description                                                    |
+| ----------- | ---------------------------------------------------------------|
+| `SPC k u`   | Jump to summary                                                |
+| `SPC k U`   | Open summary                                                   |
+| `SPC k k`   | Stop nearest                                                   |
+| `SPC k K`   | Stop                                                           |
+| `SPC k a`   | Attach                                                         |
+| `SPC k c`   | Clear                                                          |
+| `SPC k d`   | Debug nearest                                                  |
+| `SPC k D`   | Debug                                                          |
+| `SPC k j`   | Jump to next failed test                                       |
+| `SPC k k`   | Jump to previous failed test                                   |
+| `SPC k o`   | Show output                                                    |
+| `SPC k O`   | Jump to output                                                 |


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[vim-ultest](https://github.com/rcarriga/vim-ultest) has some useful features on top of vim-test. This change adds the config option `use_ultest` to the test layer which, if set to true, installs the plugin and adds bindings for it.