### PR TITLE
AspectJ support has been misspelled

### DIFF
--- a/autoload/SpaceVim/layers/lang/aspectj.vim
+++ b/autoload/SpaceVim/layers/lang/aspectj.vim
@@ -1,5 +1,5 @@
 "=============================================================================
-" asepctj.vim --- asepctj language support in SpaceVim
+" aspectj.vim --- aspectj language support in SpaceVim
 " Copyright (c) 2016-2022 Wang Shidong & Contributors
 " Author: Wang Shidong < wsdjeg@outlook.com >
 " URL: https://spacevim.org
@@ -7,18 +7,18 @@
 "=============================================================================
 
 ""
-" @section lang#asepctj, layers-lang-asepctj
+" @section lang#aspectj, layers-lang-aspectj
 " @parentsection layers
-" This layer provides syntax highlighting for asepctj. To enable this
+" This layer provides syntax highlighting for aspectj. To enable this
 " layer:
 " >
 "   [layers]
-"     name = "lang#asepctj"
+"     name = "lang#aspectj"
 " <
 
 function! SpaceVim#layers#lang#aspectj#plugins() abort
   let plugins = []
-  call add(plugins, ['wsdjeg/vim-asepctj', { 'merged' : 0}])
+  call add(plugins, ['wsdjeg/vim-aspectj', { 'merged' : 0}])
   return plugins
 endfunction
 

--- a/doc/SpaceVim.txt
+++ b/doc/SpaceVim.txt
@@ -120,7 +120,7 @@ CONTENTS                                                   *SpaceVim-contents*
       25. lang#actionscript................|SpaceVim-layers-lang-actionscript|
       26. lang#agda................................|SpaceVim-layers-lang-agda|
       27. lang#asciidoc........................|SpaceVim-layers-lang-asciidoc|
-      28. lang#asepctj..........................|SpaceVim-layers-lang-asepctj|
+      28. lang#aspectj..........................|SpaceVim-layers-lang-aspectj|
       29. lang#assembly........................|SpaceVim-layers-lang-assembly|
       30. lang#autohotkey....................|SpaceVim-layers-lang-autohotkey|
       31. lang#autoit............................|SpaceVim-layers-lang-autoit|
@@ -2319,12 +2319,12 @@ This layer provides syntax highlighting for asciidoc. To enable this layer:
 <
 
 ==============================================================================
-LANG#ASEPCTJ                                    *SpaceVim-layers-lang-asepctj*
+LANG#ASEPCTJ                                    *SpaceVim-layers-lang-aspectj*
 
-This layer provides syntax highlighting for asepctj. To enable this layer:
+This layer provides syntax highlighting for aspectj. To enable this layer:
 >
   [layers]
-    name = "lang#asepctj"
+    name = "lang#aspectj"
 <
 
 ==============================================================================

--- a/docs/_posts/2020-04-05-SpaceVim-release-v1.4.0.md
+++ b/docs/_posts/2020-04-05-SpaceVim-release-v1.4.0.md
@@ -41,7 +41,7 @@ Eight programming language layers have been added since the last release:
 - Add [`lang#zig`](../layers/lang/zig/) layer [#3355](https://github.com/SpaceVim/SpaceVim/pull/3355)
 - Add `lang#wdl` layer [#3307](https://github.com/SpaceVim/SpaceVim/pull/3307)
 - Add [`lang#ring`](../layers/lang/ring/) layer [#3311](https://github.com/SpaceVim/SpaceVim/pull/3311)
-- Add [`lang#asepctj`](../layers/lang/asepctj/) layer [#3313](https://github.com/SpaceVim/SpaceVim/pull/3313)
+- Add [`lang#aspectj`](../layers/lang/aspectj/) layer [#3313](https://github.com/SpaceVim/SpaceVim/pull/3313)
 - Add [`lang#lasso`](../layers/lang/lasso/) layer [#3314](https://github.com/SpaceVim/SpaceVim/pull/3314)
 - Add `lang#xquery` layer [#3327](https://github.com/SpaceVim/SpaceVim/pull/3327)
 - Add [`lang#janet`](../layers/lang/janet/) layer [#3330](https://github.com/SpaceVim/SpaceVim/pull/3330)

--- a/docs/cn/layers/lang/aspectj.md
+++ b/docs/cn/layers/lang/aspectj.md
@@ -1,10 +1,10 @@
 ---
-title: "SpaceVim lang#asepctj layer"
+title: "SpaceVim lang#aspectj layer"
 description: "这一模块为 SpaceVim 提供了 AsepctJ 的编辑支持，包括代码高亮。"
 lang: zh
 ---
 
-# [Available Layers](../../) >> lang#asepctj
+# [Available Layers](../../) >> lang#aspectj
 
 <!-- vim-markdown-toc GFM -->
 
@@ -23,7 +23,7 @@ lang: zh
 
 ```toml
 [[layers]]
-  name = "lang#asepctj"
+  name = "lang#aspectj"
 ```
 
 

--- a/docs/layers/lang/aspectj.md
+++ b/docs/layers/lang/aspectj.md
@@ -1,9 +1,9 @@
 ---
-title: "SpaceVim lang#asepctj layer"
+title: "SpaceVim lang#aspectj layer"
 description: "AsepctJ language support, including syntax highlighting."
 ---
 
-# [Available Layers](../../) >> lang#asepctj
+# [Available Layers](../../) >> lang#aspectj
 
 <!-- vim-markdown-toc GFM -->
 
@@ -22,6 +22,6 @@ To use this configuration layer, update your custom configuration file with:
 
 ```toml
 [[layers]]
-  name = "lang#asepctj"
+  name = "lang#aspectj"
 ```
 

--- a/wiki/en/programming-languages.md
+++ b/wiki/en/programming-languages.md
@@ -14,7 +14,7 @@ This is a list of programming languages supported in SpaceVim:
 | Agda                                                      | [lang#agda](https://spacevim.org/layers/lang/agda/)                 |      |
 | ActionScript                                              | [lang#actionscript](https://spacevim.org/layers/lang/actionscript/) |      |
 | Assembly                                                  | lang#assemble                                                       |      |
-| AspectJ                                                   | [lang#asepctj](https://spacevim.org/layers/lang/aspectj/)           |      |
+| AspectJ                                                   | [lang#aspectj](https://spacevim.org/layers/lang/aspectj/)           |      |
 | AutoHotkey                                                | [lang#autohotkey](https://spacevim.org/layers/lang/autohotkey/)     |      |
 | Bash, Fish, zsh                                           | [lang#sh](https://spacevim.org/layers/lang/sh/)                     |      |
 | C#                                                        | [lang#csharp](https://spacevim.org/layers/lang/csharp/)             |      |


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

The documentation and comments on AspectJ support were mostly misspelled as `asepctj`.

This PR is a mechanical replace (using [fastmod](https://github.com/facebookincubator/fastmod)) of `asepctj` to `aspectj`.