### PR TITLE
fix(projectmanager): invalid order function

### DIFF
--- a/lua/spacevim/plugin/projectmanager.lua
+++ b/lua/spacevim/plugin/projectmanager.lua
@@ -159,7 +159,7 @@ local function compare(d1, d2)
   -- the project_rooter_outermost is 0/false or 1 true
   if sp_opt.project_rooter_outermost == 0
     or sp_opt.project_rooter_outermost == false then
-    if bl > al then
+    if bl >= al then
       return false
     else
       return true


### PR DESCRIPTION
when `project_rooter_outermost = false` is configured to false this error appears:
```
Error detected while processing function SpaceVim#plugins#projectmanager#current_root:
line    1:
E5108: Error executing lua ...x/sync/.SpaceVim//lua/spacevim/plugin/projectmanager.lua:177: invalid order function for sorting
stack traceback:
        [C]: in function 'sort'
        ...x/sync/.SpaceVim//lua/spacevim/plugin/projectmanager.lua:177: in function 'find_root_directory'
        ...x/sync/.SpaceVim//lua/spacevim/plugin/projectmanager.lua:414: in function 'current_root'
        [string "luaeval()"]:1: in main chunk
E5108: Error executing lua ...x/sync/.SpaceVim//lua/spacevim/plugin/projectmanager.lua:177: invalid order function for sorting
stack traceback:
        [C]: in function 'sort'
        ...x/sync/.SpaceVim//lua/spacevim/plugin/projectmanager.lua:177: in function 'find_root_directory'
        ...x/sync/.SpaceVim//lua/spacevim/plugin/projectmanager.lua:414: in function 'current_root'
        [string "luaeval()"]:1: in main chunk
```

i personally don't have experience in lua so the change may not be the best thing to do