### PR TITLE
Include autoload/SpaceVim/api/time.vim when detaching FlyGrep.

### DIFF
--- a/.ci/detach_plugin.sh
+++ b/.ci/detach_plugin.sh
@@ -52,6 +52,7 @@ main () {
             _detect autoload/SpaceVim/api/vim.vim
             _detect autoload/SpaceVim/api/file.vim
             _detect autoload/SpaceVim/api/system.vim
+            _detect autoload/SpaceVim/api/time.vim
             _detect autoload/SpaceVim/mapping/search.vim
             _detect autoload/SpaceVim/logger.vim
             _detect syntax/SpaceVimFlyGrep.vim


### PR DESCRIPTION
### PR Prelude

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

FlyGrep uses SpaceVim's logger api, which uses the time api.
