### PR TITLE
Fix wrong function call for --no-fonts option provided

### DIFF
--- a/docs/install.sh
+++ b/docs/install.sh
@@ -425,7 +425,6 @@ main () {
                 fetch_repo
                 install_vim
                 install_neovim
-                install_fonts
                 install_done
                 exit 0
                 ;;


### PR DESCRIPTION
FIX parsing --no-fonts resulting in the fonts being installed anyway.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [y] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [y] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [y] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Clean code and being straightforward with the usage of the install script.