### PR TITLE
fix(mkfontdir): only check for mkfontdir when OS is not Darwin

### DIFF
--- a/docs/install.sh
+++ b/docs/install.sh
@@ -353,8 +353,6 @@ download_font () {
 
 # install_fonts {{{
 install_fonts () {
-    need_cmd 'mkfontdir'
-    need_cmd 'mkfontscale'
     if [[ ! -d "$HOME/.local/share/fonts" ]]; then
         mkdir -p $HOME/.local/share/fonts
     fi
@@ -366,6 +364,8 @@ install_fonts () {
         fi
         cp $HOME/.local/share/fonts/* $HOME/Library/Fonts/
     else
+        need_cmd 'mkfontdir'
+        need_cmd 'mkfontscale'
         fc-cache -fv > /dev/null
         mkfontdir "$HOME/.local/share/fonts" > /dev/null
         mkfontscale "$HOME/.local/share/fonts" > /dev/null


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [X] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [X] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?
`mkfontdir` and `mkfontscale` are not available and not needed for Mac OS. Moved checks to the intended place.