### PR TITLE
docs(lsp): add description for nvim(>=0.5.0)

### DIFF
--- a/docs/_posts/2019-05-11-use-vim-as-a-c-cpp-ide.md
+++ b/docs/_posts/2019-05-11-use-vim-as-a-c-cpp-ide.md
@@ -78,6 +78,14 @@ lsp 模块默认使用 `clangd` 作为 C/C++ 的语言服务器后台命令。
     c = ["clangd"]
 ```
 
+如果使用的是 `nvim(>=0.5.0)`，则需要指定 `enabled_clients` 选项：
+
+```toml
+[[layers]]
+  name = 'lsp'
+  enabled_clients = ['clangd']
+```
+
 ### 语法检查
 
 `checkers` 模块为 SpaceVim 提供了语法检查的功能，该模块默认已经载入。该模块默认使用 [neomake](https://github.com/neomake/neomake)


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

While using nvim(>=0.5.0), clangd is not setup if option
'enabled_clients' is not specified.
