### PR TITLE
Fix typo in undotree/README.md

### DIFF
--- a/bundle/undotree/README.md
+++ b/bundle/undotree/README.md
@@ -40,7 +40,7 @@ Use whatever plug-in manager to pull the master branch.
     * Saved changes are marked as `s` and the big `S` indicates the most recent saved change.
  1. Press `?` in undotree window for quick help.
  1. Persistent undo
-    * Usually I would like to store the undo files in a seperate place like below.
+    * Usually I would like to store the undo files in a separate place like below.
 
 ```
 if has("persistent_undo")


### PR DESCRIPTION


### PR Prelude



- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

seperate -> separate