### PR TITLE
Fix lsp plugin init loading error.

### DIFF
--- a/bundle/nvim-lspconfig/lua/lspconfig.lua
+++ b/bundle/nvim-lspconfig/lua/lspconfig.lua
@@ -77,7 +77,7 @@ end
 local mt = {}
 function mt:__index(k)
   if configs[k] == nil then
-    local success, config = pcall(require, 'lspconfig.server_configurations.' .. k)
+    local success, config = pcall(require, 'lspconfig.server_configurations.' .. tostring(k))
     if success then
       configs[k] = config
     else


### PR DESCRIPTION
[dein] Error occurred while executing hook: nvim-lspconfig
[dein] Vim(lua):E5108: Error executing lua ...iaobin/.SpaceVim/bundle/nvim-lspconfig/lua/lspconfig.l
ua:80: attempt to concatenate local 'k' (a boolean value)
[dein] stack traceback:
[dein] ^I...iaobin/.SpaceVim/bundle/nvim-lspconfig/lua/lspconfig.lua:80: in function '__index'
[dein] ^I[string ":lua"]:49: in main chunk

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [ ] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [ ] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?
Bug fixing.
[Please explain **in detail** why the changes in this PR are needed.]
platform: macos 12.5.1
nvim version: NVIM v0.8.0-dev-831-g1de62b9ea
