### PR TITLE
add job api

### DIFF
--- a/bundle/gtags.vim/autoload/ctags.vim
+++ b/bundle/gtags.vim/autoload/ctags.vim
@@ -103,8 +103,7 @@ endfunction
 
 function! s:on_update_exit(id, data, event) abort
   " @bug on exit function is not called when failed
-  " C:\Users\wsdjeg\.SpaceVim>C:\Users\wsdjeg\.SpaceVim\bundle\phpcomplete.vim\bin\ctags.exe -R -o C:/Users/wsdjeg/.cache/SpaceVim/tags/C__Users_wsd
-  " jeg__SpaceVim_/tags C:\Users\wsdjeg\.SpaceVim
+  " C:\Users\wsdjeg\.SpaceVim>C:\Users\wsdjeg\.SpaceVim\bundle\phpcomplete.vim\bin\ctags.exe -R -o C:/Users/wsdjeg/.cache/SpaceVim/tags/C__Users_wsdjeg__SpaceVim_/tags C:\Users\wsdjeg\.SpaceVim
   "
   " C:\Users\wsdjeg\.SpaceVim>echo %ERRORLEVEL%
   " -1073741819

--- a/lua/spacevim/api/job.lua
+++ b/lua/spacevim/api/job.lua
@@ -1,0 +1,29 @@
+--=============================================================================
+-- job.lua --- 
+-- Copyright (c) 2016-2022 Wang Shidong & Contributors
+-- Author: Wang Shidong < wsdjeg@outlook.com >
+-- URL: https://spacevim.org
+-- License: GPLv3
+--=============================================================================
+
+local M = {}
+
+local uv = vim.loop
+
+
+
+
+function M.start(cmd, opts) -- {{{
+  local command = ''
+  if type(cmd) == "string" then
+    command = 'cmd.exe'
+  elseif type(cmd) == "table" then
+    command = cmd[1]
+  end
+
+  uv.spawn(command, opt, exit_cb)
+end
+-- }}}
+
+
+return M

--- a/lua/spacevim/api/job.lua
+++ b/lua/spacevim/api/job.lua
@@ -129,7 +129,7 @@ function M.chanclose(id, t)
   end
 end
 
-function M.close(id)
+function M.stop(id)
   local jobobj = _jobs['jobid_' .. id]
 
   if not jobobj then
@@ -137,7 +137,7 @@ function M.close(id)
   end
 
   local handle = jobobj.handle
-  uv.close(handle)
+  handle:kill(6)
 end
 
 return M

--- a/lua/spacevim/api/job.lua
+++ b/lua/spacevim/api/job.lua
@@ -1,5 +1,5 @@
 --=============================================================================
--- job.lua --- 
+-- job.lua ---
 -- Copyright (c) 2016-2022 Wang Shidong & Contributors
 -- Author: Wang Shidong < wsdjeg@outlook.com >
 -- URL: https://spacevim.org
@@ -10,20 +10,68 @@ local M = {}
 
 local uv = vim.loop
 
-
-
-
-function M.start(cmd, opts) -- {{{
-  local command = ''
-  if type(cmd) == "string" then
-    command = 'cmd.exe'
-  elseif type(cmd) == "table" then
-    command = cmd[1]
-  end
-
-  uv.spawn(command, opt, exit_cb)
+local function exit_cb() -- {{{
 end
 -- }}}
 
+local _jobs = {}
+local _jobid = 0
+
+local function new_job_obj(id, handle, opt) -- {{{
+end
+-- }}}
+
+function M.start(cmd, opts) -- {{{
+  local stdin = uv.new_pipe()
+  local stdout = uv.new_pipe()
+  local stderr = uv.new_pipe()
+  local command = ''
+  if type(cmd) == 'string' then
+    command = 'cmd.exe'
+  elseif type(cmd) == 'table' then
+    command = cmd[1]
+  end
+
+  local opt = {
+    stdio = { stdin, stdout, stderr },
+  }
+
+  local handle, pid = uv.spawn(command, opt, exit_cb)
+  _jobid = _jobid + 1
+
+  local current_id = _jobid
+
+  table.insert(_jobs, {
+    ['jobid_' .. _jobid] = new_job_obj(_jobid, handle, opts),
+  })
+  if opts.stdout then
+    uv.read_start(stdout, function(err, data)
+      assert(not err, err)
+      if data then
+        print('stdout chunk', stdout, data)
+      else
+        print('stdout end', stdout)
+      end
+    end)
+  end
+
+  if opts.stdout then
+    uv.read_start(stderr, function(err, data)
+      if data then
+        opts.stdout(current_id, data, 'stdout')
+      end
+    end)
+  end
+
+  uv.write(stdin, 'Hello World')
+
+  uv.shutdown(stdin, function()
+    print('stdin shutdown', stdin)
+    uv.close(handle, function()
+      print('process closed', handle, pid)
+    end)
+  end)
+end
+-- }}}
 
 return M

--- a/lua/spacevim/api/job.lua
+++ b/lua/spacevim/api/job.lua
@@ -136,6 +136,22 @@ function M.stop(id)
     error('can not find job:' .. id)
   end
 
+  -- close stdio
+  local stdin = jobobj.state.stdin
+  if stdin and stdin:is_active() then
+    stdin:close()
+  end
+  -- close stdio
+  local stdout = jobobj.state.stout
+  if stdout and stdout:is_active() then
+    stdout:close()
+  end
+  -- close stdio
+  local stderr = jobobj.state.stderr
+  if stderr and stderr:is_active() then
+    stderr:close()
+  end
+
   local handle = jobobj.handle
   handle:kill(6)
 end

--- a/lua/spacevim/api/job.lua
+++ b/lua/spacevim/api/job.lua
@@ -64,14 +64,6 @@ function M.start(cmd, opts) -- {{{
     end)
   end
 
-  -- uv.write(stdin, 'Hello World')
-
-  uv.shutdown(stdin, function()
-    -- print('stdin shutdown', stdin)
-    uv.close(handle, function()
-      -- print('process closed', handle, pid)
-    end)
-  end)
 end
 -- }}}
 

--- a/lua/spacevim/api/job.lua
+++ b/lua/spacevim/api/job.lua
@@ -10,10 +10,6 @@ local M = {}
 
 local uv = vim.loop
 
-local function exit_cb() -- {{{
-end
--- }}}
-
 local _jobs = {}
 local _jobid = 0
 
@@ -26,49 +22,54 @@ function M.start(cmd, opts) -- {{{
   local stdout = uv.new_pipe()
   local stderr = uv.new_pipe()
   local command = ''
+  local argv = {}
   if type(cmd) == 'string' then
     command = 'cmd.exe'
   elseif type(cmd) == 'table' then
     command = cmd[1]
+    argv = vim.list_slice(cmd, 2)
   end
 
   local opt = {
     stdio = { stdin, stdout, stderr },
+    args = argv
   }
+  _jobid = _jobid + 1
+  local current_id = _jobid
+  local exit_cb
+  if opts.on_exit then
+    exit_cb = function(code, singin)
+      opts.on_exit(current_id, code, singin)
+    end
+  end
 
   local handle, pid = uv.spawn(command, opt, exit_cb)
-  _jobid = _jobid + 1
-
-  local current_id = _jobid
 
   table.insert(_jobs, {
     ['jobid_' .. _jobid] = new_job_obj(_jobid, handle, opts),
   })
-  if opts.stdout then
+  if opts.on_stdout then
     uv.read_start(stdout, function(err, data)
-      assert(not err, err)
       if data then
-        print('stdout chunk', stdout, data)
-      else
-        print('stdout end', stdout)
+        opts.on_stdout(current_id, data, 'stdout')
       end
     end)
   end
 
-  if opts.stdout then
+  if opts.on_stderr then
     uv.read_start(stderr, function(err, data)
       if data then
-        opts.stdout(current_id, data, 'stdout')
+        opts.on_stderr(current_id, data, 'stderr')
       end
     end)
   end
 
-  uv.write(stdin, 'Hello World')
+  -- uv.write(stdin, 'Hello World')
 
   uv.shutdown(stdin, function()
-    print('stdin shutdown', stdin)
+    -- print('stdin shutdown', stdin)
     uv.close(handle, function()
-      print('process closed', handle, pid)
+      -- print('process closed', handle, pid)
     end)
   end)
 end

--- a/test/lua/test_job.lua
+++ b/test/lua/test_job.lua
@@ -1,14 +1,14 @@
 local job = require('spacevim.api.job')
 
-job.start({ 'cat', '--version' }, {
+job.start({ 'vim', '--version' }, {
   on_stdout = function(id, data, event)
     vim.print(id)
     vim.print(data)
     vim.print(event)
   end,
-  on_exit = function(id, code, singin)
+  on_exit = function(id, code, signal)
     vim.print(id)
-    vim.print(data)
-    vim.print(event)
+    vim.print('exit code', code)
+    vim.print('exit signal', signal)
   end,
 })

--- a/test/lua/test_job.lua
+++ b/test/lua/test_job.lua
@@ -1,0 +1,14 @@
+local job = require('spacevim.api.job')
+
+job.start({ 'cat', '--version' }, {
+  on_stdout = function(id, data, event)
+    vim.print(id)
+    vim.print(data)
+    vim.print(event)
+  end,
+  on_exit = function(id, code, singin)
+    vim.print(id)
+    vim.print(data)
+    vim.print(event)
+  end,
+})

--- a/test/lua/test_job.lua
+++ b/test/lua/test_job.lua
@@ -1,7 +1,12 @@
 local job = require('spacevim.api.job')
 
-local jobid = job.start({ 'cat' }, {
+local jobid = job.start({ 'rg', 'wsdjeg', '.' }, {
   on_stdout = function(id, data, event)
+    vim.print(id)
+    vim.print(data)
+    vim.print(event)
+  end,
+  on_stderr = function(id, data, event)
     vim.print(id)
     vim.print(data)
     vim.print(event)
@@ -14,5 +19,5 @@ local jobid = job.start({ 'cat' }, {
 })
 
 
-job.send(jobid, 'hello world')
-job.stop(jobid)
+-- job.send(jobid, 'hello world')
+-- job.stop(jobid)

--- a/test/lua/test_job.lua
+++ b/test/lua/test_job.lua
@@ -1,6 +1,6 @@
 local job = require('spacevim.api.job')
 
-job.start({ 'ctags', '-R', '-o', 'C:/Users/wsdjeg/.cache/SpaceVim/tags/C__Users_wsdjeg__SpaceVim_/tags', 'C:\\Users\\wsdjeg\\.SpaceVim' }, {
+local jobid = job.start({ 'cat' }, {
   on_stdout = function(id, data, event)
     vim.print(id)
     vim.print(data)
@@ -12,3 +12,7 @@ job.start({ 'ctags', '-R', '-o', 'C:/Users/wsdjeg/.cache/SpaceVim/tags/C__Users_
     vim.print('exit signal', signal)
   end,
 })
+
+
+job.send(jobid, 'hello world')
+job.close(jobid)

--- a/test/lua/test_job.lua
+++ b/test/lua/test_job.lua
@@ -1,6 +1,6 @@
 local job = require('spacevim.api.job')
 
-job.start({ 'vim', '--version' }, {
+job.start({ 'ctags', '-R', '-o', 'C:/Users/wsdjeg/.cache/SpaceVim/tags/C__Users_wsdjeg__SpaceVim_/tags', 'C:\\Users\\wsdjeg\\.SpaceVim' }, {
   on_stdout = function(id, data, event)
     vim.print(id)
     vim.print(data)

--- a/test/lua/test_job.lua
+++ b/test/lua/test_job.lua
@@ -15,4 +15,4 @@ local jobid = job.start({ 'cat' }, {
 
 
 job.send(jobid, 'hello world')
-job.close(jobid)
+job.stop(jobid)


### PR DESCRIPTION
close https://github.com/neovim/neovim/issues/20856

This PR implement a new job api based on libuv. the example form https://github.com/neovim/neovim/issues/20856:

in nvim, run `:let g:test_ctags_cmd = ['C:\Users\wsdjeg\.SpaceVim\bundle\phpcomplete.vim\bin\ctags.exe', '-R', '--extra=+f', '-o', 'C:/Users/wsdjeg/.cache/SpaceVim/tags/C__Users_wsdjeg__SpaceVim_/tags', 'C:\Users\wsdjeg\.SpaceVim']`

test.lua

```lua
local job = require('spacevim.api.job')

local jobid = job.start(vim.g.test_ctags_cmd, {
  on_stdout = function(id, data, event)
    vim.print(id)
    vim.print(data)
    vim.print(event)
  end,
  on_stderr = function(id, data, event)
    vim.print(id)
    vim.print(data)
    vim.print(event)
  end,
  on_exit = function(id, code, signal)
    vim.print(id)
    vim.print('exit code', code)
    vim.print('exit signal', signal)
  end,
})



```

run `:luafile %`, then output is:

```
1
exit code 3221225477
exit signal 0
```