### PR TITLE
Issue 4754 - Remove -quiet flag on xclip clipboard.

### DIFF
--- a/bundle/vim-clipboard/autoload/clipboard.vim
+++ b/bundle/vim-clipboard/autoload/clipboard.vim
@@ -25,7 +25,7 @@ function! s:set_command() abort
     let yank = 'wl-copy --foreground --type text/plain'
     let paste = 'wl-paste --no-newline'
   elseif !empty($DISPLAY) && executable('xclip')
-    let yank = 'xclip -quiet -i -selection clipboard'
+    let yank = 'xclip -i -selection clipboard'
     let paste = 'xclip -o -selection clipboard'
   elseif !empty($DISPLAY) && executable('xsel')
     let yank = 'xsel -i -b'


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [X ] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [X ] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [X ] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]

I had similar issues to what was described in [Issue 4754](https://github.com/SpaceVim/SpaceVim/issues/4754) and once I found that, I realized it worked if I used xsel for the clipboard rather than xclip. This should fix it for xclip as far as I can tell.

Disclaimer: I am no vim/NeoVim/SpaceVim expert. So feel free to close if you see any issue with this. I'm simply trying to help out after some frustrating debugging in my end 😃 
