### PR TITLE
Adding quite options to powershell exec

### DIFF
--- a/autoload/SpaceVim/layers/lang/powershell.vim
+++ b/autoload/SpaceVim/layers/lang/powershell.vim
@@ -15,7 +15,7 @@ endfunction
 
 
 function! SpaceVim#layers#lang#powershell#config() abort
-  call SpaceVim#plugins#repl#reg('powershell', 'powershell')
+  call SpaceVim#plugins#repl#reg('powershell', 'powershell  -NoLogo -NoProfile -NonInteractive')
   call SpaceVim#plugins#runner#reg_runner('powershell', 'powershell %s')
   call SpaceVim#mapping#space#regesit_lang_mappings('powershell', function('s:language_specified_mappings'))
 endfunction


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [ x ] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [ x ] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [ x ] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Customized profiles can/do break in non-standard terminals, increase execution time, and usually don't help in this context. I'm suggesting a change to an "embedded" or "script" style launching of powershell to accommodate this.
