### PR TITLE
fix for lua removing leading zeros (#4714)

### DIFF
--- a/lua/spacevim/default.lua
+++ b/lua/spacevim/default.lua
@@ -90,19 +90,19 @@ function M.options()
     vim.g.conf_dir = vim.g.data_dir .. 'conf'
 
     if vim.fn.finddir(vim.g.data_dir) == '' then
-        pcall(vim.fn.mkdir, vim.g.data_dir, 'p', 0700)
+        pcall(vim.fn.mkdir, vim.g.data_dir, 'p', '0700')
     end
     if vim.fn.finddir(vim.g.backup_dir) == '' then
-        pcall(vim.fn.mkdir, vim.g.backup_dir, 'p', 0700)
+        pcall(vim.fn.mkdir, vim.g.backup_dir, 'p', '0700')
     end
     if vim.fn.finddir(vim.g.swap_dir) == '' then
-        pcall(vim.fn.mkdir, vim.g.swap_dir, 'p', 0700)
+        pcall(vim.fn.mkdir, vim.g.swap_dir, 'p', '0700')
     end
     if vim.fn.finddir(vim.g.undo_dir) == '' then
-        pcall(vim.fn.mkdir, vim.g.undo_dir, 'p', 0700)
+        pcall(vim.fn.mkdir, vim.g.undo_dir, 'p', '0700')
     end
     if vim.fn.finddir(vim.g.conf_dir) == '' then
-        pcall(vim.fn.mkdir, vim.g.conf_dir, 'p', 0700)
+        pcall(vim.fn.mkdir, vim.g.conf_dir, 'p', '0700')
     end
     vim.o.undodir = vim.g.undo_dir
     vim.o.backupdir = vim.g.backup_dir


### PR DESCRIPTION
As I explained in [here](https://github.com/SpaceVim/SpaceVim/issues/4714#issuecomment-1268919712), leading zeros in lua are removed, thus resulting in a vim call of such:
```vim
:silent call mkdir("not/gonna/work", 'p', 700)
```
which results in the wrong permission.

Added quotes to make sure the leading zeros are kept.