### PR TITLE
docs: fix github workflow build badges

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -8,7 +8,7 @@
 [入门指南](https://spacevim.org/cn/quick-start-guide/) \|
 [推特](https://twitter.com/SpaceVim)
 
-[![build](https://img.shields.io/github/workflow/status/SpaceVim/SpaceVim/test)](https://github.com/SpaceVim/SpaceVim/actions/workflows/check.yml?query=branch%3Amaster)
+[![build](https://img.shields.io/github/actions/workflow/status/SpaceVim/SpaceVim/check.yml?branch=master)](https://github.com/SpaceVim/SpaceVim/actions/workflows/check.yml?query=branch%3Amaster)
 [![Codecov coverage](https://img.shields.io/codecov/c/github/SpaceVim/SpaceVim.svg)](https://codecov.io/gh/SpaceVim/SpaceVim)
 [![Release](https://img.shields.io/badge/Release-2.0.0-8700FF.svg)](https://spacevim.org/SpaceVim-release-v2.0.0/)
 [![GPLv3 License](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://github.com/SpaceVim/SpaceVim/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [Chat](https://chat.mozilla.org/#/room/#spacevim:matrix.org) \|
 [Twitter](https://twitter.com/SpaceVim)
 
-[![build](https://img.shields.io/github/workflow/status/SpaceVim/SpaceVim/test)](https://github.com/SpaceVim/SpaceVim/actions/workflows/check.yml?query=branch%3Amaster)
+[![build](https://img.shields.io/github/actions/workflow/status/SpaceVim/SpaceVim/check.yml?branch=master)](https://github.com/SpaceVim/SpaceVim/actions/workflows/check.yml?query=branch%3Amaster)
 [![Codecov coverage](https://img.shields.io/codecov/c/github/SpaceVim/SpaceVim.svg)](https://codecov.io/gh/SpaceVim/SpaceVim)
 [![Release](https://img.shields.io/badge/Release-2.0.0-8700FF.svg)](https://spacevim.org/SpaceVim-release-v2.0.0/)
 [![GPLv3 License](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://github.com/SpaceVim/SpaceVim/blob/master/LICENSE)

--- a/docs/cn/index.md
+++ b/docs/cn/index.md
@@ -5,7 +5,7 @@ lang: zh
 ---
 
 [![matrix](https://img.shields.io/matrix/spacevim-cn:matrix.org?color=green&label=%23spacevim-cn%3Amatrix.org&logo=matrix)](https://chat.mozilla.org/#/room/#spacevim-cn:matrix.org)
-[![build](https://img.shields.io/github/workflow/status/SpaceVim/SpaceVim/test)](https://github.com/SpaceVim/SpaceVim/actions/workflows/check.yml?query=branch%3Amaster)
+[![build](https://img.shields.io/github/actions/workflow/status/SpaceVim/SpaceVim/check.yml?branch=master)](https://github.com/SpaceVim/SpaceVim/actions/workflows/check.yml?query=branch%3Amaster)
 [![Codecov coverage](https://img.shields.io/codecov/c/github/SpaceVim/SpaceVim.svg)](https://codecov.io/gh/SpaceVim/SpaceVim)
 [![Release](https://img.shields.io/badge/Release-2.0.0-8700FF.svg)](https://spacevim.org/SpaceVim-release-v2.0.0/)
 [![GPLv3 License](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://github.com/SpaceVim/SpaceVim/blob/master/LICENSE)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ description: "SpaceVim is a community-driven vim distribution that seeks to prov
 ---
 
 [![matrix](https://img.shields.io/matrix/spacevim:matrix.org?color=green&label=%23spacevim%3Amatrix.org&logo=matrix)](https://chat.mozilla.org/#/room/#spacevim:matrix.org)
-[![build](https://img.shields.io/github/workflow/status/SpaceVim/SpaceVim/test)](https://github.com/SpaceVim/SpaceVim/actions/workflows/check.yml?query=branch%3Amaster)
+[![build](https://img.shields.io/github/actions/workflow/status/SpaceVim/SpaceVim/check.yml?branch=master)](https://github.com/SpaceVim/SpaceVim/actions/workflows/check.yml?query=branch%3Amaster)
 [![Codecov coverage](https://img.shields.io/codecov/c/github/SpaceVim/SpaceVim.svg)](https://codecov.io/gh/SpaceVim/SpaceVim)
 [![Release](https://img.shields.io/badge/Release-2.0.0-8700FF.svg)](https://spacevim.org/SpaceVim-release-v2.0.0/)
 [![GPLv3 License](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://github.com/SpaceVim/SpaceVim/blob/master/LICENSE)


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [X] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [X] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Currently the 'build' badge/shield in the README(s) and index doesn't actually show build information, it shows a link to a shields issue:

![Screenshot 2023-01-11 at 16 10 59](https://user-images.githubusercontent.com/20516159/211857296-2d652d28-7b6d-4c08-9828-944f448632f0.png)

This affects the SpaceVim website (which I believe uses the index.md file as the homepage):

![Screenshot 2023-01-11 at 16 13 41](https://user-images.githubusercontent.com/20516159/211857955-5438c0f7-9c9a-41ae-b7f9-4e2a5f869a4f.png)

In summary, these badges were changed in a breaking fashion such that the badges were just linking to the github issue rather than showing the data. Updating the url resolves this.

See the linked GitHub issue from the current version of the badge for the full details: https://github.com/badges/shields/issues/8671

So far, I've just made the basic change to the files - let me know if I need to carry out any build process or similar for the docs in order for the PR to move forward.

