### PR TITLE
Fix: Not showing git branch vim-fugitive

### DIFF
--- a/autoload/SpaceVim/layers/VersionControl.vim
+++ b/autoload/SpaceVim/layers/VersionControl.vim
@@ -77,10 +77,10 @@ endfunction
 function! s:git_branch() abort
   if exists('g:loaded_fugitive')
     try
-      let head = fugitive#head()
+      let head = exists("*FugitiveHead") ? FugitiveHead() : fugitive#Head()
       if empty(head)
-        call fugitive#detect(getcwd())
-        let head = fugitive#head()
+        call FugitiveDetect(getcwd())
+        let head = exists("*FugitiveHead") ? FugitiveHead() : fugitive#Head()
       endif
       if g:spacevim_statusline_unicode == 1
         return empty(head) ? '' : '  '.head . ' ' . s:gtm_status()


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?
Problem:
- fugitive#head() & fugitive#detect() not working

Solution:
- Moved to newer API
- Replaced fugitive#head() with FugitiveHead() if it exists or use
  fugitive#Head()
- In [cd7db1d](https://github.com/tpope/vim-fugitive/commit/cd7db1d57cc991b27d9c9ce6552faea3075ada61) of vim-fugitive, fugitive#detect() was replaced with
  FugitiveDetect()


