### PR TITLE
Fix: no need to config lsp capabilities in nvim-cmp.vim

### DIFF
--- a/config/plugins/nvim-cmp.vim
+++ b/config/plugins/nvim-cmp.vim
@@ -41,12 +41,4 @@ lua <<EOF
       { name = 'path' },
     })
   })
--- The nvim-cmp almost supports LSP's capabilities so You should advertise it to LSP servers..
-local capabilities = vim.lsp.protocol.make_client_capabilities()
-capabilities = require('cmp_nvim_lsp').update_capabilities(capabilities)
-
--- The following example advertise capabilities to `clangd`.
-require'lspconfig'.clangd.setup {
-  capabilities = capabilities,
-}
 EOF


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x ] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [ x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x ] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

There is no need to config lsp capabilities in nvim-cmp.vim. It should be done in language layers.

Moreover, `cmp_nvim_lsp.update_capabilities` is deprecated and will be removed in `cmp-nvim-lsp` 1.0.0, use `cmp_nvim_lsp.default_capabilities` instead. The deleted line will trigger the deprecated warning