### PR TITLE
Fix: (nvim-cmp) broken hotkeys and add tab,s-tab

### DIFF
--- a/config/plugins/nvim-cmp.vim
+++ b/config/plugins/nvim-cmp.vim
@@ -13,6 +13,20 @@ lua <<EOF
         c = cmp.mapping.close(),
       }),
       ['<CR>'] = cmp.mapping.confirm({ select = true }),
+      ['<Tab>'] = function(fallback)
+        if cmp.visible() then
+          cmp.select_next_item()
+        else
+          fallback()
+        end
+      end,
+      ['<S-Tab>'] = function(fallback)
+        if cmp.visible() then
+          cmp.select_prev_item()
+        else
+          fallback()
+        end
+      end,
     }),
     formatting = {
       format = require("lspkind").cmp_format({with_text = true, menu = ({

--- a/config/plugins/nvim-cmp.vim
+++ b/config/plugins/nvim-cmp.vim
@@ -3,7 +3,7 @@ lua <<EOF
   local cmp = require'cmp'
 
   cmp.setup({
-    mapping = {
+    mapping = cmp.mapping.preset.insert({
       ['<C-d>'] = cmp.mapping(cmp.mapping.scroll_docs(-4), { 'i', 'c' }),
       ['<C-f>'] = cmp.mapping(cmp.mapping.scroll_docs(4), { 'i', 'c' }),
       ['<C-Space>'] = cmp.mapping(cmp.mapping.complete(), { 'i', 'c' }),
@@ -13,7 +13,7 @@ lua <<EOF
         c = cmp.mapping.close(),
       }),
       ['<CR>'] = cmp.mapping.confirm({ select = true }),
-    },
+    }),
     formatting = {
       format = require("lspkind").cmp_format({with_text = true, menu = ({
           buffer = "[Buffer]",


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

PR consists **two commits** which actually do a bit different fixes though as for me are strongly related.

**The first one** fixes [an issue](https://groups.google.com/g/spacevim/c/Q8LBeNBBm60) which probably caused by BC break in nvim-cmp though I didn't try to find any proof. Anyway [current nvim-cmp's readme](https://github.com/hrsh7th/nvim-cmp/blob/main/README.md) contains slightly different way of setting up hotkeys. I've fixed it according to nvim-cmp's readme while leaving the keys themselves untouched. After the fix the hotkeys started working again.

**The second one** adds key bindings for `<Tab>` and `<S-Tab>` which is [conventional according to SpaceVim documentation](https://spacevim.org/layers/autocomplete/#completion). That's why I treated it as a _fix_ instead of _feature_.
Though my config does not respect the rule _"based on auto_completion_tab_key_behavior"_ - sorry, I have no idea how to implement it and whether it is possible with nvim-cmp at all.
As You can see those keys are added not plainly but as specific callbacks. To be honest I have no idea whether it is obligatory to define keys in such a way though I understand what they check (it's quite obvious) and it seems to have sense. I've token such an example from [nvim-cmp backwards compatibility thread](https://github.com/hrsh7th/nvim-cmp/issues/231).