### PR TITLE
Feature: support`Telescope ultisnips` command if snippet engine is ultisnips

### DIFF
--- a/autoload/SpaceVim/layers/telescope.vim
+++ b/autoload/SpaceVim/layers/telescope.vim
@@ -51,6 +51,10 @@ function! SpaceVim#layers#telescope#plugins() abort
   call add(plugins, [g:_spacevim_root_dir . 'bundle/telescope-ctags-outline.nvim', {'merged' : 0}])
   call add(plugins, [g:_spacevim_root_dir . 'bundle/neoyank.vim',        { 'merged' : 0}])
   call add(plugins, [g:_spacevim_root_dir . 'bundle/telescope-fzf-native.nvim',        { 'merged' : 0}])
+  if g:spacevim_snippet_engine ==# 'ultisnips'
+    call add(plugins, ['fhill2/telescope-ultisnips.nvim', { 'merged' : 0}])
+  endif
+
   return plugins
 endfunction
 
@@ -309,6 +313,20 @@ function! s:defind_fuzzy_finder() abort
           \ 'Definition: ' . s:file . ':' . lnum,
           \ ]
           \ ]
+
+  if g:spacevim_snippet_engine ==# 'ultisnips'
+    nnoremap <silent> <Leader>fs  :<C-u>Telescope ultisnips<CR>
+    let lnum = expand('<slnum>') + s:unite_lnum - 4
+    let g:_spacevim_mappings.f.s = ['Telescope ultisnips',
+          \ 'fuzzy find ultisnips snippets',
+          \ [
+            \ '[Leader f s] is to fuzzy find ultisnips snippets',
+            \ '',
+            \ 'Definition: ' . s:file . ':' . lnum,
+            \ ]
+            \ ]
+  endif
+
 
   let lnum = expand('<slnum>') + s:unite_lnum - 4
   call SpaceVim#mapping#space#def('nnoremap', ['f', 'v', 's'], 'Telescope scriptnames',

--- a/config/plugins/telescope.vim
+++ b/config/plugins/telescope.vim
@@ -11,6 +11,10 @@ if filereadable(g:_spacevim_root_dir . 'bundle/telescope-fzf-native.nvim/build/l
       \ || filereadable(g:_spacevim_root_dir . 'bundle/telescope-fzf-native.nvim/build/libfzf.dll')
   lua require('telescope').load_extension('fzf')
 endif
+if g:spacevim_snippet_engine ==# 'ultisnips'
+  lua require('telescope').load_extension('ultisnips')
+endif
+
 lua <<EOF
 local actions = require("telescope.actions")
 require("telescope").setup{

--- a/docs/layers/autocomplete.md
+++ b/docs/layers/autocomplete.md
@@ -178,6 +178,7 @@ To disable this feature, set the variable `auto_completion_enable_snippets_in_po
 | ----------- | -------------------------------------------------------------- |
 | `M-/`       | Expand a snippet if text before point is a prefix of a snippet |
 | `SPC i s`   | List all current snippets for inserting                      |
+| `<Leader> f s` | Fuzzy find Ultisnips snippets if `snippet_engine = "ultisnips"` and the layer [`telescope`](../telescope) is used |
 
 NOTE: `SPC i s` requires that at least one fuzzy search layer be loaded. If the `snippet_engine` is `neosnippet`.
 The fuzzy finder layer can be `leaderf`, `denite` or `unite`. For `ultisnips`, you can use `leaderf` or `unite` layer.

--- a/docs/layers/autocomplete.md
+++ b/docs/layers/autocomplete.md
@@ -178,7 +178,7 @@ To disable this feature, set the variable `auto_completion_enable_snippets_in_po
 | ----------- | -------------------------------------------------------------- |
 | `M-/`       | Expand a snippet if text before point is a prefix of a snippet |
 | `SPC i s`   | List all current snippets for inserting                      |
-| `<Leader> f s` | Fuzzy find Ultisnips snippets if `snippet_engine = "ultisnips"` and the layer [`telescope`](../telescope) is used |
+| `<Leader> f s` | Fuzzy find Ultisnips snippets if `snippet_engine = "ultisnips"` and the layer [`telescope`](../telescope) is used. Thanks to [telescope-ultisnips.nvim](https://github.com/fhill2/telescope-ultisnips.nvim)|
 
 NOTE: `SPC i s` requires that at least one fuzzy search layer be loaded. If the `snippet_engine` is `neosnippet`.
 The fuzzy finder layer can be `leaderf`, `denite` or `unite`. For `ultisnips`, you can use `leaderf` or `unite` layer.

--- a/docs/layers/telescope.md
+++ b/docs/layers/telescope.md
@@ -38,4 +38,4 @@ SpaceVim uses `f` as the default customized key binding prefix for telescope lay
 | `<Leader> f t`       | Fuzzy find tags               |
 | `<Leader> f q`       | Fuzzy find quick fix          |
 | `<Leader> f r`       | Resumes telescope window      |
-| `<Leader> f s`       | Fuzzy find Ultisnips snippets (if `snippet_engine = "ultisnips"`) |
+| `<Leader> f s`       | Fuzzy find Ultisnips snippets (if `snippet_engine = "ultisnips"`). Thanks to [telescope-ultisnips.nvim](https://github.com/fhill2/telescope-ultisnips.nvim)|

--- a/docs/layers/telescope.md
+++ b/docs/layers/telescope.md
@@ -38,3 +38,4 @@ SpaceVim uses `f` as the default customized key binding prefix for telescope lay
 | `<Leader> f t`       | Fuzzy find tags               |
 | `<Leader> f q`       | Fuzzy find quick fix          |
 | `<Leader> f r`       | Resumes telescope window      |
+| `<Leader> f s`       | Fuzzy find Ultisnips snippets (if `snippet_engine = "ultisnips"`) |


### PR DESCRIPTION
Add more feature to the Telescope layer. Use `<Leader> f s` to `Fuzzy find Ultisnips snippets` if `snippets_engine="ultisnips"`.
Use [fhill2/telescope-ultisnips.nvim](https://github.com/fhill2/telescope-ultisnips.nvim).

The mapping is added to the doc.

Not 100% sure whether I can `add(plugins, ['fhill2/telescope-ultisnips.nvim', { 'merged' : 0}])`, a not bundled package.