### PR TITLE
docs(core): update docs to clarify location of settings

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -260,6 +260,9 @@ SpaceVim also supports project specific configuration files.
 The init file is `.SpaceVim.d/init.toml` in the root of your project.
 The local `.SpaceVim.d/` will also be added to the `&runtimepath`.
 
+Please be aware that if there are errors in your `init.toml`, the setting will not be applied. See [FAQ](../faq/#why-are-the-options-in-toml-file-not-applied). 
+
+
 All SpaceVim options can be found in `:h SpaceVim-options`,
 the key is the same as the option name without the `g:spacevim_` prefix.
 
@@ -316,7 +319,8 @@ For adding multiple custom plugins:
 **disable existing plugins**
 
 If you want to disable plugins which are added by SpaceVim,
-you can use SpaceVim `disabled_plugins` options:
+you can use SpaceVim `disabled_plugins` in the `[options]` section of your configuration file.
+options:
 
 ```toml
 [options]
@@ -330,8 +334,7 @@ SpaceVim provides two kinds of bootstrap functions
 for custom configurations and key bindings,
 namely `bootstrap_before` and `bootstrap_after`.
 
-To enable them you need to add the following into
-`~/.SpaceVim.d/init.toml`.
+To enable them you need to add the following into lines to the `[options]` section of your configuration file.
 
 ```toml
 [options]
@@ -411,8 +414,8 @@ The different key bindings between SpaceVim and vim are shown as below.
   ```
 
 - In vim the `,` key repeats the last last `f`, `F`, `t` and `T`, but in SpaceVim it is the language specific Leader key.
-  To disable this feature, set the option `enable_language_specific_leader` to `false`.
-
+  To disable this feature, set the option `enable_language_specific_leader` to `false` in in the `[options]` section of your configuration file.
+  
   ```toml
   [options]
       enable_language_specific_leader = false
@@ -440,10 +443,11 @@ The different key bindings between SpaceVim and vim are shown as below.
 - In SpaceVim the `Ctrl-f` binding on the command line is mapped to `<Right>`, which will move cursor to the right.
 
 SpaceVim provides a vimcompatible mode, in vimcompatible mode, all the differences above will disappear.
-You can enable the vimcompatible mode by adding `vimcompatible = true` to the `[options]` section.
+You can enable the vimcompatible mode by adding `vimcompatible = true` to the `[options]` section of your configuration file.
 
 If you want to disable any differences above, use the relevant options.
-For example, in order to disable language specific leader, you may add the following lines to your configuration file:
+For example, in order to disable language specific leader, you may add the following lines to the `[options]` section of
+`~/.SpaceVim.d/init.toml`:
 
 ```toml
 [options]
@@ -517,7 +521,7 @@ There are two variants of this colorscheme, dark and light. Some aspects
 of these colorschemes can be customized in the custom configuration file, read `:h gruvbox`.
 
 It is possible to change the colorscheme in `~/.SpaceVim.d/init.toml` with
-the variable `colorscheme`. For instance, to specify `desert`:
+the variable `colorscheme`. For instance, to specify `desert` add the following to the `[options]` section:
 
 ```toml
 [options]
@@ -691,7 +695,7 @@ All the colors are based on the current colorscheme.
 
 **Statusline separators:**
 
-It is possible to easily customize the statusline separator by setting the `statusline_separator` variable in your custom configuration file and then redraw the statusline. For instance, if you want to set the separator back to the well-known arrow separator, add the following snippet to your configuration file:
+It is possible to easily customize the statusline separator by setting the `statusline_separator` variable in your custom configuration file and then redraw the statusline. For instance, if you want to set the separator back to the well-known arrow separator, add the following snippet to the `[options]` section of your configuration file:
 
 ```toml
 [options]
@@ -769,7 +773,7 @@ endfunction
 
 This example is the gruvbox colorscheme, if you want to use same colors when
 switching between different colorschemes, you may need to set
-`custom_color_palette` in your custom configuration file. For example:
+`custom_color_palette` in the `[options]` section of your custom configuration file. For example:
 
 ```toml
 [options]
@@ -859,7 +863,7 @@ Key bindings within the tab manager window:
 SpaceVim uses `nerdtree` as the default file tree, the default key binding is `<F3>`.
 SpaceVim also provides `SPC f t` and `SPC f T` to open the file tree.
 
-To change the filemanager plugin:
+To change the filemanager plugin insert the following to the `[options]` section of your configuration file. 
 
 ```toml
 [options]
@@ -877,7 +881,7 @@ to your custom configuration file. Here is a picture of this feature:
 
 ![file-tree](https://user-images.githubusercontent.com/13142418/80496111-5065b380-899b-11ea-95c7-02af4d304aaf.png)
 
-There is also an option to configure show/hide the file tree, default to show. To hide the file tree by default, you can use the `enable_vimfiler_welcome` option:
+There is also an option to configure show/hide the file tree, default to show. To hide the file tree by default, you can use the `enable_vimfiler_welcome` in the `[options]` section:
 
 ```toml
 [options]
@@ -1072,7 +1076,7 @@ Then use `<Tab>` or `<Up>` and `<Down>` to select the mapping, press `<Enter>` t
 #### Code indentation
 
 The default indentation of code is 2, which is controlled by the option `default_indent`.
-If you prefer to use 4 as code indentation. Just add the following snippet to SpaceVim's
+If you prefer to use 4 as code indentation. Just add the following snippet to the `[options]` section in the SpaceVim's
 configuration file:
 
 ```toml
@@ -1082,7 +1086,7 @@ configuration file:
 
 The `default_indent` option will be applied to vim's `&tabstop`, `&softtabstop` and
 `&shiftwidth` options. By default, when the user inserts a `<Tab>`, it will be expanded
-to spaces. This feature can be disabled by `expand_tab` option.
+to spaces. This feature can be disabled by `expand_tab` option the `[options]` section:
 
 ```toml
 [options]
@@ -1308,7 +1312,7 @@ write
 ### Window manager
 
 Window manager key bindings can only be used in normal mode. The default leader `[WIN]` is `s`, you
-can change it via `windows_leader` option:
+can change it via `windows_leader` in the `[options]` section:
 
 ```toml
 [options]
@@ -1483,7 +1487,7 @@ By default, `find` is the default tool, you can use `ctrl-e` to switch tools.
 
 ![find](https://user-images.githubusercontent.com/13142418/97999590-79717000-1e26-11eb-91b1-458ab30d6254.gif)
 
-To change the default file searching tool, you can use `file_searching_tools` option.
+To change the default file searching tool, you can use `file_searching_tools` in the `[options]` section. 
 It is `[]` by default.
 
 ```toml
@@ -1929,7 +1933,7 @@ which contains short descriptions of all the mappings starting with `z`.
 
 When you open a file, SpaceVim will change the current directory to the root
 directory of the project that contains this file. The project's root directory detection
-is based on the `project_rooter_patterns` option, and the default value is:
+is based on the `project_rooter_patterns` in the `[options]` section, and the default value is:
 
 ```toml
 [options]

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,7 +18,7 @@ and usage.
   - [Can I try SpaceVim without overwriting my vimrc?](#can-i-try-spacevim-without-overwriting-my-vimrc)
   - [Why use toml as the default configuration file format?](#why-use-toml-as-the-default-configuration-file-format)
   - [Where should I put my configuration?](#where-should-i-put-my-configuration)
-  - [Why the option in toml file does not applied?](#why-the-option-in-toml-file-does-not-applied)
+  - [Why are the options in toml file not applied?](#why-are-the-options-in-toml-file-not-applied)
   - [E492: Not an editor command: ^M](#e492-not-an-editor-command-m)
   - [Why SpaceVim can not display default colorscheme?](#why-spacevim-can-not-display-default-colorscheme)
   - [Why can't I update plugins?](#why-cant-i-update-plugins)
@@ -110,10 +110,10 @@ drawbacks we found with the other choices considered:
 SpaceVim loads custom global configuration from `~/.SpaceVim.d/init.toml`. It also supports project specific configuration.
 That means it will load `.SpaceVim.d/init.toml` from the root of your project.
 
-### Why the option in toml file does not applied?
+### Why are the options in toml file not applied?
 
-Many people have encountered the same problem. the option has been added in init.toml. but SpaceVim do not use it.
-One possibility is that there is a syntax error in tomL. For example:
+Many people have encountered the same problem. The options have been added to `init.toml` but SpaceVim do not use it.
+One possibility is that there is a syntax error in toml. For example:
 
 ```
 [options]
@@ -131,7 +131,9 @@ One possibility is that there is a syntax error in tomL. For example:
     bootstrap_before = 'myspacevim#before'
 ```
 
-In this example, only `bootstrap_before` option will be used. So there should only one `[options]` section in toml file.
+In this example, only `bootstrap_before` option will be used. 
+
+In SpaceVim should have only one `[options]` section in toml file. In the example above, the `bootstrap_before` line should be moved before `[[layers]]`.
 
 ### E492: Not an editor command: ^M
 

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -132,6 +132,8 @@ an example for basic usage of SpaceVim. For more info, please check out [documen
 If you want to use vim script to configure SpaceVim, please check out the
 [bootstrap function](../documentation/#bootstrap-functions) section.
 
+If there are errors in your `init.toml`, the setting will not be applied. See [FAQ](../faq/#why-are-the-options-in-toml-file-not-applied). There should be only one `[options]` section in `init.toml`.
+
 ## Online tutorials
 
 This is a list of online tutorials for using SpaceVim as a general IDE and programming language support:


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

The update clarifies the location of options in init.toml. There should only one [options] section in toml file.