### PR TITLE
fix xdg support

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -7,7 +7,7 @@
 "=============================================================================
 
 " Use XDG paths if available
-if !empty($XDG_CONFIG_HOME) && !empty($XDG_DATA_HOME)
+if !empty($XDG_CONFIG_HOME) && !empty($XDG_DATA_HOME) && !empty($XDG_STATE_HOME)
     set runtimepath^=$XDG_CONFIG_HOME/vim
     set runtimepath+=$XDG_DATA_HOME/vim
     set runtimepath+=$XDG_CONFIG_HOME/vim/after


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

I noticed all the directories I used vim on (most of them) had a directory called `$XDG_STATE_HOME` in them. Upon digging into spacevim, I came to believe the issue stemmed from trying to create the directory when the variable wasn't set.

Alternatively, maybe we should expand the variables before calling mkdir?
