### PR TITLE
Include files required for the lua logger api when detaching flygrep.

### DIFF
--- a/.ci/detach_plugin.sh
+++ b/.ci/detach_plugin.sh
@@ -36,6 +36,7 @@ main () {
             _checkdir autoload/SpaceVim/api/data
             _checkdir autoload/SpaceVim/mapping
             _checkdir autoload/SpaceVim/plugins
+            _checkdir lua/spacevim/api
             _detact autoload/SpaceVim/plugins/flygrep.vim
             _detact autoload/SpaceVim/api.vim
             _detact autoload/SpaceVim/api/logger.vim
@@ -59,6 +60,10 @@ main () {
             _detact autoload/SpaceVim/api/time.vim
             _detact autoload/SpaceVim/mapping/search.vim
             _detact autoload/SpaceVim/logger.vim
+            _detact lua/spacevim.lua
+            _detact lua/spacevim/api.lua
+            _detact lua/spacevim/api/logger.lua
+            _detact lua/spacevim/logger.lua
             _detact syntax/SpaceVimFlyGrep.vim
             _default_readme "FlyGrep.vim" "Grep on the fly in Vim/Neovim"
             _detact LICENSE


### PR DESCRIPTION
### PR Prelude

- [X] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [X] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Detached flygrep doesn't work without it.
