### PR TITLE
fix(lsp): type error when loading lsp config

### DIFF
--- a/autoload/SpaceVim/layers/lsp.vim
+++ b/autoload/SpaceVim/layers/lsp.vim
@@ -102,13 +102,15 @@ for _, lsp in ipairs(servers) do
 end
 local override_client_cmds = require('spacevim').eval('s:override_client_cmds')
 for client, override_cmd in pairs(override_client_cmds) do
-  nvim_lsp[client].setup {
-    cmd = override_cmd,
-    on_attach = on_attach,
-    flags = {
-      debounce_text_changes = 150,
+  if type(client) == "string" then
+    nvim_lsp[client].setup {
+      cmd = override_cmd,
+      on_attach = on_attach,
+      flags = {
+        debounce_text_changes = 150,
+        }
       }
-    }
+  end
 end
 EOF
 endfunction


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

This PR fixes the problem discussed in #4698 but in a more proper way.

I haven't figured out why `require('spacevim').eval('s:override_client_cmds')` returns `{ true: 6 }` after 2 hours of digging. I'll just leave this question unanswered as I don't want to jump in a rabbit hole.