### PR TITLE
Change download font url

### DIFF
--- a/docs/install.sh
+++ b/docs/install.sh
@@ -333,7 +333,7 @@ welcome () {
 
 # download_font {{{
 download_font () {
-    url="https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/SourceCodePro/Regular/complete/${1// /%20}"
+    url="https://raw.githubusercontent.com/ryanoasis/nerd-fonts/master/patched-fonts/SourceCodePro/Regular/complete/${1// /%20}"
     path="$HOME/.local/share/fonts/$1"
     if [[ -f "$path" && ! -s "$path" ]]
     then


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]

Old link redirects to raw.githubusercontent.com and because of that script creates empty file instead of downloading font. The other option is to add `curl` key `-L` to follow redirect. We can discuss this if needed.