### PR TITLE
Fix: neovim not being able to create a new file #4836

### DIFF
--- a/autoload/SpaceVim.vim
+++ b/autoload/SpaceVim.vim
@@ -1637,6 +1637,8 @@ function! s:parser_argv() abort
         return [1, fnamemodify(expand(v:argv[-1]), ':p')]
       elseif filereadable(v:argv[-1])
         return [2, get(v:, 'argv', ['failed to get v:argv'])]
+      elseif v:argv[-1] != '--embed'
+        return [2, v:argv[-1]]
       else
         return [0]
       endif


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Since Neovim version 0.9.0, SpaceVim could not create a new file with command `$ nvim new_file.ext` (#4836). This happened because argv list was never empty, but was treated as empty even though it had some arguments, because the `--embed` argument always appeared in the list. With this PR creating files works as intended.


Since I am new to vim language, it would be a good idea if someone checked that the string comparison is done right (should I be using a builtin function? Should I have expanded v:argv[-1] with `expand(v:argv[-1])`)? Do lowercase/uppercase matter?). Are there any other arguments that could appear apart from `--embed`?

It's just 2 short lines of code, so hopefully it can be merged soon.
