### PR TITLE
Docs: do not start commit description with capital letter

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -101,7 +101,7 @@ you can also use a specific layer name or plugin name as a scope.
 **subject:**
 
 Subjects should be no greater than 50 characters,
-should begin with a capital letter and do not end with a period.
+should not begin with a capital letter and do not end with a period.
 
 Use an imperative tone to describe what a commit does,
 rather than what it did. For example, use change; not changed or changes.


### PR DESCRIPTION
The vast majority of last 1000 commits do not use a capital letter to start the <description> field in the commit subject: $ git log --oneline -n 1000 origin/master | grep ': [A-Z]' | wc -l 11
$ git log --oneline -n 1000 origin/master | grep ': [a-z]' | wc -l 984
Assume this is the new convention and update the doc.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [X] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [X] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Add the de-facto convention to the docs, (hopefully) generating more consistence in the commit log