### PR TITLE
docs(kotlin): update doc for `kotlin` layer

### DIFF
--- a/docs/layers/lang/kotlin.md
+++ b/docs/layers/lang/kotlin.md
@@ -90,5 +90,5 @@ kotlin language server command via:
     'kotlin',
   ]
   [layers.override_cmd]
-    kotlin = 'path/to/kotlin-language-server'
+    kotlin = ['path/to/kotlin-language-server']
 ```


### PR DESCRIPTION
Signed-off-by: Russell Richardson <admin@russ.network>

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]

Whilst attempting to enable LSP support for Kotlin in SpaceVim, I ran into the same problem that was mentioned over at [this issue](https://github.com/SpaceVim/SpaceVim/issues/4482), the solution notes that the original author should have checked the documentation for the correct syntax. However, the documentation in this case doesn't show the correct usage (as the override command should be passed in as an array, rather than a single string). This PR fixes that discrepancy.