### PR TITLE
docs(typo): fix typo in documentation.md

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -387,7 +387,7 @@ endfunction
 ```
 
 Similarly, if you want to add custom key bindings prefixed by language leader key,
-which is typically `,`, you can add them to the boostrap function. **Make sure** that the
+which is typically `,`, you can add them to the bootstrap function. **Make sure** that the
 key bindings are not used by SpaceVim.
 
 ```vim


### PR DESCRIPTION


### PR Prelude

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

boostrap -> bootstrap
