### PR TITLE
Fix: (nvim-cmp) change source priority

### DIFF
--- a/config/plugins/nvim-cmp.vim
+++ b/config/plugins/nvim-cmp.vim
@@ -20,11 +20,11 @@ lua <<EOF
         })}),
     },
     sources = cmp.config.sources({
-      { name = 'path' },
+      { name = 'nvim_lsp' },
     }, {
       { name = 'buffer' },
     }, {
-      { name = 'nvim_lsp' },
+      { name = 'path' },
     })
   })
 -- The nvim-cmp almost supports LSP's capabilities so You should advertise it to LSP servers..


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Fixes #4614 (though currently issues are disabled and it's probably a useless link).
When buffer already contains `MyClassSmthElse` - You cannot autocomplete `My`, `MyClass` or `MyClassSmth` because source list for nvim-cmp works like a priority list. Only suggestions from one specific source are displayed so priority should be carefully configured. Particularly I've set `lsp` source as most relevant.