### PR TITLE
Fix trivial typo in 2022-07-02-SpaceVim-release-v2.0.0.md

### DIFF
--- a/docs/_posts/2022-07-02-SpaceVim-release-v2.0.0.md
+++ b/docs/_posts/2022-07-02-SpaceVim-release-v2.0.0.md
@@ -22,7 +22,7 @@ comments: true
 
 The last release is v1.9.0, After six months development.
 The v2.0.0 has been released. This is second major release of SpaceVim.
-So let's take a look at what happened since last relase.
+So let's take a look at what happened since last release.
 
 ![welcome page](https://user-images.githubusercontent.com/13142418/176910121-8e7ca78f-8434-4ac7-9b02-08c4d15f8ad9.png)
 


### PR DESCRIPTION
[trivial] Fix minor typo in v2.0.0 release page: s/relase/release

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [&check;] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [&check;] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [&check;] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

This trivial change fixes a minor typo on the releases page for SpaceVim v2.0.0. The word "release" was misspelled as "relase".
