### PR TITLE
Fix convert Chinese number to digits.

### DIFF
--- a/autoload/SpaceVim/layers/chinese.vim
+++ b/autoload/SpaceVim/layers/chinese.vim
@@ -124,20 +124,22 @@ function! s:Chinese2Digit(cnDigitString)
     endif
     let result = 0
     let tmp = 0
-    while len(parse)
+    while !empty(parse)
       let x = remove(parse, -1)
-      if x == 'w'
-          let tmp *= 10000
-          let result += tmp
-          let tmp = 0
-      elseif x == 'y'
-          let tmp *= 100000000
-          let result += tmp
-          let tmp = 0
-      elseif x == 'z'
-          let tmp *= 1000000000000
-          let result += tmp
-          let tmp = 0
+      if type(x) == type("")
+        if x == 'w'
+            let tmp *= 10000
+            let result += tmp
+            let tmp = 0
+        elseif x == 'y'
+            let tmp *= 100000000
+            let result += tmp
+            let tmp = 0
+        elseif x == 'z'
+            let tmp *= 1000000000000
+            let result += tmp
+            let tmp = 0
+        endif
       else
           let tmp += x
       endif

--- a/autoload/SpaceVim/layers/chinese.vim
+++ b/autoload/SpaceVim/layers/chinese.vim
@@ -93,7 +93,7 @@ function! s:Chinese2Digit(cnDigitString)
     let decimal = len(cnList) == 2 ? cnList[1] : [] " 小数部分
     let unit = 0  " 当前单位
     let parse = []  " 解析数组
-    while len(integer) > 0
+    while !empty(integer)
       let x = remove(integer, -1)
       if has_key(CN_UNIT, x)
         " 当前字符是单位
@@ -144,9 +144,7 @@ function! s:Chinese2Digit(cnDigitString)
     endwhile
     let result += tmp
     if !empty(decimal)
-      for [k, v] in items(CN_NUM)
-        let decimal = substitute(decimal, k, v, 'g')
-      endfor
+      let decimal = substitute(decimal, ".", {m -> CN_NUM[m[0]]}, 'g')
       let result .= "." . decimal
     endif
   endif

--- a/autoload/SpaceVim/layers/chinese.vim
+++ b/autoload/SpaceVim/layers/chinese.vim
@@ -44,9 +44,7 @@ function! SpaceVim#layers#chinese#config() abort
   call SpaceVim#mapping#space#def('nnoremap', ['x', 'g', 't'], 'Translate'         , 'translate current word'  , 1)
   call SpaceVim#mapping#space#def('nnoremap', ['l', 'c']     , 'CheckChinese', 'Check with ChineseLinter', 1)
   let g:_spacevim_mappings_space.n.c = {'name' : '+Convert'}
-  call SpaceVim#mapping#space#def('nnoremap', ['n', 'c', 'd'], 'silent call call('
-        \ . string(s:_function('s:ConvertChineseNumberUnderCursorToDigit')) . ', [])',
-        \ 'Convert Chinese Number to Digit', 1)
+  call SpaceVim#mapping#space#def('nmap', ['n', 'c', 'd'], '<Plug>ConvertChineseNumberToDigit', 'convert Chinese number to digit', 0, 1)
   " do not load vimcdoc plugin 
   let g:loaded_vimcdoc = 1
 endfunction
@@ -57,100 +55,100 @@ function! SpaceVim#layers#chinese#health() abort
   return 1
 endfunction
 
-function! s:ConvertChineseNumberUnderCursorToDigit() abort
-  let cword = expand('<cword>')
-  let ChineseNumberPattern = '[〇一二三四五六七八九十百千万亿兆零壹贰叁肆伍陆柒捌玖拾佰仟萬億貮两点]\+'
-  while cword =~ ChineseNumberPattern
-    let matchword = matchstr(cword, ChineseNumberPattern)
-    let cword = substitute(cword, matchword, s:Chinese2Digit(matchword), "")
-  endwhile
-  if !empty(cword)
-    let save_register = @k
-    let save_cursor = getcurpos()
-    let @k = cword
+command! -nargs=0 -range ConvertChineseNumberToDigit :<line1>,<line2>call s:ConvertChineseNumberToDigit()
+nnoremap <silent> <Plug>ConvertChineseNumberToDigit  :ConvertChineseNumberToDigit<cr>
+vnoremap <silent> <Plug>ConvertChineseNumberToDigit  :ConvertChineseNumberToDigit<cr>
+function! s:ConvertChineseNumberToDigit() range
+  let save_cursor = getcurpos()
+  let ChineseNumberPattern = '[〇一二三四五六七八九十百千万亿兆零壹贰叁肆伍陆柒捌玖拾佰仟萬億两点]\+'
+  if mode() ==? 'n' && a:firstline == a:lastline
+    let cword = expand('<cword>')
+    let cword = substitute(cword, ChineseNumberPattern, '\=s:Chinese2Digit(submatch(0))', "g")
+    let save_register_k = getreg("k")
+    call setreg("k", cword)
     normal! viw"kp
-    call setpos('.', save_cursor)
-    let @k = save_register
+    call setreg("k", save_register_k)
+  else
+    silent execute a:firstline . "," . a:lastline . 'substitute/' . ChineseNumberPattern . '/\=s:Chinese2Digit(submatch(0))/g'
   endif
+  call setpos('.', save_cursor)
 endfunction
 
-let s:list = SpaceVim#api#import('data#list')
-function! s:Chinese2Digit(cnDigitString) abort
+function! s:Chinese2Digit(cnDigitString)
   let CN_NUM = {
         \ '〇': 0, '一': 1, '二': 2, '三': 3, '四': 4, '五': 5, '六': 6, '七': 7, '八': 8, '九': 9,
         \ '零': 0, '壹': 1, '贰': 2, '叁': 3, '肆': 4, '伍': 5, '陆': 6, '柒': 7, '捌': 8, '玖': 9,
-        \ '貮': 2, '两': 2
+        \ '貮': 2, '两': 2, '点': '.'
         \ }
   let CN_UNIT = {
         \ '十': 10, '拾': 10, '百': 100, '佰': 100, '千': 1000, '仟': 1000, '万': 10000, '萬': 10000,
         \ '亿': 100000000, '億': 100000000, '兆': 1000000000000
         \ }
 
-  let cnList = split(a:cnDigitString, "点")
-  let integer = cnList[0]  " 整数部分
-  let decimal = len(cnList) == 2 ? cnList[1] : [] " 小数部分
-  let unit = 0  " 当前单位
-  let parse = []  " 解析数组
-  let i = len(integer)
-  while i >= 0
-    let i -= 1
-    let x = integer[i]
-    if has_key(CN_UNIT, x)
-      " 当前字符是单位
-      let unit = CN_UNIT[x]
-      if unit == 10000 " 万位
-        s:list.push(parse, "w")
-        let unit = 1
-      elseif unit == 100000000 " 亿位
-        s:list.push(parse, "y")
-        let unit = 1
-      elseif unit == 1000000000000  " 兆位
-        s:list.push(parse, "z")
-        let unit = 1
+  if a:cnDigitString =~ '^[点两貮〇一二三四五六七八九零壹贰叁肆伍陆柒捌玖]\+$'
+    let result = substitute(a:cnDigitString, ".", {m -> CN_NUM[m[0]]}, 'g')
+  else
+    let cnList = split(a:cnDigitString, "点")
+    let integer = map(str2list(cnList[0]), 'nr2char(v:val)')  " 整数部分
+    let decimal = len(cnList) == 2 ? cnList[1] : [] " 小数部分
+    let unit = 0  " 当前单位
+    let parse = []  " 解析数组
+    while len(integer) > 0
+      let x = remove(integer, -1)
+      if has_key(CN_UNIT, x)
+        " 当前字符是单位
+        let unit = CN_UNIT[x]
+        if unit == 10000 " 万位
+          call add(parse, "w")
+          let unit = 1
+        elseif unit == 100000000 " 亿位
+          call add(parse, "y")
+          let unit = 1
+        elseif unit == 1000000000000  " 兆位
+          call add (parse, "z")
+          let unit = 1
+        endif
         continue
+      else
+        " 当前字符是数字
+        let dig = CN_NUM[x]
+        if unit
+          let dig *= unit
+          let unit = 0
+        endif
+        call add(parse, dig)
       endif
-    else
-      " 当前字符是数字
-      let dig = CN_NUM[x]
-      if unit
-        let dig = dig * unit
-        let unit = 0
+    endwhile
+    if unit == 10  " 处理10-19的数字
+      call add(parse, 10)
+    endif
+    let result = 0
+    let tmp = 0
+    while len(parse)
+      let x = remove(parse, -1)
+      if x == 'w'
+          let tmp *= 10000
+          let result += tmp
+          let tmp = 0
+      elseif x == 'y'
+          let tmp *= 100000000
+          let result += tmp
+          let tmp = 0
+      elseif x == 'z'
+          let tmp *= 1000000000000
+          let result += tmp
+          let tmp = 0
+      else
+          let tmp += x
       endif
-      s:list.push(parse, dig)
-    endif
-  endwhile
-
-  if unit == 10  " 处理10-19的数字
-    s:list.push(parse, 10)
-  endif
-  let result = 0
-  let tmp = 0
-  while parse
-    let x = s:list.pop(parse)
-    if x == 'w'
-        let tmp *= 10000
-        let result += tmp
-        let tmp = 0
-    elseif x == 'y'
-        let tmp *= 100000000
-        let result += tmp
-        let tmp = 0
-    elseif x == 'z'
-        let tmp *= 1000000000000
-        let result += tmp
-        let tmp = 0
-    else
-        let tmp += x
-    endif
+    endwhile
     let result += tmp
-  endwhile
-
-  if !empth(decimal)
-    for [k, v] in items(CN_NUM)
-      let decimal = substitute(decimal, k, v, 'g')
-    endfor
-    let decimal = "0." + decimal
-    let result += eval(decimal)
+    if !empty(decimal)
+      for [k, v] in items(CN_NUM)
+        let decimal = substitute(decimal, k, v, 'g')
+      endfor
+      let result .= "." . decimal
+    endif
   endif
   return result
 endfunction


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

the function s:ConvertChineseNumberToDigit can run fluently after this commit. and it also can convert this kind of Chinese number, such as  "二零二二“.
But I really don't know why line 65 `expand('<cword>')` cannot fetch the word under the cursor. when there is more than 1 Chinese number in 1 one line, although I have located the cursor at non-first Chinese number. This function always convert the first Chinese number to digit.
I have print getpos(), the col is always 1. Anyone can help?