### PR TITLE
fix(rust): rust lsp check typos fix (need capital S and V in SpaceVim…

### DIFF
--- a/autoload/SpaceVim/layers/lang/rust.vim
+++ b/autoload/SpaceVim/layers/lang/rust.vim
@@ -110,9 +110,9 @@ endif
 function! SpaceVim#layers#lang#rust#plugins() abort
   let plugins = []
   call add(plugins, [g:_spacevim_root_dir . 'bundle/rust.vim', {'merged' : 0}])
-  if !spacevim#layers#lsp#check_filetype('rust')
-        \ && !spacevim#layers#lsp#check_server('rls')
-        \ && !spacevim#layers#lsp#check_server('rust_analyzer')
+  if !SpaceVim#layers#lsp#check_filetype('rust')
+        \ && !SpaceVim#layers#lsp#check_server('rls')
+        \ && !SpaceVim#layers#lsp#check_server('rust_analyzer')
     call add(plugins, ['racer-rust/vim-racer', {'merged' : 0}])
   endif
   return plugins
@@ -202,9 +202,9 @@ function! s:language_specified_mappings() abort
         \ . string(function('s:execCMD')) . ', ["cargo fmt"])',
         \ 'format project files', 1)
 
-  if spacevim#layers#lsp#check_filetype('rust')
-        \ || spacevim#layers#lsp#check_server('rls')
-        \ || spacevim#layers#lsp#check_server('rust_analyzer')
+  if SpaceVim#layers#lsp#check_filetype('rust')
+        \ || SpaceVim#layers#lsp#check_server('rls')
+        \ || SpaceVim#layers#lsp#check_server('rust_analyzer')
     nnoremap <silent><buffer> K :call SpaceVim#lsp#show_doc()<CR>
     nnoremap <silent><buffer> gD :<C-u>call SpaceVim#lsp#go_to_typedef()<Cr>
 


### PR DESCRIPTION
…#...

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

The commit 37e6806 tries to fix Rust lsp, but introduces a few typos (spacevim#... instead of SpaceVim#...). These typos cause lsp to malfunction. This is the fix for those typos. Ready to merge asap.