### PR TITLE
remove --nodetach

### DIFF
--- a/bundle/vim-clipboard/autoload/clipboard.vim
+++ b/bundle/vim-clipboard/autoload/clipboard.vim
@@ -28,7 +28,7 @@ function! s:set_command() abort
     let yank = 'xclip -quiet -i -selection clipboard'
     let paste = 'xclip -o -selection clipboard'
   elseif !empty($DISPLAY) && executable('xsel')
-    let yank = 'xsel --nodetach -i -b'
+    let yank = 'xsel -i -b'
     let paste = 'xsel -o -b'
   elseif executable('lemonade')
     let yank = 'lemonade copy'


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [X] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [X] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]
Fix for issue #4754
Why do we have this flag for xsel command? If I remove it will make clipboard work for me. Will this be a good thing for everyone? And what is the reason for --nodetach being there in the first place?