### PR TITLE
fix the config subdir bug

### DIFF
--- a/docs/install.sh
+++ b/docs/install.sh
@@ -91,7 +91,7 @@ System="$(uname -s)"
 
 XDGSpaceDir="${XDG_CONFIG_HOME:-${HOME}/.}${XDG_CONFIG_HOME:+/}SpaceVim"
 XDGvimDir="${XDG_CONFIG_HOME:-${HOME}/.}${XDG_CONFIG_HOME:+/}vim"
-XDGnvimDir="${XDG_CONFIG_HOME:-${HOME}/.}${XDG_CONFIG_HOME:+/}config/nvim"
+XDGnvimDir="${XDG_CONFIG_HOME:-${HOME}/.}${XDG_CONFIG_HOME:+/}nvim"
 
 # need_cmd {{{
 need_cmd () {


### PR DESCRIPTION
it should install into $XDG_CONFIG_HOME/nvim NOT [...]/config/nvim

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Simple example: my $XDG_CONFIG_HOME is ~/.config, so neovim expects the config files to be in ~/.config/nvim NOT ~/.config/config/nvim